### PR TITLE
Growatt serial-no buffer overrun + manifest pymodbus

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -407,7 +407,7 @@ def value_function_rtc(initval, descr, datadict):
             rtc_months,
             rtc_years,
         ) = initval
-        val = f"{rtc_days:02}/{rtc_months:02}/{rtc_years:02} {rtc_hours:02}:{rtc_minutes:02}:{rtc_seconds:02}"
+        val = f"{rtc_days:02}/{rtc_months:02}/{rtc_years%100:02} {rtc_hours:02}:{rtc_minutes:02}:{rtc_seconds:02}"
         return datetime.strptime(val, "%d/%m/%y %H:%M:%S")  # ok since sensor.py has been adapted
     except:
         pass
@@ -423,7 +423,7 @@ def value_function_rtc_ymd(initval, descr, datadict):
             rtc_minutes,
             rtc_seconds,
         ) = initval
-        val = f"{rtc_days:02}/{rtc_months:02}/{rtc_years:02} {rtc_hours:02}:{rtc_minutes:02}:{rtc_seconds:02}"
+        val = f"{rtc_days:02}/{rtc_months:02}/{rtc_years%100:02} {rtc_hours:02}:{rtc_minutes:02}:{rtc_seconds:02}"
         return datetime.strptime(val, "%d/%m/%y %H:%M:%S")  # ok since sensor.py has been adapted
     except:
         pass

--- a/custom_components/solax_modbus/manifest.json
+++ b/custom_components/solax_modbus/manifest.json
@@ -9,6 +9,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wills106/homsassistant-solax-modbus/issues",
-  "requirements": ["pymodbus==3.7.4"],
-  "version": "2025.01.6"
+  "requirements": ["pymodbus==3.8.3"],
+  "version": "2025.01.7"
 }

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -61,7 +61,7 @@ SENSOR_TYPES = []
 async def async_read_serialnr(hub, address):
     res = None
     try:
-        inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=address, count=6)
+        inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=address, count=5)
         if not inverter_data.isError():
             decoder = BinaryPayloadDecoder.fromRegisters(inverter_data.registers, byteorder=Endian.BIG)
             res = decoder.decode_string(12).decode("ascii")

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -64,7 +64,7 @@ async def async_read_serialnr(hub, address):
         inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=address, count=5)
         if not inverter_data.isError():
             decoder = BinaryPayloadDecoder.fromRegisters(inverter_data.registers, byteorder=Endian.BIG)
-            res = decoder.decode_string(12).decode("ascii")
+            res = decoder.decode_string(10).decode("ascii")
             hub.seriesnumber = res
     except Exception as ex: _LOGGER.warning(f"{hub.name}: attempt to read firmware failed at 0x{address:x}", exc_info=True)
     if not res: _LOGGER.warning(f"{hub.name}: reading firmware number from address 0x{address:x} failed; other address may succeed")


### PR DESCRIPTION
- Solved issue where the serial number read count is to large for the actual registers in function `async_read_serialnr`.
- Updated pymodbus to align with home assistants 25.1 version (thanks @Luflosi for the comment on the PR)
- Updated version so version could be released if needed.
- Updated functions `value_function_rtc_ymd` and `value_function_rtc` to handle years with 4 digits as well