### PR TITLE
fix: correct EV charger 32-bit word order

### DIFF
--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -1159,5 +1159,5 @@ plugin_instance = solax_ev_charger_plugin(
     SWITCH_TYPES=[],
     block_size=100,
     #order16=Endian.BIG,
-    order32="little",
+    order32="big",
 )


### PR DESCRIPTION
## Summary
- switch EV charger plugin 32-bit word order to big-endian
- aligns 32-bit values like `charge_duration` with expected seconds
- addresses issue #1793

## Test plan
- sanity-check 32-bit word-order math (little=21233664, big=324 for sample regs)
- not tested on live hardware in this change