### PR TITLE
Added special settings for solis

### DIFF
--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -108,6 +108,13 @@ class SolisModbusSensorEntityDescription(BaseModbusSensorEntityDescription):
 
 # ====================================== Computed value functions  =================================================
 
+# This value function converts the bits to the number
+def mutate_bit_in_register(bit: int, state: int, descr: str, datadict: dict):
+    value = datadict.get(descr, 0)
+    _LOGGER.debug(f">>> Old value of {descr}: {value}")
+    new_value = (value & ~(1 << bit)) | (state << bit)
+    return new_value
+
 
 def value_function_timingmode(initval, descr, datadict):
     return [
@@ -830,9 +837,96 @@ NUMBER_TYPES = [
         max_exceptions=MAX_CURRENTS,
         entity_category=EntityCategory.CONFIG,
     ),
+    SolisModbusNumberEntityDescription(
+        name="Special Settings",
+        key="special_settings",
+        register=43249,
+        icon="mdi:switch",
+        fmt="i",
+        native_min_value=0,
+        native_max_value=4096,
+        native_step=1,
+        allowedtypes=HYBRID,
+        entity_category=EntityCategory.CONFIG,
+    ),
 ]
 
 # ================================= Select Declarations ============================================================
+
+SWITCH_TYPES = [
+    SolisModbusSwitchEntityDescription(
+        name="MPPT Parallel Function",
+        key="mppt_parallel_function",
+        register=43249,
+        icon="mdi:switch",
+        register_bit=0,
+        sensor_key="special_settings",
+        value_function=mutate_bit_in_register,
+    ),
+    SolisModbusSwitchEntityDescription(
+        name="IgFollow",
+        key="timed_charge_slot_2_enable",
+        register=43249,
+        icon="mdi:switch",
+        register_bit=1,
+        sensor_key="special_settings",
+        value_function=mutate_bit_in_register,
+    ),
+    SolisModbusSwitchEntityDescription(
+        name="Relay protection",
+        key="timed_charge_slot_3_enable",
+        register=43249,
+        icon="mdi:switch",
+        register_bit=2,
+        sensor_key="special_settings",
+        value_function=mutate_bit_in_register,
+    ),
+    SolisModbusSwitchEntityDescription(
+        name="I-leak protection",
+        key="timed_charge_slot_4_enable",
+        register=43249,
+        icon="mdi:switch",
+        register_bit=3,
+        sensor_key="special_settings",
+        value_function=mutate_bit_in_register,
+    ),
+    SolisModbusSwitchEntityDescription(
+        name="PV iso Protection",
+        key="timed_charge_slot_5_enable",
+        register=43249,
+        icon="mdi:switch",
+        register_bit=4,
+        sensor_key="special_settings",
+        value_function=mutate_bit_in_register,
+    ),
+    SolisModbusSwitchEntityDescription(
+        name="Grid-interference protection",
+        key="timed_charge_slot_6_enable",
+        register=43249,
+        icon="mdi:switch",
+        register_bit=5,
+        sensor_key="special_settings",
+        value_function=mutate_bit_in_register,
+    ),
+    SolisModbusSwitchEntityDescription(
+        name="DC component of grid current protection switch",
+        key="timed_discharge_slot_1_enable",
+        register=43249,
+        icon="mdi:switch",
+        register_bit=6,
+        sensor_key="special_settings",
+        value_function=mutate_bit_in_register,
+    ),
+    SolisModbusSwitchEntityDescription(
+        name="Const Voltage Mode Enable",
+        key="timed_discharge_slot_2_enable",
+        register=43249,
+        icon="mdi:switch",
+        register_bit=7,
+        sensor_key="special_settings",
+        value_function=mutate_bit_in_register,
+    ),
+]
 
 SELECT_TYPES = [
     SolisModbusSelectEntityDescription(
@@ -2603,7 +2697,7 @@ plugin_instance = solis_plugin(
     NUMBER_TYPES=NUMBER_TYPES,
     BUTTON_TYPES=BUTTON_TYPES,
     SELECT_TYPES=SELECT_TYPES,
-    SWITCH_TYPES=[],
+    SWITCH_TYPES=SWITCH_TYPES,
     block_size=40,
     order16=Endian.BIG,
     order32=Endian.BIG,

--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -93,6 +93,11 @@ class SolisModbusNumberEntityDescription(BaseModbusNumberEntityDescription):
 @dataclass
 class SolisModbusSelectEntityDescription(BaseModbusSelectEntityDescription):
     allowedtypes: int = ALLDEFAULT  # maybe 0x0000 (nothing) is a better default choice
+    
+
+@dataclass
+class SolisModbusSwitchEntityDescription(BaseModbusSwitchEntityDescription):
+    allowedtypes: int = ALLDEFAULT  # maybe 0x0000 (nothing) is a better default choice
 
 
 @dataclass
@@ -865,7 +870,7 @@ SWITCH_TYPES = [
     ),
     SolisModbusSwitchEntityDescription(
         name="IgFollow",
-        key="timed_charge_slot_2_enable",
+        key="igfollow",
         register=43249,
         icon="mdi:switch",
         register_bit=1,
@@ -874,7 +879,7 @@ SWITCH_TYPES = [
     ),
     SolisModbusSwitchEntityDescription(
         name="Relay protection",
-        key="timed_charge_slot_3_enable",
+        key="relay_protection",
         register=43249,
         icon="mdi:switch",
         register_bit=2,
@@ -883,7 +888,7 @@ SWITCH_TYPES = [
     ),
     SolisModbusSwitchEntityDescription(
         name="I-leak protection",
-        key="timed_charge_slot_4_enable",
+        key="i_leak_protection",
         register=43249,
         icon="mdi:switch",
         register_bit=3,
@@ -892,7 +897,7 @@ SWITCH_TYPES = [
     ),
     SolisModbusSwitchEntityDescription(
         name="PV iso Protection",
-        key="timed_charge_slot_5_enable",
+        key="pv_iso_protection",
         register=43249,
         icon="mdi:switch",
         register_bit=4,
@@ -901,7 +906,7 @@ SWITCH_TYPES = [
     ),
     SolisModbusSwitchEntityDescription(
         name="Grid-interference protection",
-        key="timed_charge_slot_6_enable",
+        key="grid_interference_protection",
         register=43249,
         icon="mdi:switch",
         register_bit=5,
@@ -910,7 +915,7 @@ SWITCH_TYPES = [
     ),
     SolisModbusSwitchEntityDescription(
         name="DC component of grid current protection switch",
-        key="timed_discharge_slot_1_enable",
+        key="dc_component_of_grid_current_protection_switch",
         register=43249,
         icon="mdi:switch",
         register_bit=6,
@@ -919,7 +924,7 @@ SWITCH_TYPES = [
     ),
     SolisModbusSwitchEntityDescription(
         name="Const Voltage Mode Enable",
-        key="timed_discharge_slot_2_enable",
+        key="const_voltage_mode_enable",
         register=43249,
         icon="mdi:switch",
         register_bit=7,
@@ -2601,6 +2606,15 @@ SENSOR_TYPES: list[SolisModbusSensorEntityDescription] = [
         allowedtypes=HYBRID,
         entity_category=EntityCategory.CONFIG,
         icon="mdi:battery-clock",
+    ),
+    SolisModbusSensorEntityDescription(
+        name="Special Settings",
+        key="special_settings",
+        register=43249,
+        icon="mdi:switch",
+        entity_registry_enabled_default=True,
+        allowedtypes=HYBRID,
+        entity_category=EntityCategory.CONFIG,
     ),
 ]
 


### PR DESCRIPTION
I have a dynamic contract and for that I want to be able to "disable" the PV power generation of the inverter when the grid price is negative.

By adding the the special settings register from the Solis I am able to do so.

Register 43249:
Bit0, MPPT parallel function
Bit1, IgFollow 
Bit2, Relay protection 
Bit3, I-leak protection 
Bit4, PV iso Protection 
Bit5, Grid-Interference protection 
Bit6, The DC component of the grid current protection switch 
Bit7, Const Voltage Mode Enable
Bit8-11 Grid-filter level 0-7 (not added)
Bit12-15 Afci sensitivity 0-7 (not added)

By default the const voltage is at 600V, for me that is not optimal for my MPPTs, essentially turning off the PV generation.
This is the only setting I could find to disable PV generation and keep the battery&grid working.