### PR TITLE
Allow Battery control override also for 1P Solis inverters

### DIFF
--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -1056,7 +1056,7 @@ SELECT_TYPES = [
             1: "Force charge",
             2: "Force discharge",
         },
-        allowedtypes=HYBRID | X3,
+        allowedtypes=HYBRID,
         icon="mdi:dip-switch",
         value_function=value_function_battery_control_override,
     ),

--- a/custom_components/solax_modbus/plugin_solis_fb00.py
+++ b/custom_components/solax_modbus/plugin_solis_fb00.py
@@ -2199,7 +2199,7 @@ SELECT_TYPES = [
             1: "Force charge",
             2: "Force discharge",
         },
-        allowedtypes=HYBRID | X3,
+        allowedtypes=HYBRID,
         icon="mdi:dip-switch",
         value_function=value_function_battery_control_override,
     ),


### PR DESCRIPTION
From https://github.com/wills106/homeassistant-solax-modbus/issues/1872#issuecomment-4214652429 I have learned that this option should also be available for 1P Solis inverters.

The OP of the issue said its fine, I can't judge as I don't have a Solis inverter.