### PR TITLE
Adapt EXPORT_LIMIT_SCALE_EXCEPTIONS for Solax X3-Ultra 25K

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -541,6 +541,7 @@ EXPORT_LIMIT_SCALE_EXCEPTIONS = [
     ("H4502T", 1),  # Issue #418
     ("H4602A", 1),  # Issue #882
     ("H3BD", 10),  # X3-Ultra
+    ("H3BF", 10),  # X3-Ultra
     ("H4752A", 1),
     ("H3BC", 10),
     ("H34B10H", 10),  # need return @jansidlo ,


### PR DESCRIPTION
Variable EXPORT_LIMIT_SCALE_EXCEPTIONS adapted to work with Solax X3-Ultra 25K where the serial number starts with "H3BF".