### PR TITLE
Support grid import for SPH3600

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -3683,7 +3683,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         unit = REGISTER_S32,
         scale = 0.1,
         rounding = 1,
-        allowedtypes = GEN3 | X3,
+        allowedtypes = GEN3 | X3 | X1,
         icon = "mdi:home",
     ),
     GrowattModbusSensorEntityDescription(


### PR DESCRIPTION
Growatt SPH3600 hybrid inverters don't currently display the grid import. 