### PR TITLE
Set Export User Limit Scaling based on X1 or X3

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1386,23 +1386,6 @@ MAX_EXPORT: list[tuple[str, int | float]] = [
     ### All known Inverters added
 ]
 
-EXPORT_LIMIT_SCALE_EXCEPTIONS = [
-    ("H4", 10),  # assuming all Gen4s
-    ("H34", 10),  # assuming all Gen4s
-    ("H3UE", 10),  # Issue #339, 922
-    ("H4372A", 1),  # Issue #857
-    ("H4502A", 1),  # Issue #857
-    ("H4502T", 1),  # Issue #418
-    ("H4602A", 1),  # Issue #882
-    ("H3BD", 10),  # X3-Ultra D
-    ("H3BF", 10),  # X3-Ultra F
-    ("H3BB", 10),  # X3-Ultra G
-    ("H4752A", 1),
-    ("H3BC", 10),
-    ("H34B10H", 10),  # need return @jansidlo ,
-    #    ('H1E', 10 ), # more specific entry comes last and wins
-]
-
 CHARGE_SCALE_EXCEPTIONS = [
     ("802", 10),  # assuming all Aelio #1590
     #    ('H1E', 1 ), # more specific entry comes last and wins
@@ -1801,12 +1784,39 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         fmt="i",
         native_min_value=0,
         native_max_value=2500,
-        scale=1,
         native_step=100,
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=NumberDeviceClass.POWER,
-        read_scale_exceptions=EXPORT_LIMIT_SCALE_EXCEPTIONS,
-        allowedtypes=AC | HYBRID,
+        allowedtypes=AC | HYBRID | GEN | GEN2 | GEN3,
+        max_exceptions=MAX_EXPORT,
+        icon="mdi:home-export-outline",
+    ),
+    SolaxModbusNumberEntityDescription(
+        name="Export Control User Limit",
+        key="export_control_user_limit",
+        register=0x42,
+        fmt="i",
+        native_min_value=0,
+        native_max_value=6000,
+        native_step=100,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | X1,
+        max_exceptions=MAX_EXPORT,
+        icon="mdi:home-export-outline",
+    ),
+    SolaxModbusNumberEntityDescription(
+        name="Export Control User Limit",
+        key="export_control_user_limit",
+        register=0x42,
+        fmt="i",
+        native_min_value=0,
+        native_max_value=6000,
+        scale=10,
+        native_step=100,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | X3,
         max_exceptions=MAX_EXPORT,
         icon="mdi:home-export-outline",
     ),
@@ -1816,13 +1826,25 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         register=0xC8,
         fmt="i",
         native_min_value=0,
-        native_max_value=2500,
-        scale=1,
+        native_max_value=6000,
         native_step=100,
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=NumberDeviceClass.POWER,
-        read_scale_exceptions=EXPORT_LIMIT_SCALE_EXCEPTIONS,
-        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | DCB,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | DCB | X1,
+        max_exceptions=MAX_EXPORT,
+    ),
+    SolaxModbusNumberEntityDescription(
+        name="Generator Max Charge",
+        key="generator_max_charge",
+        register=0xC8,
+        fmt="i",
+        native_min_value=0,
+        native_max_value=6000,
+        scale=10,
+        native_step=100,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | DCB | X3,
         max_exceptions=MAX_EXPORT,
     ),
     SolaxModbusNumberEntityDescription(
@@ -4357,8 +4379,20 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     SolaXModbusSensorEntityDescription(
         key="export_control_user_limit",
         register=0xB6,
-        allowedtypes=AC | HYBRID | GEN2 | GEN3 | GEN4 | GEN5,
-        read_scale_exceptions=EXPORT_LIMIT_SCALE_EXCEPTIONS,
+        allowedtypes=AC | HYBRID | GEN2 | GEN3,
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
+        key="export_control_user_limit",
+        register=0xB6,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | X1,
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
+        key="export_control_user_limit",
+        register=0xB6,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | X3,
+        read_scale=0.1,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(


### PR DESCRIPTION
At the moment we have a large table of exceptions that misses newer inverters leading to issues with the scaling of this parameter.

Based on the Modbus docs, all GEN4/5/6 inverters *should* use a factor of 1 if an X1 and 10 if an X3. This largely corresponds to the table of exceptions (although for some reason all GEN4 X1 were initially set to 10 and then exceptions down to 1 added).

<img width="655" height="296" alt="image" src="https://github.com/user-attachments/assets/f8ae0a5b-8f20-469c-a0bb-6e8d83138ddc" />

<img width="584" height="137" alt="image" src="https://github.com/user-attachments/assets/18a3792e-3496-4dc1-be76-278c9deb19da" />

However looking back at past issues something may have changed between firmware versions as at least one issue reported it only because an issue after a firmware upgrade.

The docs screenshot above is from the 2025 release of the RTU for X1/X3 Gen 4/5/6 inverters.

As such I've left `config_export_control_limit_readscale` existing. This change may be breaking in that users that used to have to use the readscale "hack" will probably have to remove it. It may require people with old inverter firmwares to use the readscale "hack" where they didn't previously.

I'm open to discussion on whether this change should go ahead - my gut feeling is that we should try to match the latest documentation so that we don't have to keep adding more and more inverters into the exceptions.

---

This is related to #1897, #1777, #1636, and a few others