### PR TITLE
correct bug #1892: allow None when autorepeat is not active

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -898,10 +898,12 @@ def value_function_remotecontrol_autorepeat_remaining(initval: int, descr: Any, 
 
 
 def value_function_remotecontrol_current_pushmode_power(initval: int, descr: Any, datadict: dict[str, Any]) -> Any:
+    # do not convert to int(); None is a valid value and is returned if VPP is inactive
     return datadict.get(descr.key, 0)
 
 
 def value_function_remotecontrol_current_pv_power_limit(initval: int, descr: Any, datadict: dict[str, Any]) -> Any:
+    # do not convert to int(); None is a valid value and is returned if VPP is inactive
     return datadict.get(descr.key, 0)
 
 


### PR DESCRIPTION
The int() conversion caused an exception, that may have interrupted the value_function computation of other entities also (unsure)

This is an example where the stricter type checking introduces new errors: to be compliant with the type declaration, an int() conversion was added recently; this int conversion fails if the value is None, which is a perfectly valid value for this entity.

One could add code to check the type first, but this only adds runtime load that has no additional value at all imho.