### PR TITLE
Change error message to info

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -9685,7 +9685,7 @@ class growatt_plugin(plugin_base):
             invertertype = PV | GEN | X1  # 5000, ? MPPT
 
         else:
-            _LOGGER.error(f"{hub.name}: trying alternative location")
+            _LOGGER.info(f"{hub.name}: trying alternative location")
             seriesnumber = await async_read_serialnr(hub, 9)
             if not seriesnumber:
                 _LOGGER.error(f"{hub.name}: cannot find firmware version, even not for other Inverter")


### PR DESCRIPTION
Most of the similar error messages are

_LOGGER.info(f"{hub.name}: trying alternative location")

but one was 

_LOGGER.error(f"{hub.name}: trying alternative location")

generating an error message for growatt SPH 3600 inverter.  This PR just changes that remaining one error message to info so it's clear there isn't actually any error.