### PR TITLE
Remove Solax Remaining Battery Capacity state class

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -5244,7 +5244,6 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         key = "remaining_battery_capacity",
         native_unit_of_measurement = UnitOfEnergy.WATT_HOUR,
         device_class = SensorDeviceClass.ENERGY,
-        state_class = SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default = False,
         register = 0x118,
         register_type = REG_INPUT,


### PR DESCRIPTION
The state class for the Remaining Battery Capacity should be removed, consistent with other battery capacity sensors using the ENERGY device class. The ENERGY device class cannot use the MEASUREMENT state class.

Fixies #1137