### PR TITLE
Generalize the X3-HYB-G4 PRO inverter model identification

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -8501,7 +8501,7 @@ class solax_plugin(plugin_base):
             invertertype = HYBRID | GEN6 | X3  # X3-HYB-G4 PRO
             if kw_value >= 8:
                 invertertype |= MPPT3
-            self.inverter_model = f"X3-G4PRO-{kw_value}kW"
+            self.inverter_model = f"X3-G4PRO-{kw_value}kW"  #datasheet name X3-HYB-4.0-P
         elif seriesnumber.startswith("XAU"):
             invertertype = MIC | GEN2 | X1  # X1-Boost
             self.inverter_model = "X1-Boost"


### PR DESCRIPTION
now all X3-HYB-G4 PRO inverters should be recognized. Their kW value is incorporated in hex format in the serial number.

10K12 is falling out of this scheme but my best guess is that this is either weird from Solax or a mistake?

Worst that happens with my code is that the 10K12 would show as 18kW version. 