### PR TITLE
Correct scaling on Export User Limit readback sensor for SolaX X3 inverters

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -4410,7 +4410,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         key="export_control_user_limit",
         register=0xB6,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | X3,
-        read_scale=0.1,
+        scale=10,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(


### PR DESCRIPTION
This fixes a mistake made in #1899.

For X3, the scale factor should be the same on the Sensor entity and the Number entity, but they ended up having opposing values.

This meant the export limit was being set correctly on the inverter, but when the value is read back it appears as 1/100 of the actual value.