### PR TITLE
Update plugin_growatt.py enhanced total PV total production logic

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -550,19 +550,19 @@ def value_function_today_s_solar_energy(initval, descr, datadict):
         val = datadict.get(key)
         # If the PV Array *exists* but reports bad data - fail the whole result
         if val in (None, "unknown", "unavailable"): # unavailable if unknown
-            return "unavailable"
+            return initval
         try:
             val_f = float(val)
         except (ValueError, TypeError): # unavailable if conversion fails
-            return "unavailable"
+            return initval
         if val_f != val_f:              # unavailable if detect a NaN
-            return "unavailable"
+            return initval
 
         found_any_sensor = True
         total += val_f  # Actually get the total
 
     if not found_any_sensor:    # If literally no PV array sensors exist (e.g. integration booting), return unavailable
-        return "unavailable"
+        return initval
 
     return total
 


### PR DESCRIPTION
Added code to handle errors and unavailable states in the PV individual daily production when adding up to the total PV production.  This is to prevent PV total dropping to zero on an invalid read or HA reboot, which causes HA energy meters to double count the days PV production.
My first contribution on GitHub ever, so please let me know if I'm doing things I shouldn't