### PR TITLE
Growatt TL3-XH: add Time Slot 1,2,3 for priority setting

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -380,6 +380,6 @@ for h in range(0,24):
         if (h, m,) == (0,  0,): # add extra entry 00:01
             TIME_OPTIONS[1*256+h] = f"{h:02}:{m+1:02}"
             TIME_OPTIONS_GEN4[h*256+1] = f"{h:02}:{m+1:02}"
-        if (h, m,) == (23, 45,): # add extra entry 23:59
-            TIME_OPTIONS[(m+14)*256+h] = f"{h:02}:{m+14:02}"
-            TIME_OPTIONS_GEN4[h*256+m+14] = f"{h:02}:{m+14:02}"
+        if (h, m,) == (23, 55,): # add extra entry 23:59
+            TIME_OPTIONS[(m+4)*256+h] = f"{h:02}:{m+4:02}"
+            TIME_OPTIONS_GEN4[h*256+m+4] = f"{h:02}:{m+4:02}"

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -96,16 +96,156 @@ class GrowattModbusSensorEntityDescription(BaseModbusSensorEntityDescription):
 
 # ====================================== Computed value functions  =================================================
 
-def value_function_timingmode(initval, descr, datadict):
-    return  [ ('timed_charge_start_h', datadict.get('timed_charge_start_h', 0), ),
-              ('timed_charge_start_m', datadict.get('timed_charge_start_m', 0), ),
-              ('timed_charge_end_h', datadict.get('timed_charge_end_h', 0), ),
-              ('timed_charge_end_m', datadict.get('timed_charge_end_m', 0), ),
-              ('timed_discharge_start_h', datadict.get('timed_discharge_start_h', 0), ),
-              ('timed_discharge_start_m', datadict.get('timed_discharge_start_m', 0), ),
-              ('timed_discharge_end_h', datadict.get('timed_discharge_end_h', 0), ),
-              ('timed_discharge_end_m', datadict.get('timed_discharge_end_m', 0), ),
-            ]
+def value_function_time_slot_1(initval, descr, datadict):
+    def time_to_int(time_str):
+        hours, minutes = map(int, time_str.split(':'))
+        return (hours * 256) + minutes
+
+    time_1_begin = datadict.get('time_1_begin', '00:00')
+    time_2_begin = datadict.get('time_2_begin', '00:00')
+    time_3_begin = datadict.get('time_3_begin', '00:00')
+    time_1_end = datadict.get('time_1_end', '00:00')
+    time_2_end = datadict.get('time_2_end', '00:00')
+    time_3_end = datadict.get('time_3_end', '00:00')
+    time_1_enabled = datadict.get('time_1_enabled', 'Disabled')  # Expecting "Enabled" or "Disabled"
+    time_2_enabled = datadict.get('time_2_enabled', 'Disabled')
+    time_3_enabled = datadict.get('time_3_enabled', 'Disabled')
+    time_1_mode = datadict.get('time_1_mode', 'Load First') # Expecting "Load First", "Battery First", "Grid First"
+    time_2_mode = datadict.get('time_2_mode', 'Load First')
+    time_3_mode = datadict.get('time_3_mode', 'Load First') 
+    _LOGGER.debug(f"DEBUG value_function_time_slot_1 called with: time_1_begin: {time_1_begin}, time_1_end: {time_1_end}, time_1_enabled: {time_1_enabled}, time_1_mode: {time_1_mode}")
+    _LOGGER.debug(f"DEBUG value_function_time_slot_1 called with: time_2_begin: {time_2_begin}, time_2_end: {time_2_end}, time_2_enabled: {time_2_enabled}, time_2_mode: {time_2_mode}")
+    _LOGGER.debug(f"DEBUG value_function_time_slot_1 called with: time_3_begin: {time_3_begin}, time_3_end: {time_3_end}, time_3_enabled: {time_3_enabled}, time_3_mode: {time_3_mode}")
+
+    # Convert the times from strings to integers for calculation
+    time_1_begin = time_to_int(time_1_begin)
+    time_2_begin = time_to_int(time_2_begin)
+    time_3_begin = time_to_int(time_3_begin)
+    time_1_end = time_to_int(time_1_end)
+    time_2_end = time_to_int(time_2_end)
+    time_3_end = time_to_int(time_3_end)
+
+    if time_1_enabled == 'Enabled': 
+        time_1_begin += 32768
+    if time_2_enabled == 'Enabled': 
+        time_2_begin += 32768
+    if time_3_enabled == 'Enabled': 
+        time_3_begin += 32768
+
+    if time_1_mode == 'Battery First':
+        time_1_begin += 8192
+    elif time_1_mode == 'Grid First':
+        time_1_begin += 16384
+    if time_2_mode == 'Battery First':
+        time_2_begin += 8192
+    elif time_2_mode == 'Grid First':
+        time_2_begin += 16384
+    if time_3_mode == 'Battery First':
+        time_3_begin += 8192
+    elif time_3_mode == 'Grid First':
+        time_3_begin += 16384
+
+    # Check if end is smaller than start.. Currently only simple check, inverter will ignore if overlapping time slots. 
+    if (time_to_int(datadict.get('time_1_end', '00:00')) < time_to_int(datadict.get('time_1_begin', '00:00'))):
+        _LOGGER.error(f"Growatt: Time 1 Begin cannot be smaller than Time 1 End")
+    elif (time_to_int(datadict.get('time_2_end', '00:00')) < time_to_int(datadict.get('time_2_begin', '00:00'))):
+        _LOGGER.error(f"Growatt: Time 2 Begin cannot be smaller than Time 2 End")
+    elif (time_to_int(datadict.get('time_3_end', '00:00')) < time_to_int(datadict.get('time_3_begin', '00:00'))):
+        _LOGGER.error(f"Growatt: Time 3 Begin cannot be smaller than Time 3 End")
+    else:
+        # Write to registers
+        return [
+            (REGISTER_U16, time_1_begin),
+            (REGISTER_U16, time_1_end),
+            (REGISTER_U16, time_2_begin),
+            (REGISTER_U16, time_2_end),
+            (REGISTER_U16, time_3_begin),
+            (REGISTER_U16, time_3_end),
+        ]
+
+def value_function_time_slot_clear(initval, descr, datadict):
+    return [
+        (REGISTER_U16, 0),
+        (REGISTER_U16, 0),
+        (REGISTER_U16, 0),
+        (REGISTER_U16, 0),
+        (REGISTER_U16, 0),
+        (REGISTER_U16, 0),
+    ]
+
+def value_function_growatt_gen4time(initval, descr, datadict):
+    hours = initval // 256  # Integer division to get the hours (higher 8 bits)
+    minutes = initval % 256  # Modulo to get the minutes (lower 8 bits)
+    return f"{hours:02}:{minutes:02}"
+
+def value_function_time_slot_1_reverse_begin(initval, descr, datadict):
+    initval = datadict.get('register_3038', 0) # need to use a read entity to avoid overwriting the select
+    initval = initval & 0x1FFF # Remove bits 13-15 using a bitwise AND with 0x1FFF
+    hours = initval // 256  # Integer division to get the hours
+    minutes = initval % 256  # Modulo to get the minutes
+    return f"{hours:02}:{minutes:02}"
+
+def value_function_time_slot_2_reverse_begin(initval, descr, datadict):
+    initval = datadict.get('register_3040', 0) # need to use a read entity to avoid overwriting the select
+    initval = initval & 0x1FFF # Remove bits 13-15 using a bitwise AND with 0x1FFF
+    hours = initval // 256  # Integer division to get the hours
+    minutes = initval % 256  # Modulo to get the minutes
+    return f"{hours:02}:{minutes:02}"
+
+def value_function_time_slot_3_reverse_begin(initval, descr, datadict):
+    initval = datadict.get('register_3042', 0) # need to use a read entity to avoid overwriting the select
+    initval = initval & 0x1FFF # Remove bits 13-15 using a bitwise AND with 0x1FFF
+    hours = initval // 256  # Integer division to get the hours
+    minutes = initval % 256  # Modulo to get the minutes
+    return f"{hours:02}:{minutes:02}"
+
+def value_function_time_slot_1_reverse_enabled(initval, descr, datadict):
+    time_1_enabled = datadict.get('register_3038', 0) # need to use a read entity to avoid overwriting the select
+    if int(time_1_enabled) & (1 << 15): # Check if bit 15 is set 
+        return "Enabled"
+    else:
+        return "Disabled"
+
+def value_function_time_slot_2_reverse_enabled(initval, descr, datadict):
+    time_1_enabled = datadict.get('register_3040', 0) # need to use a read entity to avoid overwriting the select
+    if int(time_1_enabled) & (1 << 15): # Check if bit 15 is set 
+        return "Enabled"
+    else:
+        return "Disabled"
+
+def value_function_time_slot_3_reverse_enabled(initval, descr, datadict):
+    time_1_enabled = datadict.get('register_3042', 0) # need to use a read entity to avoid overwriting the select
+    if int(time_1_enabled) & (1 << 15): # Check if bit 15 is set 
+        return "Enabled"
+    else:
+        return "Disabled"
+
+def value_function_time_slot_1_reverse_mode(initval, descr, datadict):
+    time_1_mode = datadict.get('register_3038', 0) # need to use a read entity to avoid overwriting the select
+    if int(time_1_mode) & (1 << 14): # Check bit 14 first for "Grid First" (1 << 14)
+        return "Grid First"
+    elif int(time_1_mode ) & (1 << 13): # Check bit 13 for "Battery First" (1 << 13)
+        return "Battery First"
+    else: # Default case if neither bit 13 nor bit 14 is set
+        return "Load First"
+
+def value_function_time_slot_2_reverse_mode(initval, descr, datadict):
+    time_1_mode = datadict.get('register_3040', 0) # need to use a read entity to avoid overwriting the select
+    if int(time_1_mode) & (1 << 14): # Check bit 14 first for "Grid First" (1 << 14)
+        return "Grid First"
+    elif int(time_1_mode ) & (1 << 13): # Check bit 13 for "Battery First" (1 << 13)
+        return "Battery First"
+    else: # Default case if neither bit 13 nor bit 14 is set
+        return "Load First"
+
+def value_function_time_slot_3_reverse_mode(initval, descr, datadict):
+    time_1_mode = datadict.get('register_3042', 0) # need to use a read entity to avoid overwriting the select
+    if int(time_1_mode) & (1 << 14): # Check bit 14 first for "Grid First" (1 << 14)
+        return "Grid First"
+    elif int(time_1_mode ) & (1 << 13): # Check bit 13 for "Battery First" (1 << 13)
+        return "Battery First"
+    else: # Default case if neither bit 13 nor bit 14 is set
+        return "Load First"
 
 def value_function_today_s_solar_energy(initval, descr, datadict):
     return  datadict.get('today_s_pv1_solar_energy', 0) + datadict.get('today_s_pv2_solar_energy',0) + datadict.get('today_s_pv3_solar_energy',0) + datadict.get('today_s_pv4_solar_energy',0)
