### PR TITLE
issues #1440 #1473 #1482; dont poll disabled sensors, better handling of offline situations, multiple_scan_groups enhancement

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -1111,12 +1111,10 @@ class SolaXModbusHub:
         _LOGGER.info(f"rebuilding groups and blocks - pre: {initial_groups.keys()}")
         self.initial_groups = initial_groups
         for interval, interval_group in initial_groups.items():
-            _LOGGER.info(f"*** rebuild_block {self._name} interval: {interval} interval_group type: {type(interval_group)}")
             for device_name, device_group in interval_group.device_groups.items():
-                _LOGGER.info(f"*** rebuild for device {device_name} in interval {interval}")
+                _LOGGER.info(f"rebuild for device {device_name} in interval {interval}")
                 holdingRegs = dict(sorted(device_group.holdingRegs.items()))
                 inputRegs   = dict(sorted(device_group.inputRegs.items()))
-                _LOGGER.info(f"***debug*** rebuilding pre1 - len holdingRegs: {len(holdingRegs)} inputRegs: {len(inputRegs)}")
                 # update the hub groups
                 hub_interval_group = self.groups.setdefault(interval, empty_hub_interval_group_lambda())
                 hub_device_group = hub_interval_group.device_groups.setdefault(device_name, empty_hub_device_group_lambda())

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -15,7 +15,7 @@ from weakref import ref as WeakRef
 from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
 from pymodbus.exceptions import ModbusException
 from pymodbus.pdu import register_message
-
+from dataclasses import dataclass, replace
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
@@ -39,6 +39,10 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
+
+RETRIES = 0 # was 6
+INVALID_START = 99999
+
 
 try:
     from homeassistant.components.modbus import ModbusHub as CoreModbusHub, get_hub as get_core_hub
@@ -236,6 +240,24 @@ def Gen4Timestring(numb):
     m = numb >> 8
     return f"{h:02d}:{m:02d}"
 
+def is_entity_enabled(hass, entity_id): # Check if the entity is enabled in Home Assistant
+    state = hass.states.get(entity_id)
+    if state is None:
+        _LOGGER.debug(f"Entity {entity_id} not found in state manager, assuming disabled. Not added to read block")
+        return False
+    if state.state in ['unavailable', 'unknown']: # Check if the entity state is 'unavailable' or 'unknown'
+        return True
+    # If none of the above conditions are met, assume the entity is enabled
+    return True
+
+@dataclass
+class block():
+    start: int = None # start address of the block
+    end: int = None # end address of the block
+    #order16: int = None # byte endian for 16bit registers
+    #order32: int = None # word endian for 32bit registers
+    descriptions: Any = None
+    regs: Any = None # sorted list of registers used in this block
 
 class SolaXModbusHub:
     """Thread safe wrapper class for pymodbus."""
@@ -280,19 +302,19 @@ class SolaXModbusHub:
                 stopbits=1,
                 bytesize=8,
                 timeout=time_out,
-                retries=6,
+                retries=RETRIES,
             )
         elif interface == "tcp":
             if tcp_type == "rtu":
                 self._client = AsyncModbusTcpClient(
-                    host=host, port=port, timeout=time_out, framer=FramerType.RTU, retries=6
+                    host=host, port=port, timeout=time_out, framer=FramerType.RTU, retries=RETRIES
                 )
             elif tcp_type == "ascii":
                 self._client = AsyncModbusTcpClient(
-                    host=host, port=port, timeout=time_out, framer=FramerType.ASCII, retries=6
+                    host=host, port=port, timeout=time_out, framer=FramerType.ASCII, retries=RETRIES
                 )
             else:
-                self._client = AsyncModbusTcpClient(host=host, port=port, timeout=time_out, retries=6)
+                self._client = AsyncModbusTcpClient(host=host, port=port, timeout=time_out, retries=RETRIES)
         self._lock = asyncio.Lock()
         self._name = name
         self.inverterNameSuffix = config.get(CONF_INVERTER_NAME_SUFFIX)
@@ -339,11 +361,14 @@ class SolaXModbusHub:
         self.config = config
         self.entry = entry
         self.device_info = None
+        self.blocks_changed = False
 
         _LOGGER.debug("solax modbushub done %s", self.__dict__)
 
+
     async def async_init(self, *args: Any) -> None:  # noqa: D102
         while self._invertertype in (None, 0):
+            await self.async_connect()
             await self._check_connection()
             self._invertertype = await self.plugin.async_determineInverterType(self, self.config)
 
@@ -451,6 +476,7 @@ class SolaXModbusHub:
         device_key = self.device_group_key(sensor.device_info)
         grp = interval_group.device_groups.setdefault(device_key, self.empty_device_group())
         grp.sensors.append(sensor)
+        self.blocks_changed = True # will force blocks to be recomputed; probably not needed since HA reinitializes if sensors are added
 
     @callback
     async def async_remove_solax_modbus_sensor(self, sensor):
