### PR TITLE
solis: make battery_charge_direction internal=True

### DIFF
--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -1593,7 +1593,7 @@ SENSOR_TYPES: list[SolisModbusSensorEntityDescription] = [
         register=33135,
         register_type=REG_INPUT, 
         #entity_registry_enabled_default=False, # issue 1523
-        internal = True
+        internal = True,
         allowedtypes=HYBRID,
     ),
     SolisModbusSensorEntityDescription(


### PR DESCRIPTION
make sure solis users to not have to enable battery_charge_direction anymore
make this entity enabled but invisible
as mentioned in #1546 and #1507