### PR TITLE
Use custom Endian enum class if cannot import it

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -76,7 +76,6 @@ _LOGGER = logging.getLogger(__name__)
 # else:
 #    Endian_BIG = Endian.BIG
 #    Endian_LITTLE = Endian.LITTLE
-from pymodbus.constants import Endian
 from pymodbus.exceptions import ConnectionException, ModbusIOException
 from .payload import BinaryPayloadBuilder, BinaryPayloadDecoder, Endian
 from pymodbus.framer import FramerType

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -12,10 +12,17 @@ from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.components.button import ButtonEntityDescription
 from homeassistant.helpers.entity import EntityCategory
+from enum import Enum
 try:
     from pymodbus.constants import Endian  # for pymodbus < 3.0
 except ImportError:
-    from pymodbus.payload import Endian    # for pymodbus >= 3.0
+    try:        
+        from pymodbus.payload import Endian    # for pymodbus >= 3.0
+    except Exception:
+        class Endian(str, Enum):
+            AUTO = "@"
+            BIG = ">"
+            LITTLE = "<"        
 from datetime import datetime, timedelta
 from dataclasses import dataclass, replace
 import pathlib

--- a/custom_components/solax_modbus/payload.py
+++ b/custom_components/solax_modbus/payload.py
@@ -18,7 +18,7 @@ from array import array
 # pylint: disable=missing-type-doc
 from struct import pack, unpack
 
-from pymodbus.constants import Endian
+from .const import Endian
 from pymodbus.exceptions import ParameterException
 from pymodbus.logging import Log
 


### PR DESCRIPTION
Reading the release changes of `pymodbus` I noticed that after version 3.10 the `Endian` enum class was deleted. And Home Assistant 2025.8 decided to update its `pymodbus` version higher than 3.10 and so it broke the integration on latest update