### PR TITLE
Update plugin_growatt.py

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -543,8 +543,7 @@ def value_function_inverter_warning_text(initval, descr, datadict):
         (608, 0): "Backup box is abnormal",
         (609, 0): "Balanced circuit abnormal"
     }
-    label = bit_labels.get((main_code, sub_code), f"Unknown fault (main_code={main_code}, sub_code={sub_code})")
-    return label
+    return bit_labels.get((main_code, sub_code), f"Unknown warning (main_code={main_code}, sub_code={sub_code})")
 
 def value_function_inverter_fault_code(initval, descr, datadict):
     main_code = datadict.get('inverter_fault_maincode', 0)
@@ -602,8 +601,7 @@ def value_function_inverter_fault_text(initval, descr, datadict):
         (703, 0): "Backup box on-grid overload",
         (705, 0): "Overheat inside the backup box"
     }
-    label = bit_labels.get((main_code, sub_code), f"Unknown fault (main_code={main_code}, sub_code={sub_code})")
-    return label
+    return bit_labels.get((main_code, sub_code), f"Unknown fault (main_code={main_code}, sub_code={sub_code})")
 	
 def value_function_run_mode(initval, descr, datadict):
     run_mode = datadict.get('register_3000', 0)


### PR DESCRIPTION
* changed from allowedtypes = GEN4 to GEN4 | HYBRID, for all entities that I have added. Since GEN4 can be an inverter PV only, so with HYBRID added those will only be visible for Hybrid inverters.
* renamed throughput -> output energy, because this value is only how much energy that has been outputed, not in and out
* BMS status entity
* removed "Total Worked Time Seconds", entity in hours instead
* renamed "...module cycle" to "...module cycles", in plural