### PR TITLE
Fix select device issue

### DIFF
--- a/custom_components/solax_modbus/select.py
+++ b/custom_components/solax_modbus/select.py
@@ -17,7 +17,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         modbus_addr = entry.options.get(CONF_MODBUS_ADDR, DEFAULT_MODBUS_ADDR) # new style
     hub = hass.data[DOMAIN][hub_name]["hub"]
     device_info = {
-        "identifiers": {(DOMAIN, hub_name, hub.seriesnumber)},
+        "identifiers": {(DOMAIN, hub_name)},
         "name": hub.plugin.plugin_name,
         "manufacturer": hub.plugin.plugin_manufacturer,
         #"model": hub.sensor_description.inverter_model,


### PR DESCRIPTION
Looks like select wasn't updated and all "select" entities ended up in a different device in 2024.02.3