### PR TITLE
Use PV Power Total for House Load Alt Calculation

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -952,9 +952,7 @@ def value_function_house_load(initval: int, descr: Any, datadict: dict[str, Any]
 
 def value_function_house_load_alt(initval: int, descr: Any, datadict: dict[str, Any]) -> int | float:
     return int(
-        datadict.get("pv_power_1", 0)
-        + datadict.get("pv_power_2", 0)
-        + datadict.get("pv_power_3", 0)
+        datadict.get("pv_power_total", 0)
         - datadict.get("battery_power_charge", 0)
         - datadict.get("measured_power", 0)
         + datadict.get("meter_2_measured_power", 0)
@@ -8114,22 +8112,6 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         icon="mdi:home-lightning-bolt",
     ),
     SolaXModbusSensorEntityDescription(
-        name="House Load Alt",
-        key="house_load_alt",
-        value_function=value_function_house_load_alt,
-        native_unit_of_measurement=UnitOfPower.WATT,
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        allowedtypes=AC | HYBRID,
-        entity_registry_enabled_default=False,
-        depends_on=[
-            "pv_power_1",
-            "pv_power_2",
-            "pv_power_3",
-        ],
-        icon="mdi:home-lightning-bolt",
-    ),
-    SolaXModbusSensorEntityDescription(
         name="Inverter Power",
         key="inverter_power",
         value_function=value_function_inverter_power_g5,
@@ -8153,6 +8135,20 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
             "pv_power_4",
         ],
         icon="mdi:solar-power-variant",
+    ),
+    SolaXModbusSensorEntityDescription(
+        name="House Load Alt",
+        key="house_load_alt",
+        value_function=value_function_house_load_alt,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        allowedtypes=AC | HYBRID,
+        entity_registry_enabled_default=False,
+        depends_on=[
+            "pv_power_total",
+        ],
+        icon="mdi:home-lightning-bolt",
     ),
     SolaXModbusSensorEntityDescription(
         name="Remotecontrol Autorepeat Remaining",


### PR DESCRIPTION
For the `house_load_alt` sensor calculation function, we were summing PV power 1, 2 and 3 values directly. However for inverters with more than 3 MPPTs this would miss off some of the solar power. 

We already have a `pv_power_total` sensor which accounts for all of the MPPTs, so we can just use that directly in the calculation.