### PR TITLE
Update const.py to adopt to pymodbus >= 3.0

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -12,7 +12,10 @@ from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
 from homeassistant.helpers.entity import EntityCategory
-from pymodbus.payload import Endian
+try:
+    from pymodbus.constants import Endian  # for pymodbus < 3.0
+except ImportError:
+    from pymodbus.payload import Endian    # for pymodbus >= 3.0
 from datetime import datetime, timedelta
 from dataclasses import dataclass, replace
 import pathlib
@@ -541,3 +544,4 @@ for h in range(0, 24):
         ):  # add extra entry 23:59
             TIME_OPTIONS[(m + 4) * 256 + h] = f"{h:02}:{m+4:02}"
             TIME_OPTIONS_GEN4[h * 256 + m + 4] = f"{h:02}:{m+4:02}"
+


### PR DESCRIPTION
Adopt imports to support both pymodubus < 3.0 and >= separately.

Solves https://github.com/wills106/homeassistant-solax-modbus/issues/1533