### PR TITLE
Growatt: Fix run mode #791

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -3875,12 +3875,14 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         key = "inverter_state",
         value_function = value_function_inverter_state,
         allowedtypes = GEN4,
+        entity_category = EntityCategory.DIAGNOSTIC,
     ),
     GrowattModbusSensorEntityDescription(
         name = "Run Mode",
         key = "run_mode",
         value_function = value_function_run_mode,
         allowedtypes = GEN4,
+        entity_category = EntityCategory.DIAGNOSTIC,
     ),
     GrowattModbusSensorEntityDescription(
         name = "Total PV Power",

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -3840,24 +3840,25 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
 # TL-X TL-XH
 #
 #####
-#    GrowattModbusSensorEntityDescription(
-#        name = "Inverter State",
-#        key = "inverter_state",
-#        register = 3000,
-#        register_type = REG_INPUT,
-#        unit = REGISTER_U8H, #currently not working in the integration
-#        scale = { 0: "Waiting", 3: "Fault", 4: "Flash", 5: "PV Bat Online", 6: "Bat Online", },
-#        allowedtypes = GEN4,
-#    ),
-#    GrowattModbusSensorEntityDescription(
-#        name = "Run Mode",
-#        key = "run_mode",
-#        register = 3000,
-#        register_type = REG_INPUT,
-#        unit = REGISTER_U8L, #currently not working in the integration
-#        scale = { 0: "Standby", 1: "Normal", 3: "Fault", 4: "Flash", },
-#        allowedtypes = GEN4,
-#    ),
+    GrowattModbusSensorEntityDescription(
+        name = "Inverter State",
+        key = "inverter_state",
+        newblock = true,
+        register = 3000,
+        register_type = REG_INPUT,
+        unit = REGISTER_U8H, #currently not working in the integration
+        scale = { 0: "Waiting", 3: "Fault", 4: "Flash", 5: "PV Bat Online", 6: "Bat Online", },
+        allowedtypes = GEN4,
+    ),
+    GrowattModbusSensorEntityDescription(
+        name = "Run Mode",
+        key = "run_mode",
+        register = 3000,
+        register_type = REG_INPUT,
+        unit = REGISTER_U8L, #currently not working in the integration
+        scale = { 0: "Standby", 1: "Normal", 3: "Fault", 4: "Flash", },
+        allowedtypes = GEN4,
+    ),
     GrowattModbusSensorEntityDescription(
         name = "Total PV Power",
         key = "total_pv_power",

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -1029,14 +1029,14 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         key = "active_power_limit",
         register = 3,
         allowedtypes = ALL_GEN_GROUP,
-        internal = True,
+        internal = 
     ),
     GrowattModbusSensorEntityDescription(
         key = "reactive_power_limit",
         register = 4,
         unit = REGISTER_S16,
         allowedtypes = ALL_GEN_GROUP,
-        internal = True,
+        internal = 
     ),
     GrowattModbusSensorEntityDescription(
         name = "Firmware Version",
@@ -3843,7 +3843,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
     GrowattModbusSensorEntityDescription(
         name = "Inverter State",
         key = "inverter_state",
-        newblock = true,
+        newblock = True,
         register = 3000,
         register_type = REG_INPUT,
         unit = REGISTER_U8H, #currently not working in the integration

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -1052,14 +1052,14 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         key = "active_power_limit",
         register = 3,
         allowedtypes = ALL_GEN_GROUP,
-        internal = 
+        internal = True,
     ),
     GrowattModbusSensorEntityDescription(
         key = "reactive_power_limit",
         register = 4,
         unit = REGISTER_S16,
         allowedtypes = ALL_GEN_GROUP,
-        internal = 
+        internal = True,
     ),
     GrowattModbusSensorEntityDescription(
         name = "Firmware Version",

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -39,7 +39,7 @@ def splitInBlocks( descriptions, block_size, auto_block_ignore_readerror ):
     curblockregs = []
     for reg in descriptions:
         descr = descriptions[reg]
-        if (not type(descr) is dict) and (descr.newblock or ((reg - start) > block_size)):
+        if (descr.newblock or (not type(descr) is dict)) and ((reg - start) > block_size):
             if ((end - start) > 0):
                 _LOGGER.debug(f"Starting new block at 0x{reg:x} ")
                 if  ( (auto_block_ignore_readerror == True) or (auto_block_ignore_readerror == False) ) and not descr.newblock: # automatically created block

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -39,7 +39,7 @@ def splitInBlocks( descriptions, block_size, auto_block_ignore_readerror ):
     curblockregs = []
     for reg in descriptions:
         descr = descriptions[reg]
-        if (descr.newblock or (not type(descr) is dict)) and ((reg - start) > block_size):
+        if (not type(descr) is dict) and (descr.newblock or ((reg - start) > block_size)):
             if ((end - start) > 0):
                 _LOGGER.debug(f"Starting new block at 0x{reg:x} ")
                 if  ( (auto_block_ignore_readerror == True) or (auto_block_ignore_readerror == False) ) and not descr.newblock: # automatically created block


### PR DESCRIPTION
Work around the register 3000 not being split up. Read out the value as internal and then use value_function to translate.
To fix #791  