### PR TITLE
Added PV Limit entity for Solax X3 Gen2 MIC/PRO

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1401,6 +1401,17 @@ NUMBER_TYPES = [
         allowedtypes=MIC | GEN2 | X3,
     ),
     SolaxModbusNumberEntityDescription(
+        name="PV Limit",
+        key="pv_limit",
+        register=0x60F,
+        fmt="i",
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        native_unit_of_measurement=PERCENTAGE,
+        allowedtypes=MIC | GEN2 | X3,
+    ),
+    SolaxModbusNumberEntityDescription(
         name="Active Power Limit",
         key="active_power_limit",
         register=0x669,


### PR DESCRIPTION
Added "PV Limit" entity for Solax X3 Gen2 MIC/PRO to limit the power of the inverter by limiting the dc side.

I added this entity in order to have the ability to limit a additional X3-PRO-12k which is working besides a X3-Hybrid-12k. The PRO does not have any meter or CT connected which is probably the reason why limiting the export power does not work on the PRO. With this entity i can limit the power of the PRO to a percentage of the power specified for the inverter e.g. a 10% limit means a power limit of 1200W for the 12k. After setting the limit it takes 1 to 2 minutes for the inverter to reach the limit.

Sources for this entity: https://www.photovoltaikforum.com/core/file-download/369195/ page 18 "PowerLimitsPercent" and https://ro.solaxpower.com/uploads/file/x3-pro-g2-user-manual-en.pdf page 63 "Power Limits"

It works well for my inverter. Is there any reason against adding this entity?