### PR TITLE
Correct Inverter Power for SolaX X1-IES Hybrid Gen5 Inverter

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -4099,6 +4099,17 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN2 | GEN3 | GEN4,
     ),
     SolaXModbusSensorEntityDescription(
+        name="Inverter Power",
+        key="inverter_power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        register=0x2,
+        register_type=REG_INPUT,
+        unit=REGISTER_S16,
+        allowedtypes=AC | HYBRID | GEN5 | X1,
+    ),
+    SolaXModbusSensorEntityDescription(
         name="PV Voltage 1",
         key="pv_voltage_1",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -6449,7 +6460,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        allowedtypes=AC | HYBRID | GEN5,
+        allowedtypes=AC | HYBRID | GEN5 | X3,
     ),
     SolaXModbusSensorEntityDescription(
         name="PV Power Total",


### PR DESCRIPTION
In commit fa92b3ec10066f4b0368dcb9dd2d4c3fa112fd19, the Gen5 SolaX hybrid inverters were changed to use a calculation for inverter power based on three registers for each of three phases. However this only works for the 3-phase X3-IES Gen5 inverters.

The X1-IES Gen5 inverter is single phase, and so still uses the same register 0x2 as the older generation hybrid inverters.

Here we restrict the new Gen5 calculated inverter power sensor entity to X3 devices, and add a new sensor entity for the X1 gen5 variants which reads the power directly from register 0x2.

This fixes the problem I mentioned in https://github.com/wills106/homeassistant-solax-modbus/issues/813#issuecomment-2958056642.

---
(* note: perhaps there is a way to use the existing gen4 sensor, but looking at the way the allowed types works I couldn't see how that would work *)