### PR TITLE
Add Gen4 missing registers: VPP Exit Idle, Fast CT Check, EV Charger Address, Adapt Box G2 Address

### DIFF
--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -2,7 +2,7 @@ from .const import ATTR_MANUFACTURER, DOMAIN, CONF_MODBUS_ADDR, DEFAULT_MODBUS_A
 from .const import WRITE_DATA_LOCAL, WRITE_MULTISINGLE_MODBUS, WRITE_SINGLE_MODBUS, WRITE_MULTI_MODBUS, TMPDATA_EXPIRY
 
 # from .const import GEN2, GEN3, GEN4, X1, X3, HYBRID, AC, EPS
-from homeassistant.components.number import PLATFORM_SCHEMA, NumberEntity
+from homeassistant.components.number import PLATFORM_SCHEMA, NumberEntity, NumberMode
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 from dataclasses import dataclass, replace
@@ -110,6 +110,9 @@ class SolaXModbusNumber(NumberEntity):
         self._state = number_info.state  # not used AFAIK
         self.entity_description = number_info
         self._write_method = number_info.write_method
+        # Force box mode for address entities
+        if self._key in ["ev_charger_address", "adapt_box_g2_address"]:
+            self._attr_mode = NumberMode.BOX
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1896,22 +1896,26 @@ NUMBER_TYPES = [
         name="EV Charger Address",
         key="ev_charger_address",
         register=0xF9,
+        sensor_key="ev_charger_address",
         fmt="i",
         native_min_value=0,
         native_max_value=255,
         native_step=1,
-        allowedtypes=AC | HYBRID | GEN4 | GEN5,
+        allowedtypes=AC | HYBRID | GEN4,
+        entity_category=EntityCategory.CONFIG,
         icon="mdi:ev-station",
     ),
     SolaxModbusNumberEntityDescription(
         name="Adapt Box G2 Address",
         key="adapt_box_g2_address",
         register=0xFB,
+        sensor_key="adapt_box_g2_address",
         fmt="i",
         native_min_value=0,
         native_max_value=255,
         native_step=1,
-        allowedtypes=AC | HYBRID | GEN4 | GEN5,
+        allowedtypes=AC | HYBRID | GEN4,
+        entity_category=EntityCategory.CONFIG,
         icon="mdi:connection",
     ),
 ]
@@ -1919,25 +1923,6 @@ NUMBER_TYPES = [
 # ================================= Switch Declarations ============================================================
 
 SWITCH_TYPES = [
-    ###
-    #
-    # Gen4 Missing Registers - Switch Entities
-    #
-    ###
-    SolaXModbusSwitchEntityDescription(
-        name="VPP Exit Idle Enable",
-        key="vpp_exit_idle_enable",
-        register=0xF4,
-        allowedtypes=AC | HYBRID | GEN4 | GEN5,
-        icon="mdi:power-plug",
-    ),
-    SolaXModbusSwitchEntityDescription(
-        name="Fast CT Check Enable",
-        key="fast_ct_check_enable",
-        register=0xF5,
-        allowedtypes=AC | HYBRID | GEN4 | GEN5,
-        icon="mdi:current-ac",
-    ),
 ]
 
 # ================================= Select Declarations ============================================================
@@ -2553,6 +2538,30 @@ SELECT_TYPES = [
         },
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | EPS,
         icon="mdi:dip-switch",
+    ),
+    SolaxModbusSelectEntityDescription(
+        name="VPP Exit Idle Enable",
+        key="vpp_exit_idle_enable",
+        register=0xF4,
+        option_dict={
+            0: "Disabled",
+            1: "Enabled",
+        },
+        allowedtypes=AC | HYBRID | GEN4,
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:power-plug",
+    ),
+    SolaxModbusSelectEntityDescription(
+        name="Fast CT Check Enable",
+        key="fast_ct_check_enable",
+        register=0xF5,
+        option_dict={
+            0: "Disabled",
+            1: "Enabled",
+        },
+        allowedtypes=AC | HYBRID | GEN4,
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:current-ac",
     ),
     #####
     #
@@ -4614,6 +4623,48 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         key="generator_charge_soc",
         register=0x12E,
         allowedtypes=AC | HYBRID | GEN5 | GEN6 | DCB,
+        internal=True,
+    ),
+    #####
+    #
+    # Gen4 Missing Registers - Internal Sensors for Switch Reading
+    # Note: These read from holding registers for current state
+    #
+    #####
+    SolaXModbusSensorEntityDescription(
+        key="vpp_exit_idle_enable",
+        register=0xB4,
+        register_type=REG_HOLDING,
+        scale=value_function_disabled_enabled,
+        allowedtypes=AC | HYBRID | GEN4,
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
+        key="fast_ct_check_enable",
+        register=0xB3,
+        register_type=REG_HOLDING,
+        scale=value_function_disabled_enabled,
+        allowedtypes=AC | HYBRID | GEN4,
+        internal=True,
+    ),
+    #####
+    #
+    # Gen4 Missing Registers - Internal Sensors for Number Reading
+    # Note: These read from holding registers for current values
+    #
+    #####
+    SolaXModbusSensorEntityDescription(
+        key="ev_charger_address",
+        register=0x15C,
+        register_type=REG_HOLDING,
+        allowedtypes=AC | HYBRID | GEN4,
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
+        key="adapt_box_g2_address",
+        register=0x15E,
+        register_type=REG_HOLDING,
+        allowedtypes=AC | HYBRID | GEN4,
         internal=True,
     ),
     #####


### PR DESCRIPTION
## Summary
Implements the 4 missing Gen4 X3 Hybrid registers as identified in the documentation analysis.

## Changes
- **0xF4 - VPP Exit Idle Enable**: Select entity (Enabled/Disabled)
- **0xF5 - Fast CT Check Enable**: Select entity (Enabled/Disabled)  
- **0xF9 - EV Charger Address**: Number entity (0-255, box input mode)
- **0xFB - Adapt Box G2 Address**: Number entity (0-255, box input mode)

## Implementation Details
- Select entities follow existing pattern (dropdown with Enabled/Disabled options)
- Number entities use box input mode (not sliders) for better UX
- All entities placed in Configuration section
- Adds internal sensors for readback from holding registers:
  - 0xB4: VPP Exit Idle Enable readback
  - 0xB3: Fast CT Check Enable readback
  - 0x15C: EV Charger Address readback
  - 0x15E: Adapt Box G2 Address readback
- Limited to Gen4 inverters only (AC | HYBRID | GEN4)
- Write control via holding registers (0xF4, 0xF5, 0xF9, 0xFB)

## Testing
Tested on Gen4 X3 Hybrid inverters with read/write functionality verified.