### PR TITLE
fix: Prevent NoneType error in async_read_serialnr

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -62,7 +62,7 @@ async def async_read_serialnr(hub, address):
     res = None
     try:
         inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=address, count=5)
-        if not inverter_data.isError():
+        if inverter_data and not inverter_data.isError():
             decoder = BinaryPayloadDecoder.fromRegisters(inverter_data.registers, byteorder=Endian.BIG)
             res = decoder.decode_string(10).decode("ascii")
             hub.seriesnumber = res


### PR DESCRIPTION
Added a `None` check in `async_read_serialnr` to prevent an AttributeError when the inverter is offline and no response is received.