### PR TITLE
Added ESPHome as a compatible adapter

### DIFF
--- a/docs/compatible-adaptors.md
+++ b/docs/compatible-adaptors.md
@@ -80,7 +80,7 @@ This works flawless for my Solis hybrid inverter.
 
 Running ESPHome as a Modbus TCP to RTU bridge, the setup provides stable and reliable communication through an ESP32.
 An RS485 transceiver manages the UART-to-RS485 conversion, enabling data exchange.
-This setup has been successfully tested with a SolaX hybrid inverter and runs reliably when powered directly from the inverter’s 12V output.
+This setup has been successfully tested with a SolaX hybrid inverter and runs reliably when powered from the inverter’s 12V output, using a 12V-to-5V step-down converter.
 For Ethernet connectivity, an ESP32 module such as the WT32-ETH01 can be used.
 
 ## Untested but should work according to the specs...


### PR DESCRIPTION
I’ve developed an ESPHome component that integrates well with my SolaX inverter, and I’d be glad if others could benefit from it too. A nice bonus is the ability to use the same ESP32 device as a Bluetooth proxy, adding even more value to the setup.