### PR TITLE
re-implement prevent_update

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -193,15 +193,17 @@ class SolaXModbusHub:
         self._baudrate = int(baudrate)
         self._scan_interval = timedelta(seconds=scan_interval)
         self._unsub_interval_method = None
-        self._sensors = []
+        self._sensor_callbacks = []
         self.data = { "_repeatUntil": {}} # _repeatuntil contains button autorepeat expiry times
-        self.previousdata = {} # only if attribute prevent_update = True
+        self.tmpdata = {} # for WRITE_DATA_LOCAL entities with corresponding prevent_update sensor
+        self.tmpdata_expiry = {} # expiry timestamps for tempdata
         self.cyclecount = 0 # temporary - remove later
         self.slowdown = 1 # slow down factor when modbus is not responding: 1 : no slowdown, 10: ignore 9 out of 10 cycles
         self.inputBlocks = {}
         self.holdingBlocks = {}
         self.computedSensors = {}
         self.computedButtons = {}
+        self.preventSensors = {} # sensors with prevent_update = True
         self.writeLocals = {} # key to description lookup dict for write_method = WRITE_DATA_LOCAL entities
         self.sleepzero = [] # sensors that will be set to zero in sleepmode
         self.sleepnone = [] # sensors that will be cleared in sleepmode
@@ -243,20 +245,20 @@ class SolaXModbusHub:
     def async_add_solax_modbus_sensor(self, update_callback):
         """Listen for data updates."""
         # This is the first sensor, set up interval.
-        if not self._sensors:
+        if not self._sensor_callbacks:
             self.connect()
             self._unsub_interval_method = async_track_time_interval(
                 self._hass, self.async_refresh_modbus_data, self._scan_interval
             )
+        self._sensor_callbacks.append(update_callback)
 
-        self._sensors.append(update_callback)
 
     @callback
     def async_remove_solax_modbus_sensor(self, update_callback):
         """Remove data update."""
-        self._sensors.remove(update_callback)
+        self._sensor_callbacks.remove(update_callback)
 
-        if not self._sensors:
+        if not self._sensor_callbacks:
             """stop the interval timer upon removal of last sensor"""
             self._unsub_interval_method()
             self._unsub_interval_method = None
@@ -265,13 +267,13 @@ class SolaXModbusHub:
     async def async_refresh_modbus_data(self, _now: Optional[int] = None) -> None:
         """Time to update."""
         self.cyclecount = self.cyclecount+1
-        if not self._sensors:
+        if not self._sensor_callbacks:
             return
         if (self.cyclecount % self.slowdown) == 0: # only execute once every slowdown count
             update_result = self.read_modbus_data()
             if update_result:
                 self.slowdown = 1 # return to full polling after succesfull cycle
-                for update_callback in self._sensors:
+                for update_callback in self._sensor_callbacks:
                     update_callback()
             else: 
                 _LOGGER.debug(f"assuming sleep mode - slowing down by factor 10")
@@ -438,6 +440,18 @@ class SolaXModbusHub:
             if self.cyclecount < 5: _LOGGER.warning(f"{self.name}: read failed at 0x{descr.register:02x}: {descr.key}", exc_info=True)
             else: _LOGGER.warning(f"{self.name}: read failed at 0x{descr.register:02x}: {descr.key} ")
             val = 0
+
+        if descr.prevent_update:
+            if  (self.tmpdata_expiry.get(descr.key, 0) > time()): 
+                val = self.tmpdata.get(descr.key, None)
+                if val == None: 
+                    LOGGER.warning(f"cannot find tmpdata for {descr.key} - setting value to zero")
+                    val = 0
+            else: # expired
+                if self.tmpdata_expiry.get(descr.key, 0) > 0: self.localsUpdated = True 
+                self.tmpdata_expiry[descr.key] = 0 # update locals only once
+
+
         if type(descr.scale) is dict: # translate int to string 
             return_value = descr.scale.get(val, "Unknown")
         elif callable(descr.scale):  # function to call ?

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -38,6 +38,7 @@ DEFAULT_NAME = "SolaX"
 DEFAULT_SCAN_INTERVAL = 15
 DEFAULT_PORT = 502
 DEFAULT_MODBUS_ADDR = 1
