### PR TITLE
Sofar: Remove duplicate registers

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -3019,23 +3019,6 @@ SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         entity_registry_enabled_default =  False,
         allowedtypes = HYBRID | PV | X3 | PM,
     ),
-    # Does not work. needs to be written with many other registers
-    SofarModbusSensorEntityDescription(
-        name = "Battery Minimum Capacity",
-        key = "battery_minimum_capacity",
-        register = 0x104D,
-        newblock = True,
-        entity_registry_enabled_default =  False,
-        allowedtypes = HYBRID,
-    ),
-    # Does not work. needs to be written with many other registers
-    SofarModbusSensorEntityDescription(
-        name = "Battery Minimum Capacity OffGrid",
-        key = "battery_minimum_capacity_offgrid",
-        register = 0x104E,
-        entity_registry_enabled_default =  False,
-        allowedtypes = HYBRID,
-    ),
 
 ###
 #
@@ -3245,7 +3228,7 @@ SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
     SofarModbusSensorEntityDescription(
         name = "BatConfig: Address 4",
         key = "bat_config_address_4",
-        register = 0x1055,
+        register = 0x1056,
         entity_category = EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default =  False,
         allowedtypes = HYBRID,


### PR DESCRIPTION
Fixing these issues:

```
2024-03-16 18:44:47.405 WARNING (MainThread) [custom_components.solax_modbus.sensor] holding register already used: 0x104d bat_config_depth_of_discharge
2024-03-16 18:44:47.405 WARNING (MainThread) [custom_components.solax_modbus.sensor] holding register already used: 0x104e bat_config_end_of_discharge
2024-03-16 18:44:47.405 WARNING (MainThread) [custom_components.solax_modbus.sensor] holding register already used: 0x1055 bat_config_address_4
```