### PR TITLE
feat(solinteg): add Charge-Discharge working mode and power target control

### DIFF
--- a/custom_components/solax_modbus/plugin_solinteg.py
+++ b/custom_components/solax_modbus/plugin_solinteg.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass, field, replace
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.components.number import NumberDeviceClass, NumberMode
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
@@ -1562,13 +1562,13 @@ class solinteg_plugin(plugin_base):
             _LOGGER.error(f"{hub.name}: cannot find serial number, even not for other Inverter")
 
         model = await _read_model(hub)
-        if model is None:
-            _LOGGER.error(f"{hub.name}: could not read model at 0x{10008:x}")
-            bh, bl = 0, 0
+        if model is None or model == 0:
+            _LOGGER.error(f"{hub.name}: could not read inverter model")
+            return 0
         else:
             self.inverter_model = _model_str(model)  # as string
-            bh, bl = model // 256, model % 256
 
+        bh, bl = model // 256, model % 256
         invertertype = 0
         if bh in [30, 31, 32]:
             invertertype = invertertype | HYBRID
@@ -1585,30 +1585,31 @@ class solinteg_plugin(plugin_base):
             mppt = 2
             invertertype = invertertype | MPPT2
 
-        if invertertype > 0:
+        try:
             # prepare mppt mask/dict
             _mppt_mask = 2**mppt - 1
             # copy and update
             sel_dd = _mppt_dd.copy() | {2**i: f"mppt{i + 1}" for i in range(mppt)}
             # set the options
-            select_types = cast(list[SolintegModbusSelectEntityDescription], self.SELECT_TYPES)
-            for i, sscan in enumerate(select_types):
-                if sscan.key == "shadow_scan":
-                    select_types[i] = replace(sscan, option_dict=sel_dd)
+            for i, ssel in enumerate(self.SELECT_TYPES):
+                if ssel.key == "shadow_scan":
+                    self.SELECT_TYPES[i] = replace(ssel, option_dict=sel_dd)  # type: ignore
                     break
-            # use own mask
-            sensor_types = cast(list[SolintegModbusSensorEntityDescription], self.SENSOR_TYPES)
-            for i, ssensor in enumerate(sensor_types):
-                if ssensor.key == "shadow_scan":
-                    sensor_types[i] = replace(ssensor, scale=lambda v, descr, dd: _fn_mppt_mask_ex(v, _mppt_mask))
-                    break
-            read_eps = configdict.get(CONF_READ_EPS, DEFAULT_READ_EPS)
-            read_dcb = configdict.get(CONF_READ_DCB, DEFAULT_READ_DCB)
-            if read_eps:
-                invertertype = invertertype | EPS
-            if read_dcb:
-                invertertype = invertertype | DCB
 
+            # use own mask
+            for i, ssensor in enumerate(self.SENSOR_TYPES):
+                if ssensor.key == "shadow_scan":
+                    self.SENSOR_TYPES[i] = replace(ssensor, scale=lambda v, descr, dd: _fn_mppt_mask_ex(v, _mppt_mask))  # type: ignore
+                    break
+        except Exception:
+            _LOGGER.error(f"{hub.name}: unexpected error", exc_info=True)
+
+        read_eps = configdict.get(CONF_READ_EPS, DEFAULT_READ_EPS)
+        read_dcb = configdict.get(CONF_READ_DCB, DEFAULT_READ_DCB)
+        if read_eps:
+            invertertype = invertertype | EPS
+        if read_dcb:
+            invertertype = invertertype | DCB
         _LOGGER.info(f"{hub.name}: inverter type: x{invertertype:x}, mppt count={mppt}")
 
         return invertertype


### PR DESCRIPTION
## Summary

- Adds working mode `0x303` (Charge-Discharge / EMS mode) to `SELECT_TYPES` so users can select it from the Home Assistant UI
- Adds the same mode to the internal `working_mode` sensor scale dict for state tracking
- Adds `battery_charge_discharge_power_target` number entity (register 50207, `REGISTER_S16`) for direct charge/discharge power control
- Adds a matching internal sensor with consistent unit/scale for correct feedback loop

## Context

Register `50207` on Solinteg hybrid inverters holds a signed 16-bit power target for the EMS Charge-Discharge mode (`0x303`). The register unit is `x0.01 kW`, meaning register value `300` = 3 kW charge, `-200` = 2 kW discharge.

The number entity uses raw register values (`native_unit_of_measurement="x0.01 kW"`, `scale=1`) so the internal sensor feedback matches what was written. The backing sensor uses the same unit/scale for a consistent round-trip.

Working mode `0x303` is documented in the Solinteg Modbus protocol as an EMS-controlled Charge-Discharge mode, distinct from the standard modes (General, Economic, PeakShift, etc.).

## Testing

Tested on a Solinteg hybrid inverter connected via ModbusTCP. Both the mode selection and the power target number entity function correctly.