@@ -140,6 +280,24 @@ BUTTON_TYPES = [
         write_method = WRITE_MULTI_MODBUS,
         icon = "mdi:home-clock",
         value_function = value_function_sync_rtc_ymd,
+    ),
+    GrowattModbusButtonEntityDescription(
+        name = "Update Time Slots",
+        key = "time_slot_1",
+        register = 3038,
+        allowedtypes = HYBRID | GEN4,
+        write_method = WRITE_MULTI_MODBUS,
+        icon = "mdi:battery-clock",
+        value_function = value_function_time_slot_1,
+    ),
+    GrowattModbusButtonEntityDescription(
+        name = "Clear Time Slots",
+        key = "time_slot_clear",
+        register = 3038,
+        allowedtypes = HYBRID | GEN4,
+        write_method = WRITE_MULTI_MODBUS,
+        icon = "mdi:battery-clock",
+        value_function = value_function_time_slot_clear,
     ),
 ]
 
@@ -897,6 +1055,149 @@ SELECT_TYPES = [
         allowedtypes = HYBRID | AC | GEN4 | EPS,
         entity_category = EntityCategory.CONFIG,
         icon = "mdi:power-plug-battery",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 1 Begin",
+        key = "time_1_begin",
+        option_dict = TIME_OPTIONS_GEN4,
+        write_method = WRITE_DATA_LOCAL,
+        unit = REGISTER_U16,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 1 End",
+        key = "time_1_end",
+        option_dict = TIME_OPTIONS_GEN4,
+        write_method = WRITE_DATA_LOCAL,
+        unit = REGISTER_U16,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 1 Mode",
+        key = "time_1_mode",
+        option_dict = {
+                0: "Load First",
+                1: "Battery First",
+                2: "Grid First",
+            },
+        write_method = WRITE_DATA_LOCAL,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 1 Active",
+        key = "time_1_enabled",
+        option_dict = {
+                0: "Disabled",
+                1: "Enabled",
+            },
+        write_method = WRITE_DATA_LOCAL,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 2 Begin",
+        key = "time_2_begin",
+        option_dict = TIME_OPTIONS_GEN4,
+        write_method = WRITE_DATA_LOCAL,
+        unit = REGISTER_U16,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        entity_registry_enabled_default = False,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 2 End",
+        key = "time_2_end",
+        option_dict = TIME_OPTIONS_GEN4,
+        write_method = WRITE_DATA_LOCAL,
+        unit = REGISTER_U16,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        entity_registry_enabled_default = False,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 2 Mode",
+        key = "time_2_mode",
+        option_dict = {
+                0: "Load First",
+                1: "Battery First",
+                2: "Grid First",
+            },
+        write_method = WRITE_DATA_LOCAL,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        entity_registry_enabled_default = False,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 2 Active",
+        key = "time_2_enabled",
+        option_dict = {
+                0: "Disabled",
+                1: "Enabled",
+            },
+        write_method = WRITE_DATA_LOCAL,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        entity_registry_enabled_default = False,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 3 Begin",
+        key = "time_3_begin",
+        option_dict = TIME_OPTIONS_GEN4,
+        write_method = WRITE_DATA_LOCAL,
+        unit = REGISTER_U16,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        entity_registry_enabled_default = False,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 3 End",
+        key = "time_3_end",
+        option_dict = TIME_OPTIONS_GEN4,
+        write_method = WRITE_DATA_LOCAL,
+        unit = REGISTER_U16,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        entity_registry_enabled_default = False,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 3 Mode",
+        key = "time_3_mode",
+        option_dict = {
+                0: "Load First",
+                1: "Battery First",
+                2: "Grid First",
+            },
+        write_method = WRITE_DATA_LOCAL,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        entity_registry_enabled_default = False,
+        icon = "mdi:battery-clock",
+    ),
+    GrowattModbusSelectEntityDescription(
+        name = "Time 3 Active",
+        key = "time_3_enabled",
+        option_dict = {
+                0: "Disabled",
+                1: "Enabled",
+            },
+        write_method = WRITE_DATA_LOCAL,
+        allowedtypes = HYBRID | GEN4,
+        entity_category = EntityCategory.CONFIG,
+        entity_registry_enabled_default = False,
+        icon = "mdi:battery-clock",
     ),
     ###
     #
