### PR TITLE
pin pymodbus version for the time being

### DIFF
--- a/custom_components/solax_modbus/manifest.json
+++ b/custom_components/solax_modbus/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.6.4",
   "documentation": "https://github.com/wills106/homsassistant-solax-modbus",
   "issue_tracker": "https://github.com/wills106/homsassistant-solax-modbus/issues",
-  "requirements": ["pymodbus>=2.5.3"],
+  "requirements": ["pymodbus==2.5.3"],
   "dependencies": [],
   "codeowners": ["@wills106"],
   "config_flow": true,


### PR DESCRIPTION
Version 3.0.1 fails, so we need to correct this first before we can allow higher versions