### PR TITLE
Fix Modbus data read crash: safe dict iteration and descriptor handling

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -551,7 +551,7 @@ class SolaXModbusHub:
         if self.blocks_changed:
             self.rebuild_blocks(self.initial_groups) 
         if (self.cyclecount % self.slowdown) == 0:  # only execute once every slowdown count
-            for group in interval_group.device_groups.values():
+            for group in list(interval_group.device_groups.values()):
                 update_result = await self.async_read_modbus_data(group)
                 if update_result:
                     if self.slowdown > 1: _LOGGER.info(f"communication restored, resuming normal speed after slowdown")
@@ -954,9 +954,9 @@ class SolaXModbusHub:
                 _LOGGER.debug(f"failed block analysis started firstignore: {firstdescr.ignore_readerror}")
                 for reg in block.regs:
                     descr = block.descriptions[reg]
-                    if   type(descr) is dict: l = descr.items() # special case: mutliple U8x entities
-                    else: l = { descr.key: descr, } # normal case, one entity
-                    for k, d in l.items():
+                    if type(descr) is dict: l = descr.items()
+                    else: l = {descr.key: descr}.items()
+                    for k, d in l:
                         d_ignore = descr.ignore_readerror
                         d_key = descr.key
                         if (d_ignore is not True) and (d_ignore is not False):


### PR DESCRIPTION
- Wrap dict iteration in async_refresh_modbus_data() to prevent RuntimeError on mutation
- Normalize descriptor iteration in async_read_modbus_block() to handle dict_items safely

These errors are fixed:

```
2025-07-28 18:27:05.085 ERROR (MainThread) [custom_components.solax_modbus] Something went wrong reading from modbus: 'dict_items' object has no attribute 'items'
Traceback (most recent call last):
  File "/config/custom_components/solax_modbus/__init__.py", line 783, in async_read_modbus_data
    res = await self.async_read_modbus_registers_all(group)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/solax_modbus/__init__.py", line 993, in async_read_modbus_registers_all
    res = res and await self.async_read_modbus_block(data, block, "holding")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/solax_modbus/__init__.py", line 960, in async_read_modbus_block
    for k, d in l.items():
                ^^^^^^^
AttributeError: 'dict_items' object has no attribute 'items'
2025-07-28 18:27:05.100 INFO (MainThread) [custom_components.solax_modbus] modbus group read failed - assuming sleep mode - slowing down by factor 10
2025-07-28 18:27:05.100 DEBUG (MainThread) [custom_components.solax_modbus] device group read done
2025-07-28 18:27:05.101 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/config/custom_components/solax_modbus/__init__.py", line 503, in _refresh
    await self.async_refresh_modbus_data(interval_group, _now)
  File "/config/custom_components/solax_modbus/__init__.py", line 555, in async_refresh_modbus_data
    for group in interval_group.device_groups.values():
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
RuntimeError: dictionary changed size during iteration
```