@@ -479,22 +505,27 @@ class SolaXModbusHub:
 
                 if not self.groups:
                     await self.async_close()
+        #self.blocks_changed = True # will force blocks to be recomputed  - Gives problems with interval namespace
+
 
     async def async_refresh_modbus_data(self, interval_group, _now: Optional[int] = None) -> None:
         """Time to update."""
+        _LOGGER.debug(f"coordinator initiated refresh_modbus_data call")
         self.cyclecount = self.cyclecount + 1
         if not interval_group.device_groups:
             return
-
+        if self.blocks_changed:
+            self.rebuild_blocks(self.groups) # not needed ?
         if (self.cyclecount % self.slowdown) == 0:  # only execute once every slowdown count
             for group in interval_group.device_groups.values():
                 update_result = await self.async_read_modbus_data(group)
                 if update_result:
+                    if self.slowdown > 1: _LOGGER.info(f"communication restored, resuming normal speed after slowdown")
                     self.slowdown = 1  # return to full polling after successful cycle
                     for sensor in group.sensors:
                         sensor.modbus_data_updated()
                 else:
-                    _LOGGER.debug(f"assuming sleep mode - slowing down by factor 10")
+                    if self.slowdown <=1: _LOGGER.info(f"modbus group read failed - assuming sleep mode - slowing down by factor 10" )
                     self.slowdown = 10
                     for i in self.sleepnone:
                         self.data.pop(i, None)
@@ -536,37 +567,24 @@ class SolaXModbusHub:
     #    if not self._client.connected:
     #        async with self._lock:
     #            await self._client.connect()
-
+    
     async def _check_connection(self):
         if not self._client.connected:
             _LOGGER.info("Inverter is not connected, trying to connect")
-            return await self.async_connect()
-
+            await self.async_connect()
+            await asyncio.sleep(1)
         return self._client.connected
 
+
+    async def is_online(self):
+        return self._client.connected and (self.slowdown == 1)
+
     async def async_connect(self):
-        result = False
-
-        _LOGGER.debug(
-            "Trying to connect to Inverter at %s:%s",
-            self._client.comm_params.host,
-            self._client.comm_params.port,
+        #result = False
+        _LOGGER.info(
+            f"***Trying to connect to Inverter at {self._client.comm_params.host}:{self._client.comm_params.port} connected: {self._client.connected} ",
         )
-
-        result = await self._client.connect()
-        if result:
-            _LOGGER.info(
-                "Inverter connected at %s:%s",
-                self._client.comm_params.host,
-                self._client.comm_params.port,
-            )
-        else:
-            _LOGGER.warning(
-                "Unable to connect to Inverter at %s:%s",
-                self._client.comm_params.host,
-                self._client.comm_params.port,
-            )
-        return result
+        await self._client.connect()
 
     async def async_read_holding_registers(self, unit, address, count):
         """Read holding registers."""
@@ -709,15 +727,17 @@ class SolaXModbusHub:
                     _LOGGER.error(f"unsupported unit type: {typ} for {key}")
             payload = builder.to_registers()
             # for easier debugging, make next line a _LOGGER.info line
-            _LOGGER.debug(f"Ready to write multiple registers at 0x{address:02x}: {payload}")
-            async with self._lock:
-                await self._check_connection()
-                try:
-                    resp = await self._client.write_registers(address=address, values=payload, **kwargs)
-                except (ConnectionException, ModbusIOException) as e:
-                    original_message = str(e)
-                    raise HomeAssistantError(f"Error writing multiple Modbus registers: {original_message}") from e
-            return resp
+            online = await self.is_online()
+            _LOGGER.debug(f"Ready to write multiple registers at 0x{address:02x}: {payload} online: {online} ")
+            if online: 
+                async with self._lock:
+                    try:
+                        resp = await self._client.write_registers(address=address, values=payload, **kwargs)
+                    except (ConnectionException, ModbusIOException) as e:
+                        original_message = str(e)
+                        raise HomeAssistantError(f"Error writing multiple Modbus registers: {original_message}") from e
+                return resp
+            else: return None
         else:
             _LOGGER.error(f"write_registers_multi expects a list of tuples 0x{address:02x} payload: {payload}")
             return None
@@ -824,10 +844,9 @@ class SolaXModbusHub:
             if max_val is not None and return_value > max_val:
                 raise ModbusIOException(f"Value {return_value} of '{descr.key}' greater than {max_val}")
         # if (descr.sleepmode != SLEEPMODE_LASTAWAKE) or self.awakeplugin(self.data): self.data[descr.key] = return_value
-        if (self.tmpdata_expiry.get(descr.key, 0) == 0) and (
-            (descr.sleepmode != SLEEPMODE_LASTAWAKE) or self.plugin.isAwake(self.data)
-        ):
-            data[descr.key] = return_value  # case prevent_update number
+        if ((self.tmpdata_expiry.get(descr.key, 0) == 0) 
+        and ( (descr.sleepmode != SLEEPMODE_LASTAWAKE) or self.plugin.isAwake(self.data) )):
+                data[descr.key] = return_value  # case prevent_update number
 
     async def async_read_modbus_block(self, data, block, typ):
         errmsg = None
@@ -850,6 +869,7 @@ class SolaXModbusHub:
                 )
         except Exception as ex:
             errmsg = f"exception {str(ex)} "
