### PR TITLE
update plugin_solis.py and plugin_solis_fb00.py

### DIFF
--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -2670,6 +2670,8 @@ class solis_plugin(plugin_base):
             invertertype = HYBRID | X3  # Hybrid Gen5 10kW - HV
         elif seriesnumber.startswith("1805"):
             invertertype = HYBRID | X3  # PV Only Gen5 5-20kW
+        elif seriesnumber.startswith("2051"):
+            invertertype = HYBRID | X1  # Hybrid Gen6 EO1p-48v 5kW
         elif seriesnumber.startswith("6031"):
             invertertype = HYBRID | X1  # Hybrid Gen5 3105 / 3122 Model 6kW - 48V
         elif seriesnumber.startswith("6041"):

--- a/custom_components/solax_modbus/plugin_solis_fb00.py
+++ b/custom_components/solax_modbus/plugin_solis_fb00.py
@@ -4405,6 +4405,8 @@ class solis_fb00_plugin(plugin_base):
             invertertype = HYBRID | X3  # Hybrid Gen5 10kW - HV
         elif seriesnumber.startswith("1805"):
             invertertype = HYBRID | X3  # PV Only Gen5 5-20kW
+        elif seriesnumber.startswith("2051"):
+            invertertype = HYBRID | X1  # Hybrid Gen6 EO1p-48v 5kW
         elif seriesnumber.startswith("6031"):
             invertertype = HYBRID | X1  # Hybrid Gen5 3105 / 3122 Model 6kW - 48V
         elif seriesnumber.startswith("6041"):


### PR DESCRIPTION
add seriesnumber for Solis Gen6 S6-EO1p-48v 5kW inverter.
Has been tested on my own devices seems work!