### PR TITLE
Add Sofar SA3 series inverter support

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar_old.py
+++ b/custom_components/solax_modbus/plugin_sofar_old.py
@@ -1068,6 +1068,7 @@ class sofar_old_plugin(plugin_base):
 
         # derive invertertype from seriiesnumber
         if seriesnumber.startswith('SA1'):  invertertype = PV | X1 # Older Might be single
+        elif seriesnumber.count('SA3'):  invertertype = PV | X1 # Older Might be single
         elif seriesnumber.count('SB1'):  invertertype = PV | X1 # Older Might be single
         elif seriesnumber.startswith('SC1'):  invertertype = PV | X3 # Older Probably 3phase
         elif seriesnumber.startswith('SD1'):  invertertype = PV | X3 # Older Probably 3phase


### PR DESCRIPTION
SA3 series are part of SOFAR 1.1K...3.3KTL-G3 product lineup.