+            _LOGGER.debug(f"exception reading {typ} {block.start} {errmsg}")
         else:
             if realtime_data is None or realtime_data.isError():
                 errmsg = f"read_error "
@@ -895,14 +915,26 @@ class SolaXModbusHub:
             return True
         else:  # block read failure
             firstdescr = block.descriptions[block.start]  # check only first item in block
-            if firstdescr.ignore_readerror != False:  # ignore block read errors and return static data
+            _LOGGER.debug(f"**** failed {typ} block {errmsg} start {block.start} {firstdescr.key} ignore_readerror: {firstdescr.ignore_readerror}")
+            if (firstdescr.ignore_readerror is not False):  # ignore block read errors and return static data
+                _LOGGER.debug(f"**** failed block analysis started firstignore: {firstdescr.ignore_readerror}")
                 for reg in block.regs:
                     descr = block.descriptions[reg]
-                    if not (type(descr) is dict):
-                        if (descr.ignore_readerror != True) and (descr.ignore_readerror != False):
-                            data[descr.key] = descr.ignore_readerror  # return something static
+                    if   type(descr) is dict: l = descr.items() # special case: mutliple U8x entities
+                    else: l = { descr.key: descr, } # normal case, one entity
+                    for k, d in l.items():
+                        d_ignore = descr.ignore_readerror
+                        d_key = descr.key
+                        if (d_ignore is not True) and (d_ignore is not False):
+                            _LOGGER.info(f"***** returning static {d_key} = {d_ignore}")
+                            data[d_key] = d_ignore  # return something static
+                        else:
+                            if d_ignore is False: # remove potentially faulty data
+                                popped = data.pop(d_key, None) # added 20250716
+                                _LOGGER.info(f"***debug*** popping {d_key} = {popped}")
+                            else: _LOGGER.info(f"***debug*** not touching {d_key} ")
                 return True
-            else:
+            else: # dont ignore readerrors
                 if self.slowdown == 1:
                     _LOGGER.info(
                         f"{errmsg}: {self.name} cannot read {typ} registers at device {self._modbus_addr} position 0x{block.start:x}",
@@ -918,12 +950,14 @@ class SolaXModbusHub:
         else:
             _LOGGER.debug(f"device group inverter")
 
-        data = {"_repeatUntil": self.data["_repeatUntil"]} # remove for issue #1440 but then does not recognize comm errors
-        #data = self.data # add for issue #1440 - is an alias, not a copy - but then does not recognize communication errors anymore
+        #data = {"_repeatUntil": self.data["_repeatUntil"]} # remove for issue #1440 but then does not recognize comm errors
+        data = self.data # is an alias, not a copy (issue #1440)
         res = True
         for block in group.holdingBlocks:
+            _LOGGER.debug(f"** trying to read holding block {block.start} {res}")
             res = res and await self.async_read_modbus_block(data, block, "holding")
         for block in group.inputBlocks:
+            _LOGGER.debug(f"** trying to read input block {block.start} {res}")
             res = res and await self.async_read_modbus_block(data, block, "input")
 
         if self.localsUpdated:
@@ -940,8 +974,8 @@ class SolaXModbusHub:
                 _LOGGER.warning(f"device group check not success")
                 return True
 
-        for key, value in data.items(): # remove for issue #1440, but then does not recognize communication errors anymore
-            self.data[key] = value # remove for issue #1440, but then comm errors are not detected
+        #for key, value in data.items(): # remove for issue #1440, but then does not recognize communication errors anymore
+        #    self.data[key] = value # remove for issue #1440, but then comm errors are not detected
 
         if res and self.writequeue and self.plugin.isAwake(self.data):  # self.awakeplugin(self.data):
             # process outstanding write requests
@@ -989,6 +1023,97 @@ class SolaXModbusHub:
                             )
         return res
 
