### PR TITLE
introduce ignore_readerror attribute for sensor entities (untested)

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -482,7 +482,7 @@ class SolaXModbusHub:
             if firstdescr.ignore_readerror != False:  # ignore block read errors and return static data
                 for reg in block.regs: 
                     descr = block.descriptions[reg]
-                    self.data[descr.key] = descr.ignore_readerror # return something static 
+                    if ((descr.ignore_readerror != True) and (descr.ignore_readerror !=False)) : self.data[descr.key] = descr.ignore_readerror # return something static 
                 return True
             else:
                 if self.slowdown == 1: _LOGGER.info(f"{errmsg}: {self.name} cannot read {typ} registers at device {self._modbus_addr} position 0x{block.start:x}", exc_info=True)

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -449,35 +449,44 @@ class SolaXModbusHub:
 
 
     def read_modbus_block(self, block, typ):
+        errmsg = None
         if self.cyclecount <5: 
             _LOGGER.debug(f"{self.name} modbus {typ} block start: 0x{block.start:x} end: 0x{block.end:x}  len: {block.end - block.start} \nregs: {block.regs}")
         try:
             if typ == 'input': realtime_data = self.read_input_registers(unit=self._modbus_addr, address=block.start, count=block.end - block.start)
             else:              realtime_data = self.read_holding_registers(unit=self._modbus_addr, address=block.start, count=block.end - block.start)
-        except Exception as ex:
-            if self.slowdown == 1: _LOGGER.info(f"{str(ex)}: {self.name} cannot read {typ} registers at device {self._modbus_addr} position 0x{block.start:x}", exc_info=True)
-            return False
-        if realtime_data.isError():
-            if self.slowdown == 1: _LOGGER.info(f"{self.name} error reading {typ} registers at device {self._modbus_addr} position 0x{block.start:x}", exc_info=True)
-            return False
-        #decoder = BinaryPayloadDecoder.fromRegisters(realtime_data.registers, block.order16, wordorder=block.order32)
-        decoder = BinaryPayloadDecoder.fromRegisters(realtime_data.registers, self.plugin.order16, wordorder=self.plugin.order32)
-        prevreg = block.start
-        for reg in block.regs:
-            if (reg - prevreg) > 0: 
-                decoder.skip_bytes((reg-prevreg) * 2)
-                if self.cyclecount < 5: _LOGGER.debug(f"skipping bytes {(reg-prevreg) * 2}")
-            descr = block.descriptions[reg] 
-            if type(descr) is dict: #  set of byte values
-                val = decoder.decode_16bit_uint()
-                for k in descr: self.treat_address(decoder, descr[k], val)
-                prevreg = reg + 1
-            else: # single value
-                self.treat_address(decoder, descr)
-                if descr.unit in (REGISTER_S32, REGISTER_U32, REGISTER_ULSB16MSB16,): prevreg = reg + 2
-                elif descr.unit in (REGISTER_STR, REGISTER_WORDS,): prevreg = reg + descr.wordcount
-                else: prevreg = reg+1
-        return True
+        except Exception as ex:  
+            errmsg = f"exception {str(ex)} "
+        else:
+            if realtime_data.isError(): errmsg = f"read_error "
+        if errmsg == None:
+            decoder = BinaryPayloadDecoder.fromRegisters(realtime_data.registers, self.plugin.order16, wordorder=self.plugin.order32)
+            prevreg = block.start
+            for reg in block.regs:
+                if (reg - prevreg) > 0: 
+                    decoder.skip_bytes((reg-prevreg) * 2)
+                    if self.cyclecount < 5: _LOGGER.debug(f"skipping bytes {(reg-prevreg) * 2}")
+                descr = block.descriptions[reg] 
+                if type(descr) is dict: #  set of byte values
+                    val = decoder.decode_16bit_uint()
+                    for k in descr: self.treat_address(decoder, descr[k], val)
+                    prevreg = reg + 1
+                else: # single value
+                    self.treat_address(decoder, descr)
+                    if descr.unit in (REGISTER_S32, REGISTER_U32, REGISTER_ULSB16MSB16,): prevreg = reg + 2
+                    elif descr.unit in (REGISTER_STR, REGISTER_WORDS,): prevreg = reg + descr.wordcount
+                    else: prevreg = reg+1
+            return True
+        else: #block read failure
+            firstdescr = block.descriptions[start] # check only first item in block
+            if firstdescr.ignore_readerror != False:  # ignore block read errors and return static data
+                for reg in block.regs: 
+                    descr = block.descriptions[reg]
+                    self.data[descr.key] = descr.ignore_readerror # return something static 
+                return True
+            else:
+                if self.slowdown == 1: _LOGGER.info(f"{errmsg}: {self.name} cannot read {typ} registers at device {self._modbus_addr} position 0x{block.start:x}", exc_info=True)
+                return False
 
     def read_modbus_registers_all(self):
         res = True

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -127,6 +127,11 @@ class BaseModbusSensorEntityDescription(SensorEntityDescription):
     value_function: callable = None #  value = function(initval, descr, datadict)
     wordcount: int = None # only for unit = REGISTER_STR and REGISTER_WORDS
     sleepmode: int = SLEEPMODE_LAST # or SLEEPMODE_ZERO or SLEEPMODE_NONE
+    ignore_readerror: bool = False # if not False, ignore read errors for this block and return this static value
+                                   # A failing block read will be accepted as valid block if the first entity of the block contains a non-False ignore_readerror attribute. 
+                                   # The other entitties of the block can also have an ignore_readerror attribute that determines the value returned upon failure
+                                   # so typically this attribute can be set to None or "Unknown" or any other value
+                                   # This only works if the first entity of a block contains this attribute
 
 @dataclass
 class BaseModbusButtonEntityDescription(ButtonEntityDescription):

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -132,6 +132,7 @@ class BaseModbusSensorEntityDescription(SensorEntityDescription):
                                    # The other entitties of the block can also have an ignore_readerror attribute that determines the value returned upon failure
                                    # so typically this attribute can be set to None or "Unknown" or any other value
                                    # This only works if the first entity of a block contains this attribute
+                                   # When simply set to True, no initial value will be returned, but the block will be considered valid
 
 @dataclass
 class BaseModbusButtonEntityDescription(ButtonEntityDescription):


### PR DESCRIPTION
A failing block read will be accepted as valid block if the first entity of the block contains a non-False ignore_readerror attribute. The other entitties of the block can also have an ignore_readerror attribute that determines the value returned upon failure.
Typically, this attribute is set to "Unknown" or None

Untested for the time being 