### PR TITLE
Sofar doc small improvements

### DIFF
--- a/docs/compatible-adaptors.md
+++ b/docs/compatible-adaptors.md
@@ -53,8 +53,6 @@ The standard LSW-3 Wifi logger that comes with the inverter.
 
 ![Image of LSW-3 Logger](images/adaptor-sofar-lsw3-wifi-logger.png)
 
-Tested with LSE-3 firmware version LSW3_15_270A_1.65.
-
 Please see the [Sofar Installation](sofar-installation.md) for more information.
 
 #### LAN Stick Logger LSE-3
@@ -62,8 +60,6 @@ Please see the [Sofar Installation](sofar-installation.md) for more information.
 Replace the LSW-3 Wifi logger that comes with the inverter by the LSE-3 ethernet logger.
 
 ![Image of LSE-3 Logger](images/adaptor-sofar-lse3-lan-logger.png)
-
-Tested with LSE-3 firmware version ME_0D_270A_1.09.
 
 Please see the [Sofar Installation](sofar-installation.md) for more information.
 

--- a/docs/sofar-installation.md
+++ b/docs/sofar-installation.md
@@ -4,6 +4,8 @@ How to establish the connection to your Sofar Solar inverter hardware.
 
 ## General recommendation: Use a Modbus Proxy
 
+**Note:** If you use an RS485 to Modbus TCP ethernet adaptor you may ignore this section. Many RS485 to Modbus TCP adaptors have a Modbus proxy built in.
+
 If you experience issues with the reliability of the communication, especially (but not limited to) when you are accessing the Modbus interface with more clients besides Home Assistant at the same time, we recommend to try using a Modbus Proxy. A Modbus Proxy can mediate between the inverter's interface (RS485 serial, Modbus TCP, Modbus TCP over RTU) and multiple clients. You can install a Modbus proxy as a [standalone service](https://github.com/tiagocoutinho/modbus-proxy), you can use the Home Assistant [Modbus Proxy Add-on](https://github.com/Akulatraxas/ha-modbusproxy) or use the embedded Modbus proxy that comes with [EVCC](https://docs.evcc.io/en/docs/reference/configuration/modbusproxy).
 
 Important in this case: Only the Modbus proxy must connect to your inverter directly. All other clients must connect to the proxy.
@@ -48,7 +50,7 @@ The LSW-3 WiFi stick comes with the inverter and **may** be used with this integ
 Tested with firmware:
 
 - Inverter: V121202
-- LSW:  LSW3_15_MQTT_270A_1.22 with Extended System Version V1.1.00.04 (you can see this in the Solarman portal under devices on the logger's device data tab. Extendedn System Version V1.1.00.0F does not work for example).
+- LSW:  LSW3_15_MQTT_270A_1.22 with Extended System Version V1.1.00.04 (you can see this in the Solarman portal under devices on the logger's device data tab. Extended System Version V1.1.00.0F does not work for example).
 
 Simply connect to the LSW using the logger sticks IP address (make sure that you have assigned a fixed IP address in your router) and the port `8899`. If that does not work, try using a Modbus proxy in between as explained above.
 

--- a/docs/sofar-installation.md
+++ b/docs/sofar-installation.md
@@ -93,7 +93,7 @@ Tested with firmware:
 
 The LSE-3 LAN stick logger is an alternative to the LSW-3 WiFi stick logger that connects over LAN cable instead of WiFi. 
 
-In contrast to the LSW-3 you can also use it with SolarMan and this integration in parallel at the same time. The default working mode speaks some sort of Modbus TCP with some incompatibilities besides its SolarMan protocol. However this parallel use comes with a couple of caveats as you can see in the [FAQ](./sofar-faq.md) and some reliability issues. **Therefore we do not recommend to run this integration with the LSE-3 in the default 'Data collection' working mode**. We recommend to use the same 'Transparency' working mode as described above for the LSW-3 Wifi stick logger.
+The default working mode speaks some sort of Modbus TCP with some incompatibilities in parallel to the SolarMan protocol. However this parallel use comes with a couple of caveats as you can see in the [FAQ](./sofar-faq.md) and some reliability issues. **Therefore we do not recommend to run this integration with the LSE-3 in the default 'Data collection' working mode**. We recommend to use the same 'Transparency' working mode as described above for the LSW-3 Wifi stick logger.
 
 ![Image of installed LSE-3 LAN Stick Logger](images/installation-sofar-lse3-stick-logger.png)
 


### PR DESCRIPTION
Small doc improvements for Sofar
- Typo
- Added note that Modbus TCP Ethernet adaptor might not require a Modbus Proxy
- Removed tested firmwares from adaptors page for Sofar dongles as this is mentioned in depth on the Sofar installation page.
- Removed note in LSE section about LSW limitations that do no longer apply.