+    def splitInBlocks( self, descriptions):
+        start = INVALID_START
+        end = 0
+        blocks = []
+        block_size = self.plugin.block_size
+        auto_block_ignore_readerror = self.plugin.auto_block_ignore_readerror
+        curblockregs = []
+        for reg, descr in descriptions.items():
+            d_ignore_readerror = auto_block_ignore_readerror
+            if type(descr) is dict: # 2 byte  REGISTER_U8L, _U8H values on same modbus 16 bit address
+                d_newblock = False
+                d_enabled = False
+                for sub, d in descr.items():
+                    entity_id = f"sensor.{self._name}_{d.key}"
+                    d_enabled = d_enabled or is_entity_enabled(self._hass, entity_id) or d.internal
+                    d_newblock = d_newblock or d.newblock 
+                    d_unit = d.unit
+                    d_wordcount = 1 # not used here
+                    d_key = d.key # does not matter which key we use here
+                    d_regtype = d.register_type
+            else: # normal entity
+                entity_id = f"sensor.{self._name}_{descr.key}"
+                d_enabled = is_entity_enabled(self._hass, entity_id) or descr.internal
+                d_newblock = descr.newblock
+                d_unit = descr.unit
+                d_wordcount = descr.wordcount
+                d_key = descr.key
+                d_regtype = descr.register_type # HOLDING or INPUT
+
+            if d_enabled:
+                if (d_newblock or ((reg - start) > block_size)):
+                    if ((end - start) > 0):
+                        _LOGGER.debug(f"Starting new block at 0x{reg:x} ")
+                        if  ( (auto_block_ignore_readerror is True) or (auto_block_ignore_readerror is False) ) and not d_newblock: # automatically created block
+                            if type(descr) is dict: 
+                                for sub, d in descr.items():
+                                    if d.ignore_readerror is False: d.ignore_readerror = auto_block_ignore_readerror
+                            else: 
+                                if descr.ignore_readerror is False: descr.ignore_readerror = auto_block_ignore_readerror
+                        #newblock = block(start = start, end = end, order16 = descriptions[start].order16, order32 = descriptions[start].order32, descriptions = descriptions, regs = curblockregs)
+                        newblock = block(start = start, end = end, descriptions = descriptions, regs = curblockregs)
+                        blocks.append(newblock)
+                        start = INVALID_START
+                        end = 0
+                        curblockregs = []
+                else: _LOGGER.debug(f"newblock declaration found for empty block")
+
+                if start == INVALID_START: start = reg
+
+                _LOGGER.debug(f"adding register 0x{reg:x} {d_key} to block with start 0x{start:x}")
+                if d_unit in (REGISTER_STR, REGISTER_WORDS,):
+                    if (d_wordcount): end = reg+d_wordcount
+                    else: _LOGGER.warning(f"invalid or missing missing wordcount for {d_key}")
+                elif d_unit in (REGISTER_S32, REGISTER_U32, REGISTER_ULSB16MSB16,):  end = reg + 2
+                else: end = reg + 1
+                _LOGGER.debug(f"adding type {d_regtype} register 0x{reg:x} {d_key} to block with start 0x{start:x}")
+                curblockregs.append(reg)
+            else:
+                _LOGGER.debug(f"ignoring type {d_regtype} register 0x{reg:x} {d_key} to block with start 0x{start:x}")
+
+
+        if ((end-start)>0): # close last block
+            #newblock = block(start = start, end = end, order16 = descriptions[start].order16, order32 = descriptions[start].order32, descriptions = descriptions, regs = curblockregs)
+            newblock = block(start = start, end = end, descriptions = descriptions, regs = curblockregs)
+            blocks.append(newblock)
+        # Remove empty blocks before returning the blocks. - is this needed ??
+        #before = len(blocks)
+        #blocks = [b for b in blocks if b.regs] # needed ??
+        #_LOGGER.info(f"***debug***: {before} blocks before cleanup empty blocks, after: {len(blocks)}")
+        return blocks
+
+    def rebuild_blocks(self, groups): #, computedRegs):
+        _LOGGER.info(f"rebuilding groups and blocks - pre: {groups.keys()}")
+        for interval, interval_group in groups.items():
+            _LOGGER.info(f"***debug*** rebuild_block {self._name} interval: {interval} interval_group type: {type(interval_group)}")
+            for device_name, device_group in interval_group.items():
+                holdingRegs = dict(sorted(device_group.holdingRegs.items()))
+                inputRegs   = dict(sorted(device_group.inputRegs.items()))
+                hub_interval_group = self.groups.setdefault(interval, self.empty_interval_group())
+                hub_device_group = hub_interval_group.device_groups.setdefault(device_name, self.empty_device_group())
+                hub_device_group.readPreparation = device_group.readPreparation
+                hub_device_group.readFollowUp = device_group.readFollowUp
+                hub_device_group.holdingBlocks = self.splitInBlocks(holdingRegs)
+                hub_device_group.inputBlocks = self.splitInBlocks(inputRegs)
+                #self.computedSensors = computedRegs # moved outside the loops
+                for i in hub_device_group.holdingBlocks: _LOGGER.info(f"{self._name} interval {interval} dev {device_name} returning holding block: 0x{i.start:x} 0x{i.end:x} {i.regs}")
+                for i in hub_device_group.inputBlocks: _LOGGER.info(f"{self._name} interval {interval} dev {device_name} returning input block: 0x{i.start:x} 0x{i.end:x} {i.regs}")
+                _LOGGER.debug(f"holdingBlocks: {hub_device_group.holdingBlocks}")
+                _LOGGER.debug(f"inputBlocks: {hub_device_group.inputBlocks}")
+        self.blocks_changed = False
+        _LOGGER.info(f"done rebuilding groups and blocks - post: {groups.keys()}")
 
 class SolaXCoreModbusHub(SolaXModbusHub, CoreModbusHub):
     """Thread safe wrapper class for pymodbus."""

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -292,14 +292,6 @@ def autorepeat_remaining(datadict, entitykey, timestamp):
 # ================================= Computed sensor value functions  =================================================
 
 
