### PR TITLE
Sofar: Remove LSE-3 recommendation from FAQ

### DIFF
--- a/docs/sofar-faq.md
+++ b/docs/sofar-faq.md
@@ -4,15 +4,15 @@
 
 Have you double checked that the termination resistor is installed on both ends? On the adaptor side make sure that it has a termination resistor in the adaptor (check the adaptor's manual or measure it). If this is missing add a 120 Ohm resistor between A and B to properly terminate the adaptor side. On the inverter side Sofar inverters also require a termination on the last connected inverter. Note that on the COM Port the PINs 1 and 2 (A+) and PINs 3 and 4 (B-) are internally connected with each other. So if your signal cable is connected to PINs 1 and 4 you can use the PINs 2 and 3 to connect your termination resistor.
 
-The by-far best and easiest ModBus connection is provided by the replacing the LSW-3 WiFi Stick Logger with the LSE-3 Ethernet Stick Logger. The later provides Modbus TCP out of the box via the port 8899.
-
 ## RS485 communication stops after a few hours
 
 There was an issue in recent firmware versions (introduced at around V110000) that cause the firmware communication to fail after a few hours. Install a newer firmware of at least version V110051.
 
 ## I am using the LSW-3 Wifi Stick Logger, but ModBus TCP does not work
 
-Even though also on the LSW-3 Wifi Stick Logger shows that port 8899 is open, Modbus TCP connection attempts time out. Replace our stick logger with the LSE-3 LAN Stick Logger.
+Even though also on the LSW-3 Wifi Stick Logger shows that port 8899 is open, Modbus TCP connection attempts time out. 
+
+We recommend using a RS-485 Modbus TCP adaptor instead.
 
 ## I am using the LSE-3 LAN Stick Logger, but the port 8899 is not open
 
@@ -34,6 +34,8 @@ When using the UI you can ignore these errors.
 
 In automations and scripts these errors will cause your automation to stop. Workaround: Add `continue_on_error: true` to the YAML of your service calls that set values to the inverter. More details on `continue_on_error` can be found in the [Home Assistant documentation](https://www.home-assistant.io/docs/scripts/#continuing-on-error).
 
+In general we can no longer recommend the LSE-3. Instead we recommend a RS-485 Modbus TCP adaptor.
+
 ## I am using the LSE-3 logger stick, but requests timeout frequently.
 
 There are multiple possible root causes for this:
@@ -41,6 +43,8 @@ There are multiple possible root causes for this:
 - You have assigned a fixed IP address in the config UI of the logger stick. To solve this, let the logger stick fetch an IP address via DHCP, but use your router configuration to assign the same IP address to the logger stick.
 - Wrong firmware. Make sure your logger stick is using the firmware version `ME_0D_270A_1.09`. The newer firmware version `ME_0D_270A_1.11` is causing issues. Older firmwares are also not reliable. If your logger stick's firmware is not the correct version, get in touch with the [SolarMan support](https://www.solarmanpv.com/supportservice/service-contact/) and ask them to update the firmware of your logger. SolarMan support will need the serial number of your logger to do this.
 - Too many requests. Especially if you also use other software that accesses the LSE-3, too many requests can lead to time out issues. Increase the request intervals to solve this issue.
+
+In general we can no longer recommend the LSE-3. Instead we recommend a RS-485 Modbus TCP adaptor.
 
 
 ## I have changed some values, but they seem to have no impact on the inverter's operation.


### PR DESCRIPTION
We can no longer recommend the LSE-3, but the FAQ still contained a recommendation to do so. Removed the recommendation and suggest using a RS485 TCP adaptor instead.