### PR TITLE
Add kW value to Solax H34 inverter models

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -8419,8 +8419,8 @@ class solax_plugin(plugin_base):
             invertertype = HYBRID | GEN4 | X3  # TIGO TSI X3
             self.inverter_model = "X3-TIGO TSI"
         elif seriesnumber.startswith("H34"):
-            invertertype = HYBRID | GEN4 | X3  # Gen4 X3
-            self.inverter_model = "X3-Hybrid"
+            invertertype = HYBRID | GEN4 | X3  # Gen4 X3 5-15kW
+            self.inverter_model = f"X3-Hybrid-{int(seriesnumber[4:6])}kW"
         elif seriesnumber.startswith("F34"):
             invertertype = AC | GEN4 | X3  # Gen4 X3 FIT
             self.inverter_model = "X3-RetroFit"


### PR DESCRIPTION
This adds the kW value to the inverter name if it has a H34 serial number. To my knowledge there is only integer values from 5-15kW. Please correct me if I'm wrong.

To my knowledge there are H34A/B/C/T with the same 5-15kW ranges. Please correct me if I'm wrong and we need to differentiate between the different types.