### PR TITLE
Handle uninitialized Sofar select register values in plugin-specific validation

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -55,6 +55,12 @@ from .pymodbus_compat import DataType, convert_from_registers
 
 _LOGGER = logging.getLogger(__name__)
 
+_UNINITIALIZED_SELECT_DEFAULTS: dict[str, int] = {
+    "feedin_limitation_mode": 0,
+    "passive_mode_timeout": 0,
+    "passive_mode_timeout_action": 0,
+}
+
 """ ============================================================================================
 bitmasks  definitions to characterize inverters, organized by group
 these bitmasks are used in entity declarations to determine to which inverters the entity applies
@@ -158,6 +164,15 @@ class SofarModbusSensorEntityDescription(BaseModbusSensorEntityDescription):
     order32: str = "big"
     register_data_type: str = REGISTER_U16
     register_type: int = REG_HOLDING
+
+
+def validate_register_data(descr: Any, value: Any, datadict: dict[str, Any]) -> Any:
+    """Normalize known Sofar sentinel values before entities consume them."""
+    if value == 0xFFFF and descr.key in _UNINITIALIZED_SELECT_DEFAULTS:
+        normalized = _UNINITIALIZED_SELECT_DEFAULTS[descr.key]
+        _LOGGER.debug(f"Sofar: normalizing uninitialized register value for {descr.key} from 65535 to {normalized}")
+        return normalized
+    return value
 
 
 # ====================================== Computed value functions  =================================================

--- a/custom_components/solax_modbus/select.py
+++ b/custom_components/solax_modbus/select.py
@@ -123,12 +123,51 @@ class SolaXModbusSelect(SelectEntity):
 
     @property
     def current_option(self) -> str | None:
+        option_dict = self._option_dict or {}
+
         if self._key in self._hub.data:
             value = self._hub.data[self._key]
-            return str(value) if value is not None else None
         else:
-            initval = self.entity_description.initvalue
-            return str(initval) if initval is not None else None
+            value = self.entity_description.initvalue
+
+        if value is None:
+            return None
+
+        # If the value is already one of the select labels, return it as-is.
+        if isinstance(value, str) and value in self._attr_options:
+            return value
+
+        # Map raw register values back to the corresponding option labels.
+        if value in option_dict:
+            return option_dict[value]
+
+        # Some inverters report 65535 (-1) for uninitialized select registers.
+        # For the affected Sofar selects this is best treated like the zero option
+        # instead of exposing the select state as "unknown".
+        if value == 65535 and 0 in option_dict and self._key in {
+            "feedin_limitation_mode",
+            "passive_mode_timeout",
+            "passive_mode_timeout_action",
+        }:
+            return option_dict[0]
+
+        # Try again via integer coercion for values that may have been stored as strings/floats.
+        try:
+            int_value = int(value)
+        except (TypeError, ValueError):
+            return None
+
+        if int_value in option_dict:
+            return option_dict[int_value]
+
+        if int_value == 65535 and 0 in option_dict and self._key in {
+            "feedin_limitation_mode",
+            "passive_mode_timeout",
+            "passive_mode_timeout_action",
+        }:
+            return option_dict[0]
+
+        return None
 
     @property
     def name(self) -> str:

--- a/custom_components/solax_modbus/select.py
+++ b/custom_components/solax_modbus/select.py
@@ -141,16 +141,6 @@ class SolaXModbusSelect(SelectEntity):
         if value in option_dict:
             return option_dict[value]
 
-        # Some inverters report 65535 (-1) for uninitialized select registers.
-        # For the affected Sofar selects this is best treated like the zero option
-        # instead of exposing the select state as "unknown".
-        if value == 65535 and 0 in option_dict and self._key in {
-            "feedin_limitation_mode",
-            "passive_mode_timeout",
-            "passive_mode_timeout_action",
-        }:
-            return option_dict[0]
-
         # Try again via integer coercion for values that may have been stored as strings/floats.
         try:
             int_value = int(value)
@@ -159,13 +149,6 @@ class SolaXModbusSelect(SelectEntity):
 
         if int_value in option_dict:
             return option_dict[int_value]
-
-        if int_value == 65535 and 0 in option_dict and self._key in {
-            "feedin_limitation_mode",
-            "passive_mode_timeout",
-            "passive_mode_timeout_action",
-        }:
-            return option_dict[0]
 
         return None
 


### PR DESCRIPTION
This moves the Sofar-specific `65535` select fallback out of the generic select entity code and into `plugin_sofar.py`. Uninitialized values for affected Sofar select registers are now normalized before they reach the entity layer, while normal select read/write mapping stays generic and unchanged.

Should make it clearer for users and fix https://github.com/wills106/homeassistant-solax-modbus/issues/1936