### PR TITLE
Moving "Charge added total" to HOLDIG reg 0x619.

### DIFF
--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -623,8 +623,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
     SolaXEVChargerModbusSensorEntityDescription(
         name = "Charge Added Total",
         key = "charge_added_total",
-        register = 0x10,
-        register_type = REG_INPUT,
+        register=0x619,
+        register_type=REG_HOLDING,
         unit = REGISTER_U32,
         scale = 0.1,
         native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR,


### PR DESCRIPTION
For unknown reason (bug of SolaX) input register 0x10 is reg 32 BIG_ENDIAN.
Fortunately there is holding register 0x619 with same meaning which is correct.

Better to use correct register than fixing non standard encoding.

Solves #805 