### PR TITLE
Solax Gen4 meter direction and core meter direction fix

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -5922,6 +5922,15 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
 #
 #####
     SolaXModbusSensorEntityDescription(
+        name = "Measured Power",
+        key = "measured_power",
+        native_unit_of_measurement = UnitOfPower.WATT,
+        device_class = SensorDeviceClass.POWER,
+        state_class = SensorStateClass.MEASUREMENT,
+        value_function = value_function_measured_power,
+        allowedtypes = MIC | GEN2 | GEN3 | GEN4 | GEN5,
+    ),
+    SolaXModbusSensorEntityDescription(
         name = "Grid Export",
         key = "grid_export",
         native_unit_of_measurement = UnitOfPower.WATT,


### PR DESCRIPTION
This PR contains:

- Adds the missing meter direction register definitions for GEN4 inverters 
- Adds meter direction logic to measured power to avoid incorrect calculations for meters configured with positive meter flow. This fixes a major issue with incorrect house load calculations when a meter is configured with positive meter flow

To accomplish this the `measured_power` register is imported a as `measured_power_raw`. A new computed function has been added as `value_function_measured_power` that applies the direction to the raw data. That way all computations that leverage measured power inherit the fix without additional code changes.

I have been able to test this fix on Solax X3 Hybrid G4 inverters. 