+TMPDATA_EXPIRY   = 120 # seconds before temp entities return to modbus value
 CONF_READ_EPS    = "read_eps"
 CONF_READ_DCB    = "read_dcb"
 CONF_READ_PM    = "read_pm"

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -360,6 +360,23 @@ NUMBER_TYPES = [
     # Data only number types
     #
     ###
+    
+    # For testing prevent_update mechanism - start of block
+    #SolaxModbusNumberEntityDescription(
+    #    name = "Dummy Timed Charge Start Hours",
+    #    key = "dummy_timed_charge_start_h", 
+    #    unit = REGISTER_U16,
+    #    fmt = "i",
+    #    initvalue = 0,
+    #    native_min_value = 0,
+    #    native_max_value = 23,
+    #    native_step = 1,
+    #    native_unit_of_measurement = UnitOfTime.HOURS,
+    #    allowedtypes = HYBRID,
+    #    write_method = WRITE_DATA_LOCAL,
+    #    entity_category = EntityCategory.CONFIG,
+    #    icon = "mdi:battery-clock",
+    #), end of block
     SolaxModbusNumberEntityDescription(
         name = "Remotecontrol Active Power",
         key = "remotecontrol_active_power",
@@ -966,15 +983,17 @@ SELECT_TYPES = [
         entity_category = EntityCategory.CONFIG,
         icon = "mdi:battery-clock",
     ),
-    SolaxModbusSelectEntityDescription(
-        name = "Charger Start Time 2",
-        key = "charger_start_time_2",
-        register = 0x6D,
-        option_dict = TIME_OPTIONS_GEN4,
-        allowedtypes = HYBRID | AC | GEN4,
-        entity_category = EntityCategory.CONFIG,
-        icon = "mdi:battery-clock",
+    # comment this  block to test prevent_update
+    SolaxModbusSelectEntityDescription(              # block
+        name = "Charger Start Time 2",               # block
+        key = "charger_start_time_2",                # block
+        register = 0x6D,                             # block
+        option_dict = TIME_OPTIONS_GEN4,             # block
+        allowedtypes = HYBRID | AC | GEN4,           # block
+        entity_category = EntityCategory.CONFIG,     # block
+        icon = "mdi:battery-clock",                  # block
     ),
+    # end of block
     SolaxModbusSelectEntityDescription(
         name = "Charger Use Mode",
         key = "charger_use_mode",
@@ -1353,6 +1372,19 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     # Holding
     #
     ###
+
+    # only for testing prevent_update mechanism - start of block
+    #SolaXModbusSensorEntityDescription(
+    #    name = "Dummy Timed Charge Start Hours", 
+    #    key = "dummy_timed_charge_start_h",
+    #    register = 0x9C,
+    #    #scale = value_function_gen4time,
+    #    #entity_registry_enabled_default = False,
+    #    allowedtypes = GEN4,
+    #    icon = "mdi:battery-clock",
+    #    prevent_update = True,
+    #), # end of block
+
     SolaXModbusSensorEntityDescription(
         name = "Series Number",
         key = "seriesnumber",
@@ -1718,15 +1750,17 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes = GEN2 | GEN3,
         icon = "mdi:battery-clock",
     ),
+    # comment this block to test prevent_update mechanism
     SolaXModbusSensorEntityDescription(
-        name = "Charger Start Time 2", 
-        key = "charger_start_time_2",
-        register = 0x9C,
-        scale = value_function_gen4time,
-        entity_registry_enabled_default = False,
-        allowedtypes = GEN4,
-        icon = "mdi:battery-clock",
+        name = "Charger Start Time 2",           # block
+        key = "charger_start_time_2",            # block
+        register = 0x9C,                         # block
+        scale = value_function_gen4time,         # block
+        entity_registry_enabled_default = False, # block
+        allowedtypes = GEN4,                     # block
+        icon = "mdi:battery-clock",              # block
     ),
+    # end of block
     SolaXModbusSensorEntityDescription(
         name = "Charger End Time 2",
         key = "charger_end_time_2",

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -176,25 +176,21 @@ class SolaXModbusSensor(SensorEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._hub.async_add_solax_modbus_sensor(self._modbus_data_updated)
+        if self.entity_description.prevent_update: self._hub.preventSensors[self.entity_description.key] = self
 
     async def async_will_remove_from_hass(self) -> None:
         self._hub.async_remove_solax_modbus_sensor(self._modbus_data_updated)
+        if self.entity_description.prevent_update: self._hub.preventSensors.pop(self.entity_description.key, None)
 
     @callback
     def _modbus_data_updated(self):
         self.async_write_ha_state()
 
     @callback
-    def _update_state(self):
+    def _update_state(self): # never called ?????
+        _LOGGER.info(f"update_state {self.entity_description.key} : {self._hub.data.get(self.entity_description.key,'None')}")
         if self.entity_description.key in self._hub.data:
-            if self.entity_description.prevent_update:
-                old = self._hub.previousdata.get(self.entity_description.key, None)
-                new = self._hub.data[self.entity_description.key]
-                if new != old:
-                    self._hub.previousdata[self.entity_description.key] = new
-                    self._state = new
-            else: # normal case
-                self._state = self._hub.data[self.entity_description.key]
+            self._state = self._hub.data[self.entity_description.key]
 
     @property
     def name(self):


### PR DESCRIPTION
Use case: WRITE_LOCAL_DATA number with same key as modbus sensor entity Local_data changes will be memorized for 120 seconds, awaiting a write_multiple action