### PR TITLE
Handle None values in SolaX software version

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -351,6 +351,10 @@ def autorepeat_remaining(datadict: dict[str, Any], entitykey: str, timestamp: fl
 MAX_PVSTRINGS: int = 10
 
 
+def value_str_default(val: Any, default: str) -> str:
+    return str(val) if val is not None else default
+
+
 def value_function_pv_power_total(initval: Any, descr: Any, datadict: dict[str, Any]) -> int | float:
     """Calculate total PV power from all strings."""
     # changed: for performance reasons, we should not iterate over the entire datadict every polling cycle (contains hundreds ...)

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -67,6 +67,7 @@ from custom_components.solax_modbus.const import (  # type: ignore[attr-defined]
     value_function_pv_power_total,
     value_function_rtc,
     value_function_sync_rtc,
+    value_str_default,
 )
 
 from .pymodbus_compat import DataType, convert_from_registers
@@ -1102,11 +1103,21 @@ def value_function_software_version_g3(initval: int, descr: Any, datadict: dict[
 
 
 def value_function_software_version_g4(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    return f"DSP {datadict.get('firmware_dsp_major')}.{datadict.get('firmware_dsp'):>02} ARM {datadict.get('firmware_arm_major')}.{datadict.get('firmware_arm'):>02}"
+    return (
+        f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '?')}."
+        f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
+        f"ARM {value_str_default(datadict.get('firmware_arm_major'), '?')}."
+        f"{value_str_default(datadict.get('firmware_arm'), '??'):>02}"
+    )
 
 
 def value_function_software_version_g5(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    return f"DSP {datadict.get('firmware_dsp_major'):>03}.{datadict.get('firmware_dsp'):>02} ARM {datadict.get('firmware_arm_major'):>03}.{datadict.get('firmware_arm'):>02}"
+    return (
+        f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '???'):>03}."
+        f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
+        f"ARM {value_str_default(datadict.get('firmware_arm_major'), '???'):>03}."
+        f"{value_str_default(datadict.get('firmware_arm'), '??'):>02}"
+    )
 
 
 def value_function_software_version_air_g3(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:


### PR DESCRIPTION
The justify formatting helpers error if the returned value from datadict.get is None.

Fix this by using a default for missing or empty key values.

This is related to an error message seen in #1890 and #1889 but I think is just fixing a symptom of a different underlying problem.