-
-
-"""
-def value_function_pv_power_total(initval, descr, datadict): 
-    single_or_oldsum = datadict.pop("pv_power_total", None)
-    vals = [v for k, v in datadict.items() if k.startswith("pv_power_")] # multi string inverter ?
-    return single_or_oldsum if any(p is None for p in vals) else sum(vals) # if so, return sum, else single value
-"""
 MAX_PVSTRINGS = 10
 def value_function_pv_power_total(initval, descr, datadict): 
     # changed: for performance reasons, we should not iterate over the entire datadict every polling cyle (contains hundreds ...)
@@ -312,7 +304,6 @@ def value_function_pv_power_total(initval, descr, datadict):
         else: total += v 
         i += 1
     return total
-
 
 def value_function_battery_output(initval, descr, datadict):
     val = datadict.get("battery_power_charge", 0)

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -119,7 +119,6 @@ WRITE_MULTISINGLE_MODBUS = 2  # use write_mutiple modbus command for single regi
 WRITE_DATA_LOCAL = 3  # write only to local data storage (not persistent)
 WRITE_MULTI_MODBUS = 4  # use write_multiple modbus command
 
-
 _LOGGER = logging.getLogger(__name__)
 
 DEBOUNCE_TIME = timedelta(seconds=5)  # Time to prioritize user actions
@@ -293,10 +292,26 @@ def autorepeat_remaining(datadict, entitykey, timestamp):
 # ================================= Computed sensor value functions  =================================================
 
 
+
+
+"""
 def value_function_pv_power_total(initval, descr, datadict): 
     single_or_oldsum = datadict.pop("pv_power_total", None)
     vals = [v for k, v in datadict.items() if k.startswith("pv_power_")] # multi string inverter ?
     return single_or_oldsum if any(p is None for p in vals) else sum(vals) # if so, return sum, else single value
+"""
+MAX_PVSTRINGS = 10
+def value_function_pv_power_total(initval, descr, datadict): 
+    # changed: for performance reasons, we should not iterate over the entire datadict every polling cyle (contains hundreds ...)
+    total = 0
+    i = 1
+    while i <= MAX_PVSTRINGS:
+        v = datadict.get(f"pv_power_{i}", None)
+        if v is None:
+            break
+        else: total += v 
+        i += 1
+    return total
 
 
 def value_function_battery_output(initval, descr, datadict):

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -203,8 +203,11 @@ class BaseModbusSensorEntityDescription(SensorEntityDescription):
     # prevent_update: bool = False # if set to True, value will not be re-read/updated with each polling cycle; only when read value changes
     value_function: callable = None  #  value = function(initval, descr, datadict)
     wordcount: int = None  # only for unit = REGISTER_STR and REGISTER_WORDS
-    sleepmode: int = SLEEPMODE_LAST  # or SLEEPMODE_ZERO or SLEEPMODE_NONE
-    ignore_readerror: bool = False  # if not False, ignore read errors for this block and return this static value
+    sleepmode: int = SLEEPMODE_LAST  # or SLEEPMODE_ZERO, SLEEPMODE_NONE or SLEEPMODE_LASTAWAKE
+    ignore_readerror: bool = False  # not strictly boolean: boolean or static other value 
+    # if False, read errors will invalidate the data
+    # if True, data will remain untouched
+    # if not False nor True (e.g. a number): ignore read errors for this block and return this static value
     # A failing block read will be accepted as valid block if the first entity of the block contains a non-False ignore_readerror attribute.
     # The other entitties of the block can also have an ignore_readerror attribute that determines the value returned upon failure
     # so typically this attribute can be set to None or "Unknown" or any other value
@@ -265,9 +268,8 @@ class BaseModbusNumberEntityDescription(NumberEntityDescription):
     write_method: int = WRITE_SINGLE_MODBUS  # WRITE_SINGLE_MOBUS or WRITE_MULTI_MODBUS or WRITE_DATA_LOCAL
     initvalue: int = None  # initial default value for WRITE_DATA_LOCAL entities
     unit: int = None  #  optional for WRITE_DATA_LOCAL e.g REGISTER_U16, REGISTER_S32 ...
