### PR TITLE
Update pymodbus to 3.9.0 and later

### DIFF
--- a/custom_components/solax_modbus/manifest.json
+++ b/custom_components/solax_modbus/manifest.json
@@ -9,6 +9,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wills106/homsassistant-solax-modbus/issues",
-  "requirements": ["pymodbus>=3.8.3"],
+  "requirements": ["pymodbus>=3.9.0"],
   "version": "2025.06.1"
 }

--- a/custom_components/solax_modbus/payload.py
+++ b/custom_components/solax_modbus/payload.py
@@ -21,7 +21,7 @@ from struct import pack, unpack
 from pymodbus.constants import Endian
 from pymodbus.exceptions import ParameterException
 from pymodbus.logging import Log
-from pymodbus.utilities import (
+from pymodbus.pdu.pdu import (
     pack_bitstring,
     unpack_bitstring,
 )


### PR DESCRIPTION
pymodbus 3.9.0 contains a "breaking" change, see https://github.com/pymodbus-dev/pymodbus/commit/d47dc65a7995a19e9d004318ff7b050d8f82f2a5:

> Even though this PR is technically not a breaking change, it will be released as such, due to the severity of the bug.

See https://github.com/pymodbus-dev/pymodbus/issues/2623 for the actual bug report.

I'm not sure if any more code changes are required in this repo.

I'm marking this as a draft PR until HA actually updates pymodbus.