### PR TITLE
Fix ModbusSerialClient initialization: remove unsupported method

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -235,7 +235,6 @@ class SolaXModbusHub:
         self._hass = hass
         if interface == "serial":
             self._client = AsyncModbusSerialClient(
-                method="rtu",
                 port=serial_port,
                 baudrate=baudrate,
                 parity="N",


### PR DESCRIPTION
method parameter is not supported by pymodbus, according to: https://pymodbus.readthedocs.io/en/latest/source/client.html#pymodbus.client.ModbusSerialClient

The right way to provide framer type is through `framer` parameter, but that one is RTU by default, so no need to explicitly specify it in the call

This should fix https://github.com/wills106/homeassistant-solax-modbus/issues/1008