### PR TITLE
Export-First Mode: Do not cap Export-First target by inverter power

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -720,14 +720,10 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
 
         # Export limit no readscale:
         export_limit = datadict.get("export_control_user_limit", 30000)
-        inverter_limit = datadict.get("inverter_power_type", 30000)
 
-        # Both house load and exported power come from the inverter and must fit within the inverter
-        # power limit. For example if we have a 6kW inverter and 4kW of house load, then we cannot
-        # export more than 2kW even if our export limit is higher. Trim the export limit so that any
-        # excess can be used for charging the battery rather than PV being clamped.
-        export_available = max(inverter_limit - hl, 0)
-        export_limit = min(export_limit, export_available)
+        # Test mode: do not trim the export target by inverter power minus house load.
+        # This lets Export-First try to use the configured export limit directly before charging the battery.
+        export_available = export_limit
 
         # SOC bounds
         min_discharge_soc = datadict.get("selfuse_discharge_min_soc", 10)


### PR DESCRIPTION
Adjusts the Export-First Battery Limit control so the export target is based on the configured export limit instead of being reduced by inverter_power - house_load.

The previous logic could lower the effective export target too much when house load was high. This caused the controller to start charging the battery even though the inverter should still prioritize grid export.

This keeps the existing house_load_alt correction that removes current battery charging from the load basis, so battery charging is not double-counted when calculating the control target.