### PR TITLE
#924 Fixed value mapping "battery_to_ev_charger"

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -2952,8 +2952,8 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     SolaXModbusSensorEntityDescription(
         key = "battery_to_ev_charger",
         register = 0x10F,
-        scale = { 0: "Enabled",
-                  1: "Disabled", },
+        scale = { 1: "Enabled",
+                  0: "Disabled", },
         allowedtypes = AC | HYBRID | GEN4 | GEN5,
         internal = True,
     ),


### PR DESCRIPTION
Write register is diffent than read register and there was switched Enable/Disable mapping.

In fact it is incorrect also in SolaX modbus document v3.24 (latest I have).