### PR TITLE
Remove unnecessary client connection in async_write_register

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -564,7 +564,6 @@ class SolaXModbusHub:
 
     async def async_write_register(self, unit, address, payload):
         """Write register."""
-        await self.async_connect()
         awake = self.plugin.isAwake(self.data)
         if awake:
             return await self.async_lowlevel_write_register(unit, address, payload)


### PR DESCRIPTION
The client connection happens later in `self.async_lowlevel_write_register` call, if the client is not connected already

Potentially resolves #993