### PR TITLE
Disable Mode 8 Export First PV Limit Clamp by Default

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -521,6 +521,9 @@ def autorepeat_function_powercontrolmode8_recompute(initval, descr, datadict):
                 export_hysteresis_w = int(datadict.get("export_first_export_hysteresis_w", 100) or 100)
                 pv_clamp_target = max(0, hl + export_within_cap + desired_charge - export_hysteresis_w)
                 pvlimit = min(pvlimit, pv_clamp_target)
+            else:
+                # Don't clamp, use full PV limit (set variable for logging).
+                pv_clamp_target = pvlimit
             
             _LOGGER.debug(
                 f"[Mode8 Export-First] export-first: surplus={surplus}W export_target={export_within_cap}W rest={rest_for_batt}W "


### PR DESCRIPTION
The new clamping of PV limit in Mode 8 Export First mode requires further investigation. This is causing a ramp down oscillation of PV output due to the hysteresis setting.

As this is new logic not originally in this pathway, I'm proposing we make the section of code default to disabled until it has undergone further testing and development.

See #1730 for tracking of this.