### PR TITLE
Fix false SoC zero warnings in parallel slave setups

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -118,6 +118,7 @@ ALL_PM_GROUP = PM
 # Plugin-Level Register Validation
 # ============================================================================
 
+
 def _validation_cache(datadict: dict[str, Any], key: str) -> dict[str, Any]:
     """Return a per-hub cache stored inside the hub data dict."""
     cache = datadict.get("_validation_cache")


### PR DESCRIPTION
This fixes the false SoC zero reading warnings reported in [#1900](https://github.com/wills106/homeassistant-solax-modbus/issues/1900).

What changed:

The last-known validation cache is no longer shared globally across all hub instances.
Cached values are now kept per hub, so one inverter can no longer reuse SoC values from another inverter.