### PR TITLE
BatteryPack SOC in preview entity Realtime Capacity is wrong

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -3722,7 +3722,7 @@ BATTERY_SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         register=0x900E,
-        scale=0.1,
+        #scale=0.1,
         allowedtypes=BAT_BTS,
     ),
     SofarModbusSensorEntityDescription(


### PR DESCRIPTION
the battery is displayed as 6% instead of 60%, for example
Pull is local tested