### PR TITLE
Update plugin_growatt.py with VPP registers

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -1283,7 +1283,7 @@ SELECT_TYPES = [
         option_dict = {
                 0: "Disabled",
                 1: "Enabled", },
-        allowedtypes = GEN3 | GEN4,
+        allowedtypes = GEN3,
         entity_category = EntityCategory.CONFIG,
         entity_registry_enabled_default = True,
         icon = "mdi:dip-switch",


### PR DESCRIPTION
Added VPP registers to control battery first and grid first without the need to set timers. These changes are for GEN3 inverters, but may also apply to other inverters.

This all seems to be working for my system, but this is my first attempt at adding code, so may not be completely correct (suggested changes appreciated).

I have also added battery State of Health (SOH) as I thought this would be a useful parameter to monitor over time.

I am controlling battery charge/ discharge on and off via automation to set time, power, remote enable, then VPP status to enable in this order. The battery charge/discharge stops after the time period enterd or you can use a second automation to set timers and power to zero, and VPP the VPP remote and status to disabled

Thanks to Raageri, flopp999, scruysberghs, and others for information and starting the VPP discussion (Growatt WIT series modbus documentation. #1631).

Note: flopp999 has already added VPP status for GEN4.

Cheers Brad