### PR TITLE
Update plugin_growatt.py by adding serial number for GEN3 inverters

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -9500,6 +9500,9 @@ class growatt_plugin(plugin_base):
         seriesnumber = await async_read_serialnr(hub, 3001)
         if not seriesnumber:
             _LOGGER.info(f"{hub.name}: trying alternative location")
+            seriesnumber = await async_read_serialnr(hub, 209)
+        if not seriesnumber:
+            _LOGGER.info(f"{hub.name}: trying alternative location")
             seriesnumber = await async_read_serialnr(hub, 9)
         if not seriesnumber:
             _LOGGER.error(f"{hub.name}: cannot find firmware version, even not for other Inverter")


### PR DESCRIPTION
Additional code to find serial number for GEN3 inverters using register 209.

Recently @flopp999 introduced a new way to identify Growatt inverter types based on serial numbers rather than firmware numbers. The code looked for the serial number at register 3001 and then 9??. If no serial number was identified, the code then used the legacy firmware number (register 9). For my GEN3 inverter (SPH 5000TL HUB), registers in the 3000 range are not used and the serial number is located at register 209 to 213. I updated my plugin_growatt.py by adding the code below.

        if not seriesnumber:
            _LOGGER.info(f"{hub.name}: trying alternative location")
            seriesnumber = await async_read_serialnr(hub, 209)

This resulted in my serial number showing up in place of the firmware number and the integration continued to work as normal.