@@ -4823,6 +5124,120 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         scale = 0.1,
         rounding = 1,
         allowedtypes = GEN4 | HYBRID,
+    ),
+    # TL-XH GEN3 load/battery/grid first priority 
+    GrowattModbusSensorEntityDescription(
+        key = "register_3038",
+        register = 3038,
+        allowedtypes = GEN4 | HYBRID,
+        internal = True,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        key = "register_3040",
+        register = 3040,
+        allowedtypes = GEN4 | HYBRID,
+        internal = True,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        key = "register_3042",
+        register = 3042,
+        allowedtypes = GEN4 | HYBRID,
+        internal = True,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        name = "Time 1 Begin (read)",
+        key = "time_1_begin_read",
+        value_function = value_function_time_slot_1_reverse_begin,
+        allowedtypes = GEN4 | HYBRID,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        name = "Time 1 Mode (read)",
+        key = "time_1_mode_read",
+        value_function = value_function_time_slot_1_reverse_mode,
+        allowedtypes = GEN4 | HYBRID,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        name = "Time 1 Enabled (read)",
+        key = "time_1_enabled_read",
+        value_function = value_function_time_slot_1_reverse_enabled,
+        allowedtypes = GEN4 | HYBRID,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),
+    GrowattModbusSensorEntityDescription(
+        name = "Time 1 End (read)",
+        key = "time_1_end_read",
+        register = 3039,
+        scale = value_function_growatt_gen4time,
+        allowedtypes = GEN4 | HYBRID,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        name = "Time 2 Begin (read)",
+        key = "time_2_begin_read",
+        value_function = value_function_time_slot_2_reverse_begin,
+        allowedtypes = GEN4 | HYBRID,
+        entity_registry_enabled_default = False,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        name = "Time 2 Mode (read)",
+        key = "time_2_mode_read",
+        value_function = value_function_time_slot_2_reverse_mode,
+        allowedtypes = GEN4 | HYBRID,
+        entity_registry_enabled_default = False,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        name = "Time 2 Enabled (read)",
+        key = "time_2_enabled_read",
+        value_function = value_function_time_slot_2_reverse_enabled,
+        allowedtypes = GEN4 | HYBRID,
+        entity_registry_enabled_default = False,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),
+    GrowattModbusSensorEntityDescription(
+        name = "Time 2 End (read)",
+        key = "time_2_end_read",
+        register = 3041,
+        scale = value_function_growatt_gen4time,
+        allowedtypes = GEN4 | HYBRID,
+        entity_registry_enabled_default = False,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),
+    GrowattModbusSensorEntityDescription(
+        name = "Time 3 Begin (read)",
+        key = "time_3_begin_read",
+        value_function = value_function_time_slot_3_reverse_begin,
+        allowedtypes = GEN4 | HYBRID,
+        entity_registry_enabled_default = False,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        name = "Time 3 Mode (read)",
+        key = "time_3_mode_read",
+        value_function = value_function_time_slot_3_reverse_mode,
+        allowedtypes = GEN4 | HYBRID,
+        entity_registry_enabled_default = False,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),  
+    GrowattModbusSensorEntityDescription(
+        name = "Time 3 Enabled (read)",
+        key = "time_3_enabled_read",
+        value_function = value_function_time_slot_3_reverse_enabled,
+        allowedtypes = GEN4 | HYBRID,
+        entity_registry_enabled_default = False,
+        entity_category = EntityCategory.DIAGNOSTIC,
+    ),
+    GrowattModbusSensorEntityDescription(
+        name = "Time 3 End (read)",
+        key = "time_3_end_read",
+        register = 3043,
+        scale = value_function_growatt_gen4time,
+        allowedtypes = GEN4 | HYBRID,
+        entity_registry_enabled_default = False,
+        entity_category = EntityCategory.DIAGNOSTIC,
     ),
     #####
     #

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -5159,7 +5159,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         entity_category = EntityCategory.DIAGNOSTIC,
     ),  
     GrowattModbusSensorEntityDescription(
-        name = "Time 1 Enabled (read)",
+        name = "Time 1 Active (read)",
         key = "time_1_enabled_read",
         value_function = value_function_time_slot_1_reverse_enabled,
         allowedtypes = GEN4 | HYBRID,
@@ -5190,7 +5190,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         entity_category = EntityCategory.DIAGNOSTIC,
     ),  
     GrowattModbusSensorEntityDescription(
-        name = "Time 2 Enabled (read)",
+        name = "Time 2 Active (read)",
         key = "time_2_enabled_read",
         value_function = value_function_time_slot_2_reverse_enabled,
         allowedtypes = GEN4 | HYBRID,
@@ -5223,7 +5223,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         entity_category = EntityCategory.DIAGNOSTIC,
     ),  
     GrowattModbusSensorEntityDescription(
-        name = "Time 3 Enabled (read)",
+        name = "Time 3 Active (read)",
         key = "time_3_enabled_read",
         value_function = value_function_time_slot_3_reverse_enabled,
         allowedtypes = GEN4 | HYBRID,


### PR DESCRIPTION
Created a fresh PR instead of #1068.

Adds Time Slot 1, 2, 3 settings with Time Begin, Time End, Mode and Enabled for each of the three. 
Select entities and button "Update Time Slots" to write to inverter. Also added a "Clear Time Slots" if all 3 slots should be cleared. 
There are seperate sensor with added "read" in name, as it otherwise does not always write the new selected value and one have to wait 2 minutes before being able to validate that the settings was been written.  Only Time Slot 1 entities is shown by default.

Buttons:
![image](https://github.com/user-attachments/assets/ba78543a-b1cf-4ad3-8898-6f31be879c61)
![image](https://github.com/user-attachments/assets/01283ce3-0a2a-45da-8bb2-c1c881fca133)

Selects:
![image](https://github.com/user-attachments/assets/2f1dd104-6445-415a-b77f-5b8c8f858ffe)

Read sensors:
![image](https://github.com/user-attachments/assets/06c9f479-efbf-45a4-b9b8-5ecda1215c6b)
