### PR TITLE
Support phase unbalanced output with Solis inverters

### DIFF
--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -748,7 +748,20 @@ SELECT_TYPES = [
                 0: "Off",
                 16: "On",
             },
-        allowedtypes = HYBRID,
+        allowedtypes = HYBRID | X1,
+        icon = "mdi:dip-switch",
+    ),
+    SolisModbusSelectEntityDescription(
+        name = "Backflow Power Switch",
+        key = "backflow_power_switch",
+        register = 43073,
+        option_dict =  {
+                0: "Off & Balanced output",
+                16: "On & Balanced output",
+                64: "Off & Unbalanced output",
+                80: "On & Unbalanced output"
+            },
+        allowedtypes = HYBRID | X3,
         icon = "mdi:dip-switch",
     ),
     SolisModbusSelectEntityDescription(
@@ -2067,9 +2080,23 @@ SENSOR_TYPES: list[SolisModbusSensorEntityDescription] = [
         register = 43073,
         scale = {
                 0: "Off",
-                16: "On", },
+                16: "On",
+            },
         entity_registry_enabled_default = False,
-        allowedtypes = HYBRID,
+        allowedtypes = HYBRID | X1,
+    ),
+    SolisModbusSensorEntityDescription(
+        name = "Backflow Power Switch",
+        key = "backflow_power_switch",
+        register = 43073,
+        scale =  {
+                0: "Off & Balanced output",
+                16: "On & Balanced output",
+                64: "Off & Unbalanced output",
+                80: "On & Unbalanced output"
+            },
+        entity_registry_enabled_default = False,
+        allowedtypes = HYBRID | X3,
     ),
     SolisModbusSensorEntityDescription(
         name = "Backflow Power",


### PR DESCRIPTION
43073 is a register containing multiple bit switches which control all kinds of things. One of those is the phase power control mode. With the default balanced output inverter will always output the same power on all phases. This leads to selling on some phases and buying on others. With unbalanced output the inverter power control logic manages each phase separately which is what you want if your utility measures and bills each phase separately.

Unfortunately I don't see how to add multiple toggles linked to one register so I just added the options to the select. If you see a cleaner approach please let me know.

Tested with Solis S6-EH3P10K-H-EU