### PR TITLE
Prevent crash from None serialnumber

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -69,7 +69,7 @@ async def async_read_serialnr(hub, address):
     inverter_data = None
     try:
         inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=address, count=7)
-        if not inverter_data.isError():
+        if inverter_data is not None and not inverter_data.isError():
             decoder = BinaryPayloadDecoder.fromRegisters(inverter_data.registers, byteorder=Endian.BIG)
             res = decoder.decode_string(14).decode("ascii")
             if address == 0x300:


### PR DESCRIPTION
Prevents this error:

2025-08-05 22:41:00.328 WARNING (MainThread) [custom_components.solax_modbus.plugin_solax] SolaX: attempt to read serialnumber failed at 0x0 data: None Traceback (most recent call last):
  File "/config/custom_components/solax_modbus/plugin_solax.py", line 72, in async_read_serialnr
    if not inverter_data.isError():
           ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'isError'