### PR TITLE
Fix update system time

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -980,7 +980,7 @@ SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         entity_category = EntityCategory.DIAGNOSTIC,
     ),
     SofarModbusSensorEntityDescription(
-        name = "RTC",
+        name = "System Time",
         key = "rtc",
         register = 0x42C,
         unit = REGISTER_WORDS,

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -139,6 +139,17 @@ def value_function_toumode(initval, descr, datadict):
               ('tou_charge_power', datadict.get('tou_charge_power', 0), ),
             ]
 
+def value_function_sync_rtc_ymd_sofar(initval, descr, datadict):
+    now = datetime.now()
+    return [ (REGISTER_U16, now.year % 100, ),
+             (REGISTER_U16, now.month, ),
+             (REGISTER_U16, now.day, ),
+             (REGISTER_U16, now.hour, ),
+             (REGISTER_U16, now.minute, ),
+             (REGISTER_U16, now.second, ),
+             (REGISTER_U16, 1, ),
+           ]
+
 # ================================= Button Declarations ============================================================
 
 BUTTON_TYPES = [
@@ -166,7 +177,7 @@ BUTTON_TYPES = [
         allowedtypes = HYBRID | PV,
         write_method = WRITE_MULTI_MODBUS,
         icon = "mdi:home-clock",
-        value_function = value_function_sync_rtc_ymd,
+        value_function = value_function_sync_rtc_ymd_sofar,
     ),
     SofarModbusButtonEntityDescription(
         name = "Reflux: Update",
@@ -2943,6 +2954,23 @@ SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         unit = REGISTER_U32,
         entity_registry_enabled_default =  False,
         allowedtypes = HYBRID,
+    ),
+
+    SofarModbusSensorEntityDescription(
+        name = "Update System Time Operation Result",
+        key = "sync_rtc_result",
+        register = 0x100A,
+        scale = { 0: "Successful",
+                  1: "Operation in progress",
+                  2: "Enabled - Discharging",
+                  4: "Disabled",
+                  65531: "Operation failed, controller refused to respond",
+                  65532: "Operation failed, no response from the controller",
+                  65533: "Operation failed, current function disabled",
+                  65534: "Operation failed, parameter access failed",
+                  65535: "Operation failed, input parameters incorrect",  },
+        allowedtypes = HYBRID,
+        entity_category = EntityCategory.DIAGNOSTIC,
     ),
     SofarModbusSensorEntityDescription(
         name = "RO: Passive: Timeout",

--- a/docs/sofar-entity-description.md
+++ b/docs/sofar-entity-description.md
@@ -1,5 +1,7 @@
 # Description of Sofar Entities
 
+WARNING: most of the writeable parameters are written to EEPROM of the inverter after each modification. EEPROM has a limited (typically 100000) number of write cycles, so be careful that your automations do not modify these parameters too frequently.
+
 Very likely this document will always be work in progress ;-)
 
 ## Controls

--- a/docs/sofar-entity-description.md
+++ b/docs/sofar-entity-description.md
@@ -17,7 +17,7 @@ Some of the entities cannot be written alone as Sofar requires several registers
 | Reflux: Control | Control whether and how much your system is allowed to feed-in to the grid. If disabled, no power will flow from your system to the grid. If enabled, no power will be fed in. Using "Enabled Set Value" you can limit the maximum amount of power that is fed-in. See [Reflux Control](sofar-reflux-control.md) for more information. | Reflux: Update |
 | Reflux: Maximum Power | The maximum amount of power in Watts that is allowed to be fed-in to your grid from your system. | Reflux: Update |
 | Remote Control| Enable/Disable remote control to your inverter. |  |
-| Update System Time | Updates the system time of the inverter to the current time. | |
+| Update System Time | Updates the system time of the inverter to the current time of the Home Assistant system. To check whether the write action was successful check the value of "Update System Time Operation Result". Note that while a logger is connected to the USB port and the logger has access to the public internet, the inverter will automatically regularly fetch the time from the Sofar servers. However you might have chosen to disallow the communication to the Sofar servers, or you do not have a logger installed on the system. In this case you can achieve a time synchronisation by regularly pressing this button through an automation. Do not hit this button too often as values will be written to the EEPROM.| |
 | Timing: Control | Experimental: To be done |  |
 | Timing: Charge | Experimental: To be done |  |
 | Timing: Charge Power | Experimental: To be done | |


### PR DESCRIPTION
Update System Time wasn't working previously. The write action needs to write 7 registers, where the last register will be a 1 on write always. Added a diagnostic entity to read that last register, which returns the last write action status information on read.

<img width="2006" alt="image" src="https://github.com/wills106/homeassistant-solax-modbus/assets/894150/a5b6cad6-1211-4b73-9847-58c723152dcb">

Updated docs.