### PR TITLE
Remove Hz from frequency

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -635,8 +635,8 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         native_unit_of_measurement = UnitOfFrequency.HERTZ,
         state_class = SensorStateClass.MEASUREMENT,
         register = 1062,
-        scale = { 0: "50Hz",
-                  1: "60Hz", },
+        scale = { 0: "50",
+                  1: "60", },
         allowedtypes = GEN | GEN2 | EPS,
     ),
     GrowattModbusSensorEntityDescription(
@@ -988,8 +988,8 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         native_unit_of_measurement = UnitOfFrequency.HERTZ,
         state_class = SensorStateClass.MEASUREMENT,
         register = 3081,
-        scale = { 0: "50Hz",
-                  1: "60Hz", },
+        scale = { 0: "50",
+                  1: "60", },
         allowedtypes = HYBRID | AC | GEN4 | EPS,
     ),
     GrowattModbusSensorEntityDescription(


### PR DESCRIPTION
I enabled EPS and got errors in the log :
```
2023-08-20 15:14:03.086 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 591, in state
    numerical_value = int(value)
                      ^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '50Hz'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/config/custom_components/solax_modbus/__init__.py", line 292, in async_refresh_modbus_data
    update_callback()
  File "/config/custom_components/solax_modbus/sensor.py", line 172, in _modbus_data_updated
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 746, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 808, in _async_write_ha_state
    state = self._stringify_state(available)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 752, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 595, in state
    raise ValueError(
ValueError: Sensor sensor.solar_eps_set_frequency has device class 'None', state class 'measurement' unit 'Hz' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: '50Hz' (<class 'str'>)
```

Removing the Hz from both places the frequency is defined gets me through and I can see the frequency with Hz in the integration config. (Although EPS is off)