### PR TITLE
Add support for Growatt SPF5000ES firmware branch 113

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -9763,14 +9763,9 @@ class growatt_plugin(plugin_base):
                 invertertype = HYBRID | GEN4 | X3  # Hybrid TL3-XH (BP) 3kW - 10kW (MOD), 11kW - 30kW (MID)
             elif seriesnumber.startswith("V"):
                 invertertype = HYBRID | GEN4 | X3  # Hybrid TL3-XH 3kW - 10kW (MOD)
-            elif seriesnumber.startswith("067"):
+            # Include additional SPF5000ES firmware branches for auto-detection (e.g. 113).
+            elif seriesnumber.startswith(("067", "113", "500")):
                 invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW
-            elif seriesnumber.startswith("113):
-                invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW
-            elif seriesnumber.startswith("500"):
-                invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW
-            # elif seriesnumber.startswith('SPA'):  invertertype = AC | GEN2 | X3 # AC SPA 4kW - 10kW Could be based SPF?
-
             else:
                 invertertype = 0
                 _LOGGER.error(f"unrecognized {hub.name} inverter type - firmware version : {seriesnumber}")

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -9765,6 +9765,8 @@ class growatt_plugin(plugin_base):
                 invertertype = HYBRID | GEN4 | X3  # Hybrid TL3-XH 3kW - 10kW (MOD)
             elif seriesnumber.startswith("067"):
                 invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW
+            elif seriesnumber.startswith("113):
+                invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW
             elif seriesnumber.startswith("500"):
                 invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW
             # elif seriesnumber.startswith('SPA'):  invertertype = AC | GEN2 | X3 # AC SPA 4kW - 10kW Could be based SPF?


### PR DESCRIPTION
This PR extends the inverter auto-detection logic to include Growatt SPF5000ES devices running firmware branch 113.

Previously, only some SPF firmware identifiers (e.g. 067) were recognized, which required manual changes after each update for inverters using firmware 113.

This change adds the missing identifiers to the existing matching logic, allowing automatic detection without modifying the core behavior.

Tested on:
- Growatt SPF5000ES (firmware branch 113)

No regressions observed with existing firmware mappings.