### PR TITLE
enhanced SolaXModbusHub to utilize core ModbusHub connection

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -19,7 +19,6 @@ import pathlib
 
 from homeassistant.const import (
     PERCENTAGE,
-    UnitOfReactivePower,
     UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -30,6 +29,21 @@ from homeassistant.const import (
     UnitOfTime,
     CONF_SCAN_INTERVAL,
 )
+
+try:
+    from homeassistant.const import (
+        UnitOfReactivePower,
+    ) ## some changes maybe revert on update of hass
+except ImportError:
+    # NOTE:fallback for older homeassistant installation
+    #      likely to be removed in future version
+
+    from enum import StrEnum
+    from homeassistant.const import (
+        POWER_VOLT_AMPERE_REACTIVE
+    )
+    class UnitOfReactivePower(StrEnum):
+        VOLT_AMPERE_REACTIVE = POWER_VOLT_AMPERE_REACTIVE
 
 
 # ================================= Definitions for config_flow ==========================================================
@@ -55,6 +69,7 @@ CONF_SolaX_HUB   = "solax_hub"
 CONF_BAUDRATE    = "baudrate"
 CONF_PLUGIN      = "plugin"
 CONF_READ_BATTERY = "read_battery"
+CONF_CORE_HUB = "read_core_hub"
 ATTR_MANUFACTURER = "SolaX Power"
 DEFAULT_INTERFACE  = "tcp"
 DEFAULT_SERIAL_PORT = "/dev/ttyUSB0"

--- a/custom_components/solax_modbus/strings.json
+++ b/custom_components/solax_modbus/strings.json
@@ -30,6 +30,12 @@
           "port": "The TCP port on which to connect to the inverter",
           "tcp_type": "The Modbus TCP variant"
         }
+      },
+      "core": {
+        "title": "Core Modbus hub selection",
+        "data": {
+            "read_core_hub": "The core modbus hub used to connect to the inverter"
+        }
       }
     },
     "error": {
@@ -71,6 +77,12 @@
         "data": {
           "host": "The IP-address of your Inverter or Modbus Interface",
           "port": "The TCP port on which to connect to the inverter"
+        }
+      },
+      "core": {
+        "title": "Core modbus hub selection",
+        "data": {
+            "read_core_hub": "The core modbus hub used to connect to the inverter"
         }
       }
     },

--- a/custom_components/solax_modbus/translations/de.json
+++ b/custom_components/solax_modbus/translations/de.json
@@ -30,6 +30,12 @@
           "tcp_type": "Die Modbus TCP Variante"
         }
       },
+      "core": {
+        "title": "Core Modbus Hub Auswahl",
+        "data": {
+            "read_core_hub": "Core Modbus Hub über den die Verbindung zum Wechselrichter hergestellt wird."
+        }
+      },
       "battery": {
         "title": "Batteriemodule auslesen",
         "data": {
@@ -74,6 +80,12 @@
         "data": {
           "host": "Die IP Adresse des Wechselrichters oder Modbus Geräts",
           "port": "Der TCP Port für die Verbindung zum Wechselrichter"
+        }
+      },
+      "Core": {
+        "title": "Core Modbus Hub Auswahl",
+        "data": {
+            "read_core_hub": "Core Modbus Hub über den die Verbindung zum Wechselrichter hergestellt wird."
         }
       },
       "battery": {


### PR DESCRIPTION
Adds the possibility to attach to the homeassistant core ModbusHub as a third type of connection. This requires that the core Modbus module is properly configured and registers can be read from the SolaX Inverter via the core Modbus component. If selected only the name of the Modbus Hub has to be specified. At the moment the name has to be typed into the field. 

This pull request reflects the needs for  my personal setup. I do appriciate any feedback, discussion, suggestions, recommendations etc.  I will update given sufficient time and resources.
