### PR TITLE
Adapt the check of Solax EVC type using the SN number

### DIFF
--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -791,9 +791,9 @@ class solax_ev_charger_plugin(plugin_base):
             seriesnumber = "unknown"
 
         # derive invertertupe from seriiesnumber
-        if   seriesnumber.startswith('C1070'):  invertertype = X1 | POW7 # 7kW EV Single Phase
-        elif seriesnumber.startswith('C3110'):  invertertype = X3 | POW11 # 11kW EV Three Phase
-        elif seriesnumber.startswith('C3220'):  invertertype = X3 | POW22 # 22kW EV Three Phase
+        if   seriesnumber.startswith('C107'):  invertertype = X1 | POW7 # 7kW EV Single Phase
+        elif seriesnumber.startswith('C311'):  invertertype = X3 | POW11 # 11kW EV Three Phase
+        elif seriesnumber.startswith('C322'):  invertertype = X3 | POW22 # 22kW EV Three Phase
         # add cases here
         else:
             invertertype = 0


### PR DESCRIPTION
- because my EVC SN starts with "C3111"

I tested by directly modifying the line in my HA local installation. I can then finally add the EVC into HA. The sensors and controls are added correctly. See the screenshots.

<img width="1050" alt="Screenshot 2024-11-22 at 17 13 16" src="https://github.com/user-attachments/assets/2b5d70a2-6196-4af4-81d1-7d38551b3596">
<img width="1151" alt="Screenshot 2024-11-22 at 17 14 02" src="https://github.com/user-attachments/assets/e319cd16-a2c1-4c9c-99e3-1c5a67e0afce">


