### PR TITLE
Handle invalid list values from Modbus reads

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -1486,6 +1486,11 @@ class SolaXModbusHub:
         if self._validate_register_func is not None:
             val = self._validate_register_func(descr, val, data)
 
+        if isinstance(val, list) and descr.register_data_type != REGISTER_WORDS:
+            if self.cyclecount < VERBOSE_CYCLES:
+                _LOGGER.warning(f"{self._name}: invalid list value for numeric entity {descr.key}: {val} - setting value to None")
+            val = None
+
         if val is None:  # E.g. if errors have occurred during readout
             # _LOGGER.warning(f"****tmp*** treating {descr.key} failed")
             return_value = None


### PR DESCRIPTION
Fixes [#1968](https://github.com/wills106/homeassistant-solax-modbus/issues/1968).

Some failed or incomplete Modbus reads can return an empty list for numeric sensors. Home Assistant expects numeric sensors with a device class and unit to expose a real numeric value or None, not a list.

This change treats list values as invalid for all non-REGISTER_WORDS entities and stores None instead, preventing Home Assistant state update exceptions while keeping valid word-list sensors unchanged.