-    prevent_update: bool = (
-        False  # if set to True, value will not be re-read/updated with each polling cycle; only when read value changes
-    )
+    prevent_update: bool = False  # if set to True, value will not be re-read/updated with each polling cycle;
+                                  # update only when read value changes
 
 
 # ========================= autorepeat aux functions to be used on hub.data dictionary ===============================

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -293,10 +293,10 @@ def autorepeat_remaining(datadict, entitykey, timestamp):
 # ================================= Computed sensor value functions  =================================================
 
 
-def value_function_pv_power_total(initval, descr, datadict): # this function can be enhanced to handle undefined values better
-    datadict.pop("pv_power_total", None)
-    vals = [v for k, v in datadict.items() if k.startswith("pv_power_")]
-    return None if any(p is None for p in vals) else sum(vals)
+def value_function_pv_power_total(initval, descr, datadict): 
+    single_or_oldsum = datadict.pop("pv_power_total", None)
+    vals = [v for k, v in datadict.items() if k.startswith("pv_power_")] # multi string inverter ?
+    return single_or_oldsum if any(p is None for p in vals) else sum(vals) # if so, return sum, else single value
 
 
 def value_function_battery_output(initval, descr, datadict):

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -4284,7 +4284,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         rounding=1,
         allowedtypes=AC | HYBRID,
     ),
