### PR TITLE
Add PV to Heatsink Temperature 1

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -398,7 +398,7 @@ SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         register = 0x41A,
         newblock = True,
         unit = REGISTER_S16,
-        allowedtypes = HYBRID,
+        allowedtypes = HYBRID | PV,
         entity_category = EntityCategory.DIAGNOSTIC,
     ),
     SofarModbusSensorEntityDescription(


### PR DESCRIPTION
Heatsink Temperature 1 is supported on my PV device, therefore add PV to the allowedtypes