### PR TITLE
📚 Offer a tip on configuring Ethernet-enabled Wareshare devices without Windows

### DIFF
--- a/docs/modbus-adaptor-setup.md
+++ b/docs/modbus-adaptor-setup.md
@@ -36,10 +36,12 @@ DO NOT CONNECT THIS COM PORT TO AN ETHERNET SWITCH - your Ethernet switch port w
 - use the "vircom" tool (Windows) to set the IP address matching your lan (or to let the device use DHCP, it does not use DHCP by default, however we recommend using a static IP)
 
   ```{tip}
-  By default (and post factory reset), this adapter (at least its `RS485 TO POE ETH (B)` variation) has a static IP configuration set up as as 192.168.1.210/24.
+  By default, this adapter (also tested on its `RS485 TO POE ETH (B)` variation) has a static IP configuration set up as as 192.168.1.210/24.
 
   When you don't have Windows at hand, place both the adapter and your computer on the 192.168.1.0/24 subnet (you might already be using it as home LAN).
   Then, open http://192.168.1.200 in your web browser from said computer (you can of course use a phone for a quick test if it's on the same network).
+
+  Additionally, [the FAQ mentions](https://www.waveshare.com/wiki/RS485_TO_ETH_(B)#FAQ) that post factory reset, it becomes http://192.168.1.254.
 
   This eliminates the need to figure out getting a Windows VM if you're on a different computing stack or just don't want to download and execute a closed-source binary from a file share on the internet.
   ```


### PR DESCRIPTION
I struggled with this for a bit but some amount of experimentation and studying the docs revealed that Waveshare devices come pre-configured with 192.168.1.200/24, making the Windows binary redundant for many. Actually, it was a few smart home enthusiasts from a local community who dug it out of the FAQ on a different page. @ByteStorm to be precise.

The PoE Wiki page fails to mention the defaults but the non-PoE doc at https://www.waveshare.com/wiki/RS485_TO_ETH_(B)#FAQ has this:

> **Question:** What is the default access IP of the webpage?
> **Answer:**
> The default is from 192.168.1.200;
> If the factory settings have been restored, the default IP is 192.168.1.254.