### PR TITLE
Removed last deprecation message in plugins

### DIFF
--- a/custom_components/solax_modbus/plugin_alphaess.py
+++ b/custom_components/solax_modbus/plugin_alphaess.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 from time import time
 

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 from time import time
 

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/solax_modbus/plugin_sofar_old.py
+++ b/custom_components/solax_modbus/plugin_sofar_old.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 from time import time
 

--- a/custom_components/solax_modbus/plugin_solax_a1j1.py
+++ b/custom_components/solax_modbus/plugin_solax_a1j1.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 from time import time
 

--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 from time import time
 

--- a/custom_components/solax_modbus/plugin_solax_mega_forth.py
+++ b/custom_components/solax_modbus/plugin_solax_mega_forth.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 from time import time
 

--- a/custom_components/solax_modbus/plugin_solinteg.py
+++ b/custom_components/solax_modbus/plugin_solinteg.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/solax_modbus/plugin_solis_fb00.py
+++ b/custom_components/solax_modbus/plugin_solis_fb00.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 # from homeassistant.components.select import SelectEntityDescription
 # from homeassistant.components.button import ButtonEntityDescription
 # from homeassistant.components.switch import SwitchEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from .const import *
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/solax_modbus/plugin_solis_old.py
+++ b/custom_components/solax_modbus/plugin_solis_old.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/solax_modbus/plugin_srne.py
+++ b/custom_components/solax_modbus/plugin_srne.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 from time import time
 

--- a/custom_components/solax_modbus/plugin_swatten.py
+++ b/custom_components/solax_modbus/plugin_swatten.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
+from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from custom_components.solax_modbus.const import *
 from time import time
 

--- a/custom_components/solax_modbus/translations/nl.json
+++ b/custom_components/solax_modbus/translations/nl.json
@@ -7,11 +7,14 @@
           "name": "Het voorvoegsel dat moet worden gebruikt voor uw Power-sensoren",
           "read_modbus_addr": "Het modbus address van de Power-omvormer",
           "interface" : "Interface",
+          "inverter_name_suffix": "Inverter naam toevoeging",
           "read_eps": "Noodstroom optie (EPS)",
           "read_dcb": "Dry Contact Box (SolaX Hybrid Gen4 & Gen5)",
           "read_pm": "Parallel Mode (Master-Slave)",
           "plugin": "Inverter Type",
-          "scan_interval": "De polling-frequentie van de modbus registratie in seconden"
+          "scan_interval": "De polling-frequentie van de modbus registratie in seconden",
+          "scan_interval_medium": "Gemiddelde polling-frequenctie",
+          "scan_interval_fast": "Snelle polling-frequenctie"
         }
       },
       "serial": {
@@ -27,6 +30,12 @@
           "host": "Het IP-address van uw inverter of modbus-tcp adapter",
           "port": "De TCP port voor Inverter of Modbus adapter",
           "tcp_type": "De Modbus TCP variant"
+        }
+      },
+      "battery": {
+        "title": "Uitlezen van batterij module(s)",
+        "data": {
+          "read_battery": "Batterij uitlezen"
         }
       }
     },
@@ -47,11 +56,14 @@
           "name": "Het voorvoegsel dat moet worden gebruikt voor uw Power-sensoren",
           "read_modbus_addr": "Het modbus address van de Power-omvormer",
           "interface" : "Interface",
+          "inverter_name_suffix": "Inverter naam toevoeging",
           "read_eps": "Noodstroom Optie (EPS)",
           "read_dcb": "Dry Contact Box (SolaX Hybrid Gen4 & Gen5)",
           "read_pm": "Parallel Mode (Master-Slave)",
           "plugin": "Inverter Type",
-          "scan_interval": "De polling-frequentie van de modbus registratie in seconden"
+          "scan_interval": "De polling-frequentie van de modbus registratie in seconden",
+          "scan_interval_medium": "Gemiddelde polling-frequenctie",
+          "scan_interval_fast": "Snelle polling-frequenctie"
         }
       },
       "serial": {
@@ -66,6 +78,12 @@
         "data": {
           "host": "Het IP-address van uw inverter of modbus-tcp adapter",
           "port": "De TCP port voor Inverter of Modbus adapter"
+        }
+      },
+     "battery": {
+        "title": "Uitlezen van batterij module(s)",
+        "data": {
+          "read_battery": "Batterij uitlezen"
         }
       }
     },


### PR DESCRIPTION
Removed the deprecation message from pyModbus by changing the include in plugins from the original pymodbus.payload to local payload module

Issue #1223 
