### PR TITLE
Fixed typos. Shorted overflowing message

### DIFF
--- a/custom_components/solax_modbus/translations/de.json
+++ b/custom_components/solax_modbus/translations/de.json
@@ -10,14 +10,14 @@
           "read_eps": "Notstromschalter (EPS)",
           "read_dcb": "Dry Contact Box (Gen4)",
           "read_pm": "Parallel Mode (Master-Slave)",
-          "plugin": "Wechselrichjter Typ",
+          "plugin": "Wechselrichter Typ",
           "scan_interval": "Die Abfragefrequenz der Modbus Register in Sekunden"
         }
       },
       "serial": {
         "title": "Serielle Schnittstelle",
         "data": {
-          "read_serial_port": "Name ses seriellen Ports",
+          "read_serial_port": "Name des seriellen Ports",
           "baudrate": "Baudrate"
         }
       },
@@ -25,7 +25,7 @@
         "title": "TCP/IP Schnittstelle",
         "data": {
           "host": "Die IP Adresse des Wechselrichters oder Modbus Geräts",
-          "port": "Der TCP Port über den die Verbindung zum Wechselrichter hergestellt wird",
+          "port": "Der TCP Port für die Verbindung zum Wechselrichter",
           "tcp_type": "Die Modbus TCP Variante"
         }
       }
@@ -33,7 +33,7 @@
     "error": {
       "already_configured": "Gerät ist bereits konfiguriert",
       "name_already_used": "Name war bereits vorhanden oder war ungültig",
-      "invalid_host": "IP Addresse invalid"
+      "invalid_host": "IP Adresse ungültig"
     },
     "abort": {
       "already_configured": "Gerät ist bereits konfiguriert"
@@ -57,7 +57,7 @@
       "serial": {
         "title": "Serielle Schnittstelle",
         "data": {
-          "read_serial_port": "Name ses seriellen Ports",
+          "read_serial_port": "Name des seriellen Ports",
           "baudrate": "Baudrate"
         }
       },
@@ -65,14 +65,14 @@
         "title": "TCP/IP Schnittstelle",
         "data": {
           "host": "Die IP Adresse des Wechselrichters oder Modbus Geräts",
-          "port": "Der TCP Port über den die Verbindung zum Wechselrichter hergestellt wird"
+          "port": "Der TCP Port für die Verbindung zum Wechselrichter"
         }
       }
     },
     "error": {
       "already_configured": "Gerät ist bereits konfiguriert",
       "name_already_used": "Name war bereits vorhanden oder war ungültig",
-      "invalid_host": "IP Addresse invalid"
+      "invalid_host": "IP Adresse ungültig"
     },
     "abort": {
       "already_configured": "Gerät ist bereits konfiguriert"


### PR DESCRIPTION
Fixed some typos in German language.

Shortened an overflowing message:
![image](https://github.com/wills106/homeassistant-solax-modbus/assets/894150/cadbd4b7-6408-4c96-bb20-545268932778)
