### PR TITLE
Fixed Long term statistics in error case

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -445,6 +445,7 @@ class SolaXModbusHub:
 
     def treat_address(self, decoder, descr, initval=0):
         return_value = None
+        val = None
         if self.cyclecount <5: _LOGGER.debug(f"treating register 0x{descr.register:02x} : {descr.key}")
         try:
             if   descr.unit == REGISTER_U16: val = decoder.decode_16bit_uint()
@@ -462,7 +463,6 @@ class SolaXModbusHub:
         except Exception as ex: 
             if self.cyclecount < 5: _LOGGER.warning(f"{self.name}: read failed at 0x{descr.register:02x}: {descr.key}", exc_info=True)
             else: _LOGGER.warning(f"{self.name}: read failed at 0x{descr.register:02x}: {descr.key} ")
-            val = 0
         """ TO BE REMOVED 
         if descr.prevent_update:
             if  (self.tmpdata_expiry.get(descr.key, 0) > time()): 
@@ -475,7 +475,9 @@ class SolaXModbusHub:
                 self.tmpdata_expiry[descr.key] = 0 # update locals only once
         """
 
-        if type(descr.scale) is dict: # translate int to string 
+        if val == None:  # E.g. if errors have occurred during readout
+            return_value = None
+        elif type(descr.scale) is dict: # translate int to string 
             return_value = descr.scale.get(val, "Unknown")
         elif callable(descr.scale):  # function to call ?
             return_value = descr.scale(val, descr, self.data) 


### PR DESCRIPTION
I have a Sofar hyd 15ktl-3ph and Waveshare RS485 to RJ45 Ethernet in use.
Occasionally I get "read failed at ..." errors (especially when the polling frequency for modubus registers is set to 15 seconds or lower).

This PR does not solve the cause, but the consequence errors!

In case of a failed communication (**read failed at ... 0x{descr.register:02x} ...**), **val = 0** was set.
This caused the long term statistics for entities with **state_class** = **total_increasing** to get messed up.
Statistics->**Sum** was calculated incorrectly. 
The result was that the energy dashboard was also always messed up.

![grafik](https://github.com/wills106/homeassistant-solax-modbus/assets/77174685/61a4fef2-c806-451e-99c8-16dd4ce7f482)

The return value **None** now ensures that HA receives the value **Unknown** and no longer falsifies the **Sum**.

![grafik](https://github.com/wills106/homeassistant-solax-modbus/assets/77174685/c001b017-631a-4717-8f0f-c641d2511087)

