### PR TITLE
Export control scaling for X3-Ultra

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -445,7 +445,8 @@ EXPORT_LIMIT_SCALE_EXCEPTIONS = [
     ('H4372A', 1),   # Issue #857
     ('H4502A', 1),   # Issue #857
     ('H4502T', 1),   # Issue #418
-    ('H4602A', 1),   # Issue #882 
+    ('H4602A', 1),   # Issue #882
+    ('H3BD', 10),    # X3-Ultra
 #    ('H1E', 10 ), # more specific entry comes last and wins
 ]
 


### PR DESCRIPTION
At least for my X3 Ultra 15K (H3BD15) this scaling correktion is working i guess it will be the same for the other Ultras as well.

See my comment: https://github.com/wills106/homeassistant-solax-modbus/issues/998#issuecomment-2295229198
