### PR TITLE
Add new SolaX X1 Boost G3 serial number

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -8496,6 +8496,9 @@ class solax_plugin(plugin_base):
         elif seriesnumber.startswith("XB3"):
             invertertype = MIC | GEN2 | X1  # X1-Boost
             self.inverter_model = "X1-Boost"
+        elif seriesnumber.startswith("XBE"):
+            invertertype = MIC | GEN2 | X1  # X1-Boost
+            self.inverter_model = "X1-Boost"
         elif seriesnumber.startswith("XAT"):
             invertertype = MIC | GEN2 | X1  # X1-Mini G3 #1340
             self.inverter_model = "X1-Mini"

--- a/docs/compatible-inverters.md
+++ b/docs/compatible-inverters.md
@@ -188,6 +188,8 @@ Known Serial Numbers
 - XB3
 - XMA
 - XM3
+- XBE
+- XAU
 
 X1-Mini-G4
 Found to work using Modbus but does not work with any other polling period than default 15s


### PR DESCRIPTION
Add a new SolaX X1 Boost G3 serial number based  on the following specs: 
Model: SolaX X1 Boost 4.2T X1-4.2-T-D
S/N: XBE422XXXXXXXX