### PR TITLE
Add one-time initial refresh after startup

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -1031,9 +1031,7 @@ class SolaXModbusHub:
                 async with interval_group.poll_lock:
                     agg_res, updated_sensors = await self._refresh_interval_group_once(interval_group, bypass_slowdown=True)
                 await self._maybe_refresh_energy_dashboard_on_primary_update()
-                _LOGGER.debug(
-                    f"{self._name}: initial refresh for interval {interval}s finished (ok={agg_res}, sensors={updated_sensors})"
-                )
+                _LOGGER.debug(f"{self._name}: initial refresh for interval {interval}s finished (ok={agg_res}, sensors={updated_sensors})")
         finally:
             self._initial_refresh_active = False
             self._initial_refresh_done = True


### PR DESCRIPTION
This adds a one-time initial refresh after startup so entity values are populated immediately after setup.

What changed:

- a one-shot initial refresh now runs after platforms are forwarded
- all scan groups are refreshed once after the startup probe completes
- scheduled polling is briefly skipped while the initial refresh is running
- the initial refresh task is cancelled cleanly on stop