### PR TITLE
use entity registry to determine if entity is enabled - fix issue #1496, contains 1500 

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -524,7 +524,7 @@ class SolaXModbusHub:
 
         device_key = self.device_group_key(sensor.device_info)
         grp = interval_group.device_groups.setdefault(device_key, empty_hub_device_group_lambda())
-        _LOGGER.debug(f"*** debug *** adding sensor {sensor.entity_description.key} available: {sensor._attr_available} ")
+        _LOGGER.debug(f"adding sensor {sensor.entity_description.key} available: {sensor._attr_available} ")
         grp.sensors.append(sensor)
         self.blocks_changed = True # will force rebuild_blocks to be called
 

--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -98,12 +98,12 @@ class SolaXModbusNumber(NumberEntity):
         self.entity_description = number_info
         self._write_method = number_info.write_method
 
-    #async def async_added_to_hass(self) -> None:
-    #    """Register callbacks."""
-    #    await self._hub.async_add_solax_modbus_sensor(self)
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self._hub.async_add_solax_modbus_sensor(self)
 
-    #async def async_will_remove_from_hass(self) -> None:
-    #    await self._hub.async_remove_solax_modbus_sensor(self)
+    async def async_will_remove_from_hass(self) -> None:
+        await self._hub.async_remove_solax_modbus_sensor(self)
 
     """ remove duplicate declaration
     async def async_set_value(self, native_value: float) -> None:

--- a/custom_components/solax_modbus/select.py
+++ b/custom_components/solax_modbus/select.py
@@ -62,12 +62,12 @@ class SolaXModbusSelect(SelectEntity):
         self._write_method = select_info.write_method
 
     
-    ##sync def async_added_to_hass(self):
-    #    """Register callbacks."""
-    #    await self._hub.async_add_solax_modbus_sensor(self)
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        await self._hub.async_add_solax_modbus_sensor(self)
 
-    #async def async_will_remove_from_hass(self) -> None:
-    #    await self._hub.async_remove_solax_modbus_sensor(self)
+    async def async_will_remove_from_hass(self) -> None:
+        await self._hub.async_remove_solax_modbus_sensor(self)
 
 
     @callback


### PR DESCRIPTION
Use entity registry to determine if entity is enabled - testers or reviewers welcome
So that disabled entities are not polled anymore. 

Fixes issue #1494
Also contains PR #1500 fix by @rosenrot00

Thanks @thomas7475
After previous failed attempt, it would be good that users of different inverters test this first.

EDIT: seems to work now  - thanks again @thomas7475 and @rosenrot00