### PR TITLE
Fix: Modubus Client not connected error

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -508,7 +508,7 @@ class SolaXModbusHub:
 
         return self._client.connected
 
-    async def async_connect(self, retries=6):
+    async def async_connect(self):
         result = False
 
         _LOGGER.debug(

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -242,18 +242,19 @@ class SolaXModbusHub:
                 stopbits=1,
                 bytesize=8,
                 timeout=3,
+                retries=6,
             )
         else:
             if tcp_type == "rtu":
                 self._client = AsyncModbusTcpClient(
-                    host=host, port=port, timeout=5, framer=ModbusRtuFramer
+                    host=host, port=port, timeout=5, framer=ModbusRtuFramer, retries=6
                 )
             elif tcp_type == "ascii":
                 self._client = AsyncModbusTcpClient(
-                    host=host, port=port, timeout=5, framer=ModbusAsciiFramer
+                    host=host, port=port, timeout=5, framer=ModbusAsciiFramer, retries=6
                 )
             else:
-                self._client = AsyncModbusTcpClient(host=host, port=port, timeout=5)
+                self._client = AsyncModbusTcpClient(host=host, port=port, timeout=5, retries=6)
         self._lock = asyncio.Lock()
         self._name = name
         self.inverterNameSuffix = config.get(CONF_INVERTER_NAME_SUFFIX)

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -515,18 +515,8 @@ class SolaXModbusHub:
             self._client.comm_params.host,
             self._client.comm_params.port,
         )
-
-        result: bool
-        for retry in range(2):
-            result = await self._client.connect()
-            if not result:
-                _LOGGER.info(
-                    "Connect to Inverter attempt %d of 3 is not successful", retry + 1
-                )
-                await asyncio.sleep(1)
-            else:
-                break
-
+        
+        result = await self._client.connect()
         if result:
             _LOGGER.info(
                 "Inverter connected at %s:%s",


### PR DESCRIPTION
Since I wasn't able to write any values through the modbus connection, this fixed the issue for me and I can write all the values just fine now. 

According to the documentation of pymodbus, the client should be trying to reconnect automatically within the given timout:

The line await client.connect() connects to the device (or comm port), if this cannot connect successfully within the timeout it throws an exception. If connected successfully reconnecting later is handled automatically

This might be a quick fix, maybe there should be the asyncio lock applied in the for loop to keep the retry functionality?