### PR TITLE
Allow to set desired grid power along with minimum and maximum battery power.

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -104,7 +104,7 @@ class SofarModbusSensorEntityDescription(BaseModbusSensorEntityDescription):
 # ====================================== Computed value functions  =================================================
 
 def value_function_passivemode(initval, descr, datadict):
-    return [ (REGISTER_S32, datadict.get('passive_mode_battery_power', 0)),
+    return [ (REGISTER_S32, datadict.get('passive_mode_grid_power', 0)),
             (REGISTER_S32, datadict.get('passive_mode_battery_power_min', 0)), 
             (REGISTER_S32, datadict.get('passive_mode_battery_power_max', 0)),
            ]
@@ -200,8 +200,8 @@ NUMBER_TYPES = [
     #
     ###
     SofarModbusNumberEntityDescription(
-        name = "Passive Mode Battery Power",
-        key = "passive_mode_battery_power",
+        name = "Passive Mode Grid Power",
+        key = "passive_mode_grid_power",
         native_unit_of_measurement = UnitOfPower.WATT,
         device_class = NumberDeviceClass.POWER,
         unit = REGISTER_S32,

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -104,20 +104,8 @@ class SofarModbusSensorEntityDescription(BaseModbusSensorEntityDescription):
 # ====================================== Computed value functions  =================================================
 
 def value_function_passivemode(initval, descr, datadict):
-    return [ (REGISTER_S32, 0, ),
-            (REGISTER_S32, datadict.get('passive_mode_battery_power', 0)), 
-            (REGISTER_S32, datadict.get('passive_mode_battery_power', 0)),
-           ]
-
-def value_function_passivemode_min(initval, descr, datadict):
-    return [ (REGISTER_S32, 0, ),
+    return [ (REGISTER_S32, datadict.get('passive_mode_battery_power', 0)),
             (REGISTER_S32, datadict.get('passive_mode_battery_power_min', 0)), 
-            (REGISTER_S32, datadict.get('passive_mode_battery_power_min', 0)),
-           ]
-
-def value_function_passivemode_max(initval, descr, datadict):
-    return [ (REGISTER_S32, 0, ),
-            (REGISTER_S32, datadict.get('passive_mode_battery_power_max', 0)), 
             (REGISTER_S32, datadict.get('passive_mode_battery_power_max', 0)),
            ]
 
@@ -156,22 +144,6 @@ BUTTON_TYPES = [
         allowedtypes = HYBRID,
         write_method = WRITE_MULTI_MODBUS,
         value_function = value_function_passivemode,
-    ),
-    SofarModbusButtonEntityDescription(
-        name = "Passive Mode Min Battery",
-        key = "passive_mode_battery_set_min",
-        register = 0x1189,
-        allowedtypes = HYBRID,
-        write_method = WRITE_MULTI_MODBUS,
-        value_function = value_function_passivemode_min,
-    ),
-    SofarModbusButtonEntityDescription(
-        name = "Passive Mode Max Battery",
-        key = "passive_mode_battery_set_max",
-        register = 0x118B,
-        allowedtypes = HYBRID,
-        write_method = WRITE_MULTI_MODBUS,
-        value_function = value_function_passivemode_max,
     ),
     SofarModbusButtonEntityDescription(
         name = "Sync RTC",

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -9,9 +9,9 @@ from custom_components.solax_modbus.const import *
 _LOGGER = logging.getLogger(__name__)
 
 """ ============================================================================================
-bitmasks  definitions to characterize inverters, ogranized by group
-these bitmasks are used in entitydeclarations to determine to which inverters the entity applies
-within a group, the bits in an entitydeclaration will be interpreted as OR
+bitmasks  definitions to characterize inverters, organized by group
+these bitmasks are used in entity declarations to determine to which inverters the entity applies
+within a group, the bits in an entity declaration will be interpreted as OR
 between groups, an AND condition is applied, so all gruoups must match.
 An empty group (group without active flags) evaluates to True.
 example: GEN3 | GEN4 | X1 | X3 | EPS 
@@ -109,6 +109,18 @@ def value_function_passivemode(initval, descr, datadict):
             (REGISTER_S32, datadict.get('passive_mode_battery_power', 0)),
            ]
 
+def value_function_passivemode_min(initval, descr, datadict):
+    return [ (REGISTER_S32, 0, ),
+            (REGISTER_S32, datadict.get('passive_mode_battery_power_min', 0)), 
+            (REGISTER_S32, datadict.get('passive_mode_battery_power_min', 0)),
+           ]
+
+def value_function_passivemode_max(initval, descr, datadict):
+    return [ (REGISTER_S32, 0, ),
+            (REGISTER_S32, datadict.get('passive_mode_battery_power_max', 0)), 
+            (REGISTER_S32, datadict.get('passive_mode_battery_power_max', 0)),
+           ]
+
 def value_function_refluxcontrol(initval, descr, datadict):
     return  [ ('reflux_control', datadict.get('reflux_control', datadict.get('ro_reflux_control')), ),
               ('reflux_power', datadict.get('reflux_power', 0), ), 
@@ -144,6 +156,22 @@ BUTTON_TYPES = [
         allowedtypes = HYBRID,
         write_method = WRITE_MULTI_MODBUS,
         value_function = value_function_passivemode,
+    ),
+    SofarModbusButtonEntityDescription(
+        name = "Passive Mode Min Battery",
+        key = "passive_mode_battery_set_min",
+        register = 0x1189,
+        allowedtypes = HYBRID,
+        write_method = WRITE_MULTI_MODBUS,
+        value_function = value_function_passivemode_min,
+    ),
+    SofarModbusButtonEntityDescription(
+        name = "Passive Mode Max Battery",
+        key = "passive_mode_battery_set_max",
+        register = 0x118B,
+        allowedtypes = HYBRID,
+        write_method = WRITE_MULTI_MODBUS,
+        value_function = value_function_passivemode_max,
     ),
     SofarModbusButtonEntityDescription(
         name = "Sync RTC",
@@ -202,6 +230,36 @@ NUMBER_TYPES = [
     SofarModbusNumberEntityDescription(
         name = "Passive Mode Battery Power",
         key = "passive_mode_battery_power",
+        native_unit_of_measurement = UnitOfPower.WATT,
+        device_class = NumberDeviceClass.POWER,
+        unit = REGISTER_S32,
+        fmt = "i",
+        native_max_value = 15000,
+        native_min_value = -15000,
+        native_step = 100,
+        initvalue = 0,
+        allowedtypes = HYBRID,
+        prevent_update = True,
+        write_method = WRITE_DATA_LOCAL,
+    ),
+    SofarModbusNumberEntityDescription(
+        name = "Passive Mode Min Batter Power",
+        key = "passive_mode_battery_power_min",
+        native_unit_of_measurement = UnitOfPower.WATT,
+        device_class = NumberDeviceClass.POWER,
+        unit = REGISTER_S32,
+        fmt = "i",
+        native_max_value = 15000,
+        native_min_value = -15000,
+        native_step = 100,
+        initvalue = 0,
+        allowedtypes = HYBRID,
+        prevent_update = True,
+        write_method = WRITE_DATA_LOCAL,
+    ),
+    SofarModbusNumberEntityDescription(
+        name = "Passive Mode Max Battery Power",
+        key = "passive_mode_battery_power_max",
         native_unit_of_measurement = UnitOfPower.WATT,
         device_class = NumberDeviceClass.POWER,
         unit = REGISTER_S32,
@@ -2875,11 +2933,11 @@ SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         allowedtypes = HYBRID,
     ),
     SofarModbusSensorEntityDescription(
-        name = "Passive Mode Battery Power",
-        key = "passive_mode_battery_power",
+        name = "RO Passive Mode Lower",
+        key = "ro_passive_mode_lower",
         unit = REGISTER_S32,
         register = 0x1189,
-        entity_registry_enabled_default =  False,
+        #entity_registry_enabled_default =  False,
         allowedtypes = HYBRID,
     ),
     SofarModbusSensorEntityDescription(


### PR DESCRIPTION
### PREVIOUS BEHAVIOR
When setting battery power, desired grid was always set to 0 and battery min and max charge to the value of passive_mode_battery_power. This does not allow the full flexibility of the passive mode

### CHANGE
With this addition users can set desired grid power, minimum charge/discharge and maximum charge/discharge:
<img width="329" alt="image" src="https://github.com/wills106/homeassistant-solax-modbus/assets/894150/bcf83e8f-fdf6-4631-b4d0-a36fca3f950e">

When setting these values the registers are set accordingly:
<img width="312" alt="image" src="https://github.com/wills106/homeassistant-solax-modbus/assets/894150/7842fbc1-0d11-4f0a-8b91-d9544522cfcb">

Now this allows finer control like this:

- Passive Mode Grid Power: 0
- Passive Mode Max Battery Power: 2500
- Passive Mode Min Battery Power: -5000

Try to keep grid power at zero like in self use, but limit charging of the battery to 2.5kW, while still allowing discharging to 5 kW

- Passive Mode Grid Power: 2000
- Passive Mode Max Battery Power: 5000
- Passive Mode Min Battery Power: 0

Force charging the battery with 2 kW while preventing discharging. If sun delivers more allow to charge with up to 5kW.


### OUTDATED

I am trying to modify plugin_sofar.py to set upper and lower limits for battery charge/discharge in passive mode. So far it is not working yet. Values do not get committed. Not sure what I am doing wrong here as a total novice.

Registers I am trying to write are the green registers here:
<img width="1094" alt="image" src="https://github.com/wills106/homeassistant-solax-modbus/assets/894150/257ca076-4093-495c-b3bd-ea21ababba9c">

UI is showing the new controls already:
<img width="328" alt="image" src="https://github.com/wills106/homeassistant-solax-modbus/assets/894150/4384d878-0171-4d3a-99cb-2c2eb50902dd">
