### PR TITLE
Fix: SolaX HAC model detection

### DIFF
--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -1104,9 +1104,14 @@ class solax_ev_charger_plugin(plugin_base):
             power_code = seriesnumber[3:5]
 
             model_map = {
-                "02": ("X1-GAC", X1),
+                "02": ("X1-HAC", X1),
                 "03": ("X3-HAC", X3),
+                "04": ("A1-HAC", X1),
+                "05": ("J1-HAC", X1),
+                "06": ("X1-HAC-S", X1),
                 "07": ("X3-HAC-S", X3),
+                "08": ("C1-HAC", X1),
+                "09": ("C3-HAC", X3),
             }
 
             power_map = {
@@ -1122,7 +1127,7 @@ class solax_ev_charger_plugin(plugin_base):
                 model_prefix, phase_mask = model_info
                 power_label, power_mask = power_info
                 invertertype = phase_mask | power_mask | GEN2
-                self.inverter_model = f"{model_prefix}-{power_label}"
+                self.inverter_model = f"{model_prefix} {power_label}"
                 self.hardware_version = "Gen2"
                 _LOGGER.debug(
                     f"{hub.name}: Parsed serial codes model={model_code} power={power_code} -> "

--- a/docs/solax-ev-charger-operation.md
+++ b/docs/solax-ev-charger-operation.md
@@ -29,9 +29,15 @@ Newer EV chargers use a serial format like `5 03 0B 002060C0P`. The Modbus regis
 
 - Product category: `5` = EV Charger (EVC)
 - Model codes:
+  - `02` = X1-HAC
   - `03` = X3-HAC
+  - `04` = A1-HAC
+  - `05` = J1-HAC
+  - `06` = X1-HAC-S
   - `07` = X3-HAC-S
-  - `02` = X1-GAC
+  - `08` = C1-HAC
+  - `09` = C3-HAC
+
 - Power codes:
   - `04` = 4.6kW
   - `07` = 7.2kW


### PR DESCRIPTION
### Summary
- Update EV charger model detection to match the SolaX support serial specification.
- Add support for the 4.6kW model (POW4).
- Refresh documentation to reflect the updated detection rules and serial format.

### Rationale
SolaX support clarified that EV charger models are identified via category/model/power codes in the serial number.