### PR TITLE
Add a link to discussions when creating a new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/wills106/homeassistant-solax-modbus/discussions
+    about: Questions unrelated to this integration belong here.


### PR DESCRIPTION
People that do not understand GitHub flow and will try to open an issue for a question that is not directly related to this extensions will be prompted to use discussions.