### PR TITLE
Change pymodbus requirement to soft pin

### DIFF
--- a/custom_components/solax_modbus/manifest.json
+++ b/custom_components/solax_modbus/manifest.json
@@ -9,6 +9,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wills106/homsassistant-solax-modbus/issues",
-  "requirements": ["pymodbus==3.8.3"],
+  "requirements": ["pymodbus>=3.8.3"],
   "version": "2025.03.4"
 }


### PR DESCRIPTION
Hi, please, hard pinning of python requirements is really not healthy for the ecosystem (see https://github.com/davidrapan/ha-solarman/issues/456).