### PR TITLE
Correct Mode 1 Export Limit Bound and Loop Exit

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -328,7 +328,7 @@ def autorepeat_function_remotecontrol_recompute(initval, descr, datadict):
     ]
     
     if power_control == "Disabled":
-        autorepeat_stop(datadict, "powercontrolmode8_trigger")
+        autorepeat_stop(datadict, "remotecontrol_trigger")
     
     _LOGGER.debug(f"Evaluated remotecontrol_trigger: corrected/clamped values: {res}")
     return { 'action': WRITE_MULTI_MODBUS, 'data': res }


### PR DESCRIPTION
The bound check was incorrectly adding on house load. This means the more the house uses, the less the inverter was allowed to output to the home. This is backwards.

Instead the more the house uses, the more the inverter should be allowed to output power so that it can continue to cover the house load, and still export to the grid up to the grid export limit.

Furthermore,, the mode 1 exit clause changes meant mode 1 never actually stopped - rather it kept trying to stop the mode 8 loop.

---

A couple of quick tests with the Self-use mode 1 option

* With the current `main` branch after #1694 was applied:

  ```
  2025-11-07 09:25:21.490 DEBUG (MainThread) [custom_components.solax_modbus.plugin_solax] [REMOTE_CONTROL] Target calculation: mode=Enabled Power Control ap_target=-3062W
  2025-11-07 09:25:21.490 DEBUG (MainThread) [custom_components.solax_modbus.plugin_solax] [REMOTE_CONTROL] Export bounds: ap_target=-618W export_bound=-618W export_limit=3680W house_load=3062W
  2025-11-07 09:25:21.490 DEBUG (MainThread) [custom_components.solax_modbus.plugin_solax] [REMOTE_CONTROL] Bounds checking: initial_ap_target=-3062W final_ap_target=-618W adjusted_by=-2444W
  2025-11-07 09:25:21.490 DEBUG (MainThread) [custom_components.solax_modbus.plugin_solax] Evaluated remotecontrol_trigger: corrected/clamped values: [('remotecontrol_power_control', 'Enabled Power Control'), ('remotecontrol_set_type', 'Set'), ('remotecontrol_active_power', -618), ('remotecontrol_reactive_power', 0), ('remotecontrol_duration', 30.0), ('_uint16', 0), ('_uint32', 0), ('_int32', 0), ('remotecontrol_timeout', 120.0)]
  2025-11-07 09:25:21.490 DEBUG (MainThread) [custom_components.solax_modbus] **debug** ready to repeat remotecontrol_trigger data: {'action': 4, 'data': [('remotecontrol_power_control', 'Enabled Power Control'), ('remotecontrol_set_type', 'Set'), ('remotecontrol_active_power', -618), ('remotecontrol_reactive_power', 0), ('remotecontrol_duration', 30.0), ('_uint16', 0), ('_uint32', 0), ('_int32', 0), ('remotecontrol_timeout', 120.0)]}
  2025-11-07 09:25:21.491 DEBUG (MainThread) [custom_components.solax_modbus] Ready to write multiple registers at 0x7c: [1, 1, 64918, 65535, 0, 0, 30, 0, 0, 0, 0, 0, 120] online: True 
  ```

   Notice how the target is the 3062W house load, but because of the bound check, it's incorrectly set the target to only 618W. So grid import is covering the use rather than the battery. This is incorrect.

* With the changes in this PR:

  ```
  2025-11-07 09:38:55.233 DEBUG (MainThread) [custom_components.solax_modbus.plugin_solax] [REMOTE_CONTROL] Target calculation: mode=Enabled Power Control ap_target=-3125W
  2025-11-07 09:38:55.233 DEBUG (MainThread) [custom_components.solax_modbus.plugin_solax] [REMOTE_CONTROL] Export bounds: ap_target=-3125W export_bound=-6805W export_limit=3680W house_load=3125W
  2025-11-07 09:38:55.233 DEBUG (MainThread) [custom_components.solax_modbus.plugin_solax] Evaluated remotecontrol_trigger: corrected/clamped values: [('remotecontrol_power_control', 'Enabled Power Control'), ('remotecontrol_set_type', 'Set'), ('remotecontrol_active_power', -3125), ('remotecontrol_reactive_power', 0), ('remotecontrol_duration', 30.0), ('_uint16', 0), ('_uint32', 0), ('_int32', 0), ('remotecontrol_timeout', 120.0)]
  2025-11-07 09:38:55.233 DEBUG (MainThread) [custom_components.solax_modbus] **debug** ready to repeat remotecontrol_trigger data: {'action': 4, 'data': [('remotecontrol_power_control', 'Enabled Power Control'), ('remotecontrol_set_type', 'Set'), ('remotecontrol_active_power', -3125), ('remotecontrol_reactive_power', 0), ('remotecontrol_duration', 30.0), ('_uint16', 0), ('_uint32', 0), ('_int32', 0), ('remotecontrol_timeout', 120.0)]}
  2025-11-07 09:38:55.233 DEBUG (MainThread) [custom_components.solax_modbus] Ready to write multiple registers at 0x7c: [1, 1, 62411, 65535, 0, 0, 30, 0, 0, 0, 0, 0, 120] online: True 
  ```
  
  Now the target is 3125W house load, while the bound is now set to 6805W (The 3680W export limit plus the 3125W house load). The resulting target is the unchanged 3125W house load required from the battery. The battery now covers the house as it should rather than import

<img width="1356" height="504" alt="image" src="https://github.com/user-attachments/assets/50a81755-12f0-466e-a9c0-03347cbe896c" />

Notice how the change now allows the battery to discharge to cover the house load. While before it was having to import from the grid because the value was being clamped incorrectly.
