### PR TITLE
Prepare the code for update of pymodbus

### DIFF
--- a/custom_components/solax_modbus/payload.py
+++ b/custom_components/solax_modbus/payload.py
@@ -21,10 +21,13 @@ from struct import pack, unpack
 from pymodbus.constants import Endian
 from pymodbus.exceptions import ParameterException
 from pymodbus.logging import Log
-from pymodbus.utilities import (
-    pack_bitstring,
-    unpack_bitstring,
-)
+
+import pymodbus
+from packaging.version import parse
+if parse(pymodbus.__version__) >= parse("3.9.2"):
+  from pymodbus.pdu.pdu import pack_bitstring, unpack_bitstring
+else:
+  from pymodbus.utilities import pack_bitstring, unpack_bitstring
 
 
 class BinaryPayloadBuilder:


### PR DESCRIPTION
Prepare the code for the coming update in Home Assistant to use pymodbus v3.9.2 in coming release