-    SolaXModbusSensorEntityDescription(
+    SolaXModbusSensorEntityDescription( # unclear why we do not merge with next decl
         name="Inverter Power",
         key="inverter_power",
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -4293,9 +4293,9 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         register=0x2,
         register_type=REG_INPUT,
         unit=REGISTER_S16,
-        allowedtypes=AC | HYBRID | GEN2 | GEN3 | GEN4,
+        allowedtypes=AC | HYBRID | GEN2 | GEN3 | GEN4 | GEN6,
     ),
-    SolaXModbusSensorEntityDescription(
+    SolaXModbusSensorEntityDescription( # unclear why we do not merge with previous decl
         name="Inverter Power",
         key="inverter_power",
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -4304,7 +4304,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         register=0x2,
         register_type=REG_INPUT,
         unit=REGISTER_S16,
-        allowedtypes=AC | HYBRID | GEN5 | X1,
+        allowedtypes=AC | HYBRID | GEN5 | GEN6 | X1,
     ),
     SolaXModbusSensorEntityDescription(
         name="PV Voltage 1",

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -17,56 +17,84 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
 
-INVALID_START = 99999
 
 
 # =================================== sorting and grouping of entities ================================================
 
-@dataclass
-class block():
-    start: int = None # start address of the block
-    end: int = None # end address of the block
-    #order16: int = None # byte endian for 16bit registers
-    #order32: int = None # word endian for 32bit registers
-    descriptions: Any = None
-    regs: Any = None # sorted list of registers used in this block
 
 
-def splitInBlocks( descriptions, block_size, auto_block_ignore_readerror ):
+""" MOVED TO __init__.py
+def splitInBlocks( descriptions, hub ):
     start = INVALID_START
     end = 0
     blocks = []
+    block_size = hub.plugin.block_size
+    auto_block_ignore_readerror = hub.plugin.auto_block_ignore_readerror
     curblockregs = []
-    for reg in descriptions:
-        descr = descriptions[reg]
-        if (not type(descr) is dict) and (descr.newblock or ((reg - start) > block_size)):
-            if ((end - start) > 0):
-                _LOGGER.debug(f"Starting new block at 0x{reg:x} ")
-                if  ( (auto_block_ignore_readerror == True) or (auto_block_ignore_readerror == False) ) and not descr.newblock: # automatically created block
-                    descr.ignore_readerror = auto_block_ignore_readerror
-                #newblock = block(start = start, end = end, order16 = descriptions[start].order16, order32 = descriptions[start].order32, descriptions = descriptions, regs = curblockregs)
-                newblock = block(start = start, end = end, descriptions = descriptions, regs = curblockregs)
-                blocks.append(newblock)
-                start = INVALID_START
-                end = 0
-                curblockregs = []
-            else: _LOGGER.info(f"newblock declaration found for empty block")
+    for reg, descr in descriptions.items():
+        d_ignore_readerror = auto_block_ignore_readerror
+        if type(descr) is dict: # 2 byte  REGISTER_U8L, _U8H values on same modbus 16 bit address
+            d_newblock = False
+            d_enabled = False
+            for sub, d in descr.items():
+                entity_id = f"sensor.{hub.name}_{d.key}"
+                d_enabled = d_enabled or is_entity_enabled(hub._hass, entity_id) or d.internal
+                d_newblock = d_newblock or d.newblock 
+                d_unit = d.unit
+                d_wordcount = 1 # not used here
+                d_key = d.key # does not matter which key we use here
+                d_regtype = d.register_type
+        else: # normal entity
+            entity_id = f"sensor.{hub.name}_{descr.key}"
+            d_enabled = is_entity_enabled(hub._hass, entity_id) or descr.internal
+            d_newblock = descr.newblock
+            d_unit = descr.unit
+            d_wordcount = descr.wordcount
+            d_key = descr.key
+            d_regtype = descr.register_type # HOLDING or INPUT
 
-        if start == INVALID_START: start = reg
-        if type(descr) is dict: end = reg+1 # couple of byte values
-        else:
-            _LOGGER.debug(f"adding register 0x{reg:x} {descr.key} to block with start 0x{start:x}")
-            if descr.unit in (REGISTER_STR, REGISTER_WORDS,):
-                if (descr.wordcount): end = reg+descr.wordcount
-                else: _LOGGER.warning(f"invalid or missing missing wordcount for {descr.key}")
-            elif descr.unit in (REGISTER_S32, REGISTER_U32, REGISTER_ULSB16MSB16,):  end = reg + 2
+        if d_enabled:
+            if (d_newblock or ((reg - start) > block_size)):
+                if ((end - start) > 0):
+                    _LOGGER.debug(f"Starting new block at 0x{reg:x} ")
+                    if  ( (auto_block_ignore_readerror is True) or (auto_block_ignore_readerror is False) ) and not d_newblock: # automatically created block
+                        if type(descr) is dict: 
+                            for sub, d in descr.items():
+                                if d.ignore_readerror is False: d.ignore_readerror = auto_block_ignore_readerror
+                        else: 
+                            if descr.ignore_readerror is False: descr.ignore_readerror = auto_block_ignore_readerror
+                    #newblock = block(start = start, end = end, order16 = descriptions[start].order16, order32 = descriptions[start].order32, descriptions = descriptions, regs = curblockregs)
+                    newblock = block(start = start, end = end, descriptions = descriptions, regs = curblockregs)
+                    blocks.append(newblock)
+                    start = INVALID_START
+                    end = 0
+                    curblockregs = []
+            else: _LOGGER.debug(f"newblock declaration found for empty block")
+
+            if start == INVALID_START: start = reg
+
+            _LOGGER.debug(f"adding register 0x{reg:x} {d_key} to block with start 0x{start:x}")
+            if d_unit in (REGISTER_STR, REGISTER_WORDS,):
+                if (d_wordcount): end = reg+d_wordcount
+                else: _LOGGER.warning(f"invalid or missing missing wordcount for {d_key}")
+            elif d_unit in (REGISTER_S32, REGISTER_U32, REGISTER_ULSB16MSB16,):  end = reg + 2
             else: end = reg + 1
-        curblockregs.append(reg)
+            _LOGGER.debug(f"adding type {d_regtype} register 0x{reg:x} {d_key} to block with start 0x{start:x}")
+            curblockregs.append(reg)
+        else:
+            _LOGGER.debug(f"ignoring type {d_regtype} register 0x{reg:x} {d_key} to block with start 0x{start:x}")
+
+
     if ((end-start)>0): # close last block
         #newblock = block(start = start, end = end, order16 = descriptions[start].order16, order32 = descriptions[start].order32, descriptions = descriptions, regs = curblockregs)
         newblock = block(start = start, end = end, descriptions = descriptions, regs = curblockregs)
         blocks.append(newblock)
+    # Remove empty blocks before returning the blocks. - is this needed ??
+    #before = len(blocks)
+    #blocks = [b for b in blocks if b.regs] # needed ??
+    #_LOGGER.info(f"***debug***: {before} blocks before cleanup empty blocks, after: {len(blocks)}")
     return blocks
+"""
 
 # ========================================================================================================================
 
@@ -169,6 +197,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities)
     _LOGGER.info(f"{hub_name} sensor groups: {len(groups)}")
     #now the groups are available
+    hub.computedSensors = computedRegs
+    hub.rebuild_blocks(groups) #, computedRegs)
+    _LOGGER.info(f"computedRegs: {hub.computedSensors}")
+    return True
+
+
+    """ MOVED TO __init__.py
     for interval, interval_group in groups.items():
         _LOGGER.debug(f"{hub_name} group: {interval}")
         for device_name, device_group in interval_group.items():
@@ -183,17 +218,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
             hub_device_group = hub_interval_group.device_groups.setdefault(device_name, hub.empty_device_group())
             hub_device_group.readPreparation = device_group.readPreparation
             hub_device_group.readFollowUp = device_group.readFollowUp
-            hub_device_group.holdingBlocks = splitInBlocks(holdingRegs, hub.plugin.block_size, hub.plugin.auto_block_ignore_readerror)
-            hub_device_group.inputBlocks = splitInBlocks(inputRegs, hub.plugin.block_size, hub.plugin.auto_block_ignore_readerror)
+            hub_device_group.holdingBlocks = splitInBlocks(holdingRegs, hub.plugin.block_size, hub.plugin.auto_block_ignore_readerror, hub)
+            hub_device_group.inputBlocks = splitInBlocks(inputRegs, hub.plugin.block_size, hub.plugin.auto_block_ignore_readerror, hub)
             hub.computedSensors = computedRegs
 
             for i in hub_device_group.holdingBlocks: _LOGGER.info(f"{hub_name} returning holding block: 0x{i.start:x} 0x{i.end:x} {i.regs}")
             for i in hub_device_group.inputBlocks: _LOGGER.info(f"{hub_name} returning input block: 0x{i.start:x} 0x{i.end:x} {i.regs}")
             _LOGGER.debug(f"holdingBlocks: {hub_device_group.holdingBlocks}")
             _LOGGER.debug(f"inputBlocks: {hub_device_group.inputBlocks}")
-
     _LOGGER.info(f"computedRegs: {hub.computedSensors}")
     return True
+    """
+
+
+
 
 def entityToList(hub, hub_name, entities, groups, newgrp, computedRegs, device_info: DeviceInfo,
                  sensor_types, name_prefix, key_prefix, readPreparation, readFollowUp):  # noqa: D103

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -19,7 +19,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 
-empty_interval_group_lambda = lambda: SimpleNamespace(interval=0, unsub_interval_method=None, device_groups={})
+empty_interval_group_lambda = lambda: SimpleNamespace(
+            interval=0,
+            unsub_interval_method=None,
+            device_groups={}
+        )
 empty_device_group_lambda   =  lambda: SimpleNamespace(
             sensors=[],
             holdingRegs  = {}, 
@@ -38,7 +42,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     hub = hass.data[DOMAIN][hub_name]["hub"]
 
     entities = []
-    groups = {}
+    initial_groups = {}
 
     computedRegs = {}
 
@@ -62,7 +66,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     if hub.inverterNameSuffix is not None and hub.inverterNameSuffix != "":
         inverter_name_suffix = hub.inverterNameSuffix + " "
 
-    entityToList(hub, hub_name, entities, groups, empty_device_group_lambda, computedRegs, hub.device_info,
+    entityToList(hub, hub_name, entities, initial_groups, empty_device_group_lambda, computedRegs, hub.device_info,
                  plugin.SENSOR_TYPES, inverter_name_suffix, "", None, readFollowUp)
 
     readBattery = entry.options.get(CONF_READ_BATTERY, False)
@@ -120,15 +124,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
                         model=batt_pack_model)
                 return await battery_config.check_battery_on_end(hub, old_data, new_data, key_prefix, batt_nr, batt_pack_nr)
 
-            entityToList(hub, hub_name, entities, groups, empty_device_group_lambda, computedRegs, device_info_battery,
+            entityToList(hub, hub_name, entities, initial_groups, empty_device_group_lambda, computedRegs, device_info_battery,
                          battery_config.battery_sensor_type, name_prefix, key_prefix, readPreparation, readFollowUp)
 
     async_add_entities(entities)
-    _LOGGER.info(f"{hub_name} sensor groups: {len(groups)}")
     #now the groups are available
     hub.computedSensors = computedRegs
-    hub.rebuild_blocks(groups) #, computedRegs) # first time call
-    _LOGGER.info(f"computedRegs: {hub.computedSensors}")
+    hub.rebuild_blocks(initial_groups) #, computedRegs) # first time call
+    _LOGGER.debug(f"computedRegs: {hub.computedSensors}")
     return True
 
 
@@ -203,6 +206,7 @@ def entityToListSingle(hub, hub_name, entities, groups, newgrp, computedRegs, de
             else:
                 inputRegs[newdescr.register] = newdescr
         else: _LOGGER.warning(f"entity declaration without register_type found: {newdescr.key}")
+
 
 class SolaXModbusSensor(SensorEntity):
     """Representation of an SolaX Modbus sensor."""


### PR DESCRIPTION
EDITED
- implement copy of suggested #1440 issue  solution - thanks @gec75 
- reduce messages when inverter is offline or asleep issue 

- copy/implement #1474 do not poll registers that are disabled. Thanks @TonyMathiesen. If a  sensor is enabled, the read_block structure needs to be recomputed, this caused some significant code moves. It which seems to work now. 
Needs to be reviewed and tested further by developers of the scan_group mechanism. 

- set modbus RETRIES = 0 instead of 6 (did not make sense in my opinion as the polling loop will retry automatically) 
- make some code more readable
- suppress autorepeat writes when inverter is offline
- Some code (e.g. splitInBlocks) moved from sensor.py to __init__.py
- modify value_function_pv_power_total, so that it does not scan entire datadict (and catches the old pv_power_total). The function now takes 8 times less compute cycles.
- I guess this solves issue #1484 also (probably a duplicate of #1482)

As this is only tested on Solax, scan groups are not really tested. Edit: tested with a local solax plugin version with scan groups. 
Enabling sensors seems to work, Disabling sensors: works also now after some debugging. 

You can also find the source code in my development fork: https://github.com/infradom/homeassistant-solax-modbus