### PR TITLE
#1037 Detect incorrect local data file content

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -351,8 +351,15 @@ class SolaXModbusHub:
                 self.localsLoaded = (
                     True  # retry a couple of polling cycles - then assume non-existent"
                 )
-        else:
+            return
+        try:
             loaded = json.load(fp)
+        except:
+            _LOGGER.info("Local data file not readable. Reseting to empty")
+            fp.close()
+            self.saveLocalData()
+            return
+        else:
             if loaded.get("_version") == self.DATAFORMAT_VERSION:
                 for desc in self.writeLocals:
                     self.data[desc] = loaded.get(desc)
@@ -515,7 +522,7 @@ class SolaXModbusHub:
             self._client.comm_params.host,
             self._client.comm_params.port,
         )
-        
+
         result = await self._client.connect()
         if result:
             _LOGGER.info(


### PR DESCRIPTION
Fixing bug where incorrect file content stops integration from loading.

I didn't know how it happend but I found my SolaX_data.json empty. It is not valid json causing crash.

Solution is smple re-save data with saveLocalData method.

Tested myself. Simple test is to delete content of file and restart integration.