### PR TITLE
Fix config entry reload support to enable hot-reload without HA restart

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -361,15 +361,18 @@ async def async_unload_entry(hass, entry):
             _LOGGER.warning(f"{name}: error during hub stop: {ex}")
 
     # Unload platforms - this must succeed for reload to work properly
+    # Always try to unload regardless of entry state - during reload, state might not be LOADED
     unload_ok = True
-    if entry.state == ConfigEntryState.LOADED:
-        try:
-            unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-            if not unload_ok:
-                _LOGGER.error(f"{name}: failed to unload platforms")
-        except Exception as ex:
-            _LOGGER.error(f"{name}: error during platform unload: {ex}")
-            unload_ok = False
+    try:
+        _LOGGER.debug(f"{name}: attempting to unload platforms (state={entry.state})")
+        unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        if unload_ok:
+            _LOGGER.debug(f"{name}: platforms unloaded successfully")
+        else:
+            _LOGGER.error(f"{name}: platform unload returned False")
+    except Exception as ex:
+        _LOGGER.error(f"{name}: error during platform unload: {ex}")
+        unload_ok = False
 
     # Ensure removal from hass.data
     try:


### PR DESCRIPTION
This PR fixes critical bugs preventing `homeassistant.reload_config_entry` from working properly with this integration. After these fixes, the integration can be reloaded without requiring a full Home Assistant restart.

## Problem

When using `homeassistant.reload_config_entry` service (via UI reload button or API), the integration would fail with errors:
```
ValueError: Config entry SolaX 1 for solax_modbus.sensor has already been setup!
```

After reload, all sensors would stop updating, requiring a full Home Assistant restart.

## Root Cause

The `async_unload_entry()` function had this check:
```python
if entry.state == ConfigEntryState.LOADED:
    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
```

During reload operations, `entry.state` is **NOT** `ConfigEntryState.LOADED`, so platforms were never being unloaded. When `async_setup_entry()` tried to forward platforms again, Home Assistant raised `ValueError` because they were already registered.

## Solution

1. **Remove entry state check** - Always attempt to unload platforms regardless of entry state
2. **Ensure DOMAIN dict exists** - Handle reload scenario where domain dict may not exist
3. **Better error handling** - Proper logging to debug reload issues
4. **Simplified hub cleanup** - Let `async_unload_entry()` handle platform unloading properly

## Changes

**Commit 1:** Ensure DOMAIN dict exists in `async_setup_entry()`
- Prevents KeyError during reload when domain dict doesn't exist

**Commit 2:** Improve platform unload error handling
- Better logging for debugging reload issues
- Proper error propagation

**Commit 3:** Properly handle old hub cleanup during reload  
- Stop old hub before creating new one
- Clean up hub data properly

**Commit 4:** **[CRITICAL]** Remove entry state check in `async_unload_entry()`
- Always attempt platform unload regardless of entry state
- This is the key fix that makes reload work

## Testing

Tested with 3 SolaX inverters in parallel configuration:
- ✅ Multiple reload cycles completed successfully
- ✅ All sensors continue updating after reload
- ✅ No "already been setup" errors
- ✅ Polling resumes immediately after reload
- ✅ No Home Assistant restart required

## Benefits

- Fast development iteration without HA restarts
- Integration now properly supports the reload button in UI
- Compatible with `homeassistant.reload_config_entry` service
- Reduced system disruption during development and configuration changes

## Compatibility

- No breaking changes
- Works with existing configurations
- Backward compatible