### PR TITLE
Apply read_scale_exceptions to battery_2_power_charge

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -7287,6 +7287,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         register_type=REG_INPUT,
         register_data_type=REGISTER_S16,
         allowedtypes=HYBRID | GEN5 | GEN6,
+        read_scale_exceptions=CHARGE_SCALE_EXCEPTIONS,
         icon="mdi:battery-charging",
     ),
     SolaXModbusSensorEntityDescription(


### PR DESCRIPTION
The Solax Battery Power sensor on the energy dashboard shows for AELIO systems a wrong value because the read_scale_exceptions configuration for battery_2_power_charge is missing. 