### PR TITLE
Fix: use retries parameter instead of fixed value

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -517,11 +517,11 @@ class SolaXModbusHub:
         )
 
         result: bool
-        for retry in range(2):
+        for retry in range(retries):
             result = await self._client.connect()
             if not result:
                 _LOGGER.info(
-                    "Connect to Inverter attempt %d of 3 is not successful", retry + 1
+                    "Connect to Inverter attempt %d of %d is not successful", retry + 1, retries
                 )
                 await asyncio.sleep(1)
             else:


### PR DESCRIPTION
It looks like a reties parameter was introduced which should perform the retry 6 times for `self._client.connect()` but the parameter was ignored and the retry only happened twice based on the hardcoded value