### PR TITLE
Fix EPS Yield Total Scaling for Gen 5

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -6505,7 +6505,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         unit=REGISTER_U32,
         scale=0.1,
         rounding=1,
-        allowedtypes=HYBRID | GEN2 | GEN4 | EPS,
+        allowedtypes=HYBRID | GEN2 | GEN4 | GEN5 | EPS,
     ),
     SolaXModbusSensorEntityDescription(
         name="EPS Yield Total",
@@ -6516,7 +6516,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         register=0x8E,
         register_type=REG_INPUT,
         unit=REGISTER_U32,
-        allowedtypes=AC | HYBRID | GEN3 | GEN5 | EPS,
+        allowedtypes=AC | HYBRID | GEN3 | EPS,
     ),
     SolaXModbusSensorEntityDescription(
         name="EPS Yield Total",


### PR DESCRIPTION
Gen5 inverters use 0.1 scaling for EPS yield total based on testing on my X1-IES (results shown in #1797).

---

As a side note, it would be interesting to know if the same is true for Gen 3 inverters. 