### PR TITLE
Overhaul Mode8 Negative-Injection control loop

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -663,7 +663,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         max_step_w = int(datadict.get("export_feedback_max_w", 500) or 500)
 
         # Local copies
-        pvlimit = max(0, setpvlimit)
+        pvlimit = max(0, datadict.get("remotecontrol_current_pv_power_limit", setpvlimit))
         pushmode_power = 0  # + = discharge, - = charge
 
         # Debug inputs

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -663,7 +663,8 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         max_step_w = int(datadict.get("export_feedback_max_w", 500) or 500)
 
         # Local copies
-        cur_pvlimit = max(0, datadict.get("remotecontrol_current_pv_power_limit", setpvlimit))
+        pvlimit = setpvlimit
+        cur_pvlimit = max(0, datadict.get("remotecontrol_current_pv_power_limit", pvlimit))
         pushmode_power = 0  # + = discharge, - = charge
 
         # Debug inputs
@@ -700,7 +701,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
                 control_reason = "decrease-pv"
             else:
                 step_w = min(max_step_w, max(min_step_w, -error))
-                pvlimit = min(30000, cur_pvlimit + step_w)
+                pvlimit = min(setpvlimit, cur_pvlimit + step_w)
                 control_reason = "increase-pv"
 
             _LOGGER.debug(

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -563,6 +563,13 @@ def autorepeat_bms_charge(datadict: dict[str, Any], battery_capacity: float, max
     except Exception:
         f = 1.0
 
+    # Near full charge rate limit
+    chargeable_soc = max(0, max_charge_soc - battery_capacity)
+    if chargeable_soc <= 4:
+        # For last few % of charge, further reduce the rate limit to account
+        # for non-ideal charging curves and reduce battery wear
+        f = f * (float(chargeable_soc + 2.0) / 6.0)
+
     # BMS charge capability approximation
     bms_a = datadict.get("bms_charge_max_current", None)
     batt_v = (

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -631,18 +631,88 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
 
     if power_control == "Mode 8 - PV and BAT control - Duration":
         pvlimit = setpvlimit  # import capping is done later
-    elif power_control == "Negative Injection Price":  # grid export zero; PV restricted to house_load and battery charge
-        datadict.get("measured_power", 0)  # positive for export, negative for import - for future correction purposes
-        houseload = max(0, houseload)
-        if battery_capacity >= 92:
-            pvlimit = houseload + abs(setpvlimit) * (100.0 - battery_capacity) / 15.0 + 60  # slow down charging - nearly full
-        else:
-            pvlimit = setpvlimit + houseload + 60  # inverter overhead 40
-        pvlimit = max(houseload, pvlimit)
-        pushmode_power = houseload - min(pv, pvlimit) - 90 + pv / 14  # some kind of empiric correction for losses - machine learning would be better
+    elif power_control == "Negative Injection Price":
+        # --- Negative Injection Price (Mode 8 custom) ---
+        # Controller goals:
+        # 1) If PV < house load (deficit): discharge the battery up to the deficit (respecting min SOC),
+        #    aiming to prefer a slight grid import bias over export bias.
+        # 2) If PV ≥ house load (surplus): let PV feed the battery first. PV limit is then adjusted using
+        #    bounded step changes based on the measured power to prevent export.
+
+        # Use the alternative house load basis, but remove the current battery charging
+        # component again. house_load_alt includes battery charging as part of "load",
+        # which makes the regulator subtract its own charging command from the available
+        # export headroom and settle too early below the export target.
+        battery_charge = max(0, int(datadict.get("battery_power_charge", 0) or 0))
+        hl = max(0, int(houseload_alt) - battery_charge)
+
+        # SOC bounds
+        min_discharge_soc = datadict.get("selfuse_discharge_min_soc", 10)
+        max_charge_soc = datadict.get("battery_charge_upper_soc", 100)
+        # bias towards import
+        export_target = int(datadict.get("negative_injection_bias", -20) or -20)
+        export_deadband_w = int(datadict.get("export_feedback_deadband_w", 50) or 50)
+        min_step_w = int(datadict.get("export_first_step_min_w", 100) or 100)
+        max_step_w = int(datadict.get("export_feedback_max_w", 500) or 500)
+
+        # Local copies
+        pvlimit = max(0, setpvlimit)
+        pushmode_power = 0  # + = discharge, - = charge
+
+        # Debug inputs
         _LOGGER.debug(
-            f"***debug*** setpvlimit: {setpvlimit} pvlimit: {pvlimit} pushmode: {pushmode_power} houseload:{houseload} pv: {pv} batcap: {battery_capacity}"
+            f"[Mode8 Negative Injection] inputs pv={pv}W hl={houseload}W imp_lim={import_limit}W soc={battery_capacity}% "
+            f"min_soc={min_discharge_soc}% max_soc={max_charge_soc}% pvlimit={pvlimit}W battery_charge={battery_charge}W"
         )
+
+        # Optional probes (if available)
+        measured_power = datadict.get("measured_power", None)
+        _LOGGER.debug(f"[Mode8 Negative Injection] probes: measured_power={measured_power if measured_power is not None else 'n/a'} ")
+
+        if pv >= hl or setpvlimit < hl:
+            # Surplus or limited pv path: battery is requested to charge at up to the rate
+            # limit from PV alone then use measured export as the control signal to adjust PV limit.
+            # Below target: PV should be reduced to prevent export.
+            # At/above target: PV can be increased to reduce import in bounded steps.
+            surplus = max(0, pv - hl)
+            measured_power = int(measured_power or 0)
+            error = measured_power - export_target
+
+            # Battery gets surplus up to BMS limit
+            desired_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
+
+            if abs(error) <= export_deadband_w:
+                step_w = 0
+                pvlimit = setpvlimit
+                control_reason = "hold"
+            elif error > 0:
+                step_w = min(max_step_w, max(min_step_w, error))
+                pvlimit = max(0, setpvlimit - step_w)
+                control_reason = "decrease-pv"
+            else:
+                step_w = min(max_step_w, max(min_step_w, -error))
+                pvlimit = min(30000, setpvlimit + step_w)
+                control_reason = "increase-pv"
+
+            _LOGGER.debug(
+                f"[Mode8 Negative Injection] charge-first: surplus={surplus}W measured_power={measured_power}W "
+                f"export_target={export_target}W error={error}W step={step_w}W reason={control_reason} "
+                f"bms_cap≈{bms_cap_w}W pct_cap={pct_cap_w}W -> charge={desired_charge}W pvlimit={pvlimit}W hl={hl}W"
+            )
+
+        else:
+            # Deficit path: discharge battery up to the current house deficit (if SOC allows).
+            # Note this is only reached if pvlimit has been restored to above the house load by
+            # the limited pv path and we therefore have insufficient PV to cover the load.
+            deficit = hl + export_target - pv
+            if battery_capacity > min_discharge_soc:
+                pushmode_power = min(deficit, 30000)
+            else:
+                pushmode_power = 0
+            _LOGGER.debug(
+                f"[Mode8 Negative Injection] deficit: deficit={deficit}W export_target={export_target}W "
+                f"soc={battery_capacity}% chosen_push={pushmode_power}W"
+            )
 
     elif power_control == "Negative Injection and Consumption Price":  # disable PV, charge from grid
         pvlimit = 0

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -646,12 +646,8 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         # 2) If PV ≥ house load (surplus): let PV feed the battery first. PV limit is then adjusted using
         #    bounded step changes based on the measured power to prevent export.
 
-        # Use the alternative house load basis, but remove the current battery charging
-        # component again. house_load_alt includes battery charging as part of "load",
-        # which makes the regulator subtract its own charging command from the available
-        # export headroom and settle too early below the export target.
-        battery_charge = max(0, int(datadict.get("battery_power_charge", 0) or 0))
-        hl = max(0, int(houseload_alt) - battery_charge)
+        # Use the alternative house load for house load measurement, clamping to strict positive values.
+        hl = max(0, int(houseload_alt))
 
         # SOC bounds
         min_discharge_soc = datadict.get("selfuse_discharge_min_soc", 10)
@@ -663,6 +659,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         max_step_w = int(datadict.get("export_feedback_max_w", 500) or 500)
 
         # Local copies
+        battery_charge = max(0, int(datadict.get("battery_power_charge", 0) or 0))
         pvlimit = setpvlimit
         cur_pvlimit = max(0, datadict.get("remotecontrol_current_pv_power_limit", pvlimit))
         pushmode_power = 0  # + = discharge, - = charge

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -685,6 +685,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
             surplus = max(0, pv - hl)
             measured_power = int(measured_power or 0)
             error = measured_power - export_target
+            control_state = "surplus" if pv >= hl else "clipping"
 
             # Battery gets surplus up to BMS limit
             desired_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
@@ -704,7 +705,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
                 control_reason = "increase-pv"
 
             _LOGGER.debug(
-                f"[Mode8 Negative Injection] charge-first: surplus={surplus}W measured_power={measured_power}W "
+                f"[Mode8 Negative Injection] {control_state}: surplus={surplus}W measured_power={measured_power}W "
                 f"export_target={export_target}W error={error}W step={step_w}W reason={control_reason} "
                 f"bms_cap≈{bms_cap_w}W pct_cap={pct_cap_w}W -> charge={desired_charge}W pvlimit={pvlimit}W hl={hl}W"
             )

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -661,7 +661,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         # Local copies
         battery_charge = max(0, int(datadict.get("battery_power_charge", 0) or 0))
         pvlimit = setpvlimit
-        cur_pvlimit = max(0, datadict.get("remotecontrol_current_pv_power_limit", pvlimit))
+        cur_pvlimit = max(0, setpvlimit if (cur_pvlimit := datadict.get("remotecontrol_current_pv_power_limit", None)) is None else cur_pvlimit)
         pushmode_power = 0  # + = discharge, - = charge
 
         # Debug inputs

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -678,11 +678,13 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         measured_power = datadict.get("measured_power", None)
         _LOGGER.debug(f"[Mode8 Negative Injection] probes: measured_power={measured_power if measured_power is not None else 'n/a'} ")
 
-        if pv >= hl or cur_pvlimit < hl:
+        if pv >= hl or cur_pvlimit < setpvlimit:
             # Surplus or limited pv path: battery is requested to charge at up to the rate
             # limit from PV alone then use measured export as the control signal to adjust PV limit.
             # Below target: PV should be reduced to prevent export.
             # At/above target: PV can be increased to reduce import in bounded steps.
+            # If PV has been limited below the setpoint and is now below house load, continue in this
+            # loop to release PV restriction slowly.
             surplus = max(0, pv - hl)
             measured_power = int(measured_power or 0)
             error = measured_power - export_target

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -668,8 +668,9 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
 
         # Debug inputs
         _LOGGER.debug(
-            f"[Mode8 Negative Injection] inputs pv={pv}W hl={houseload}W imp_lim={import_limit}W soc={battery_capacity}% "
-            f"min_soc={min_discharge_soc}% max_soc={max_charge_soc}% pvlimit={pvlimit}W battery_charge={battery_charge}W"
+            f"[Mode8 Negative Injection] inputs pv={pv}W hl={houseload}W hl_alt={houseload_alt}W (using hl) imp_lim={import_limit}W "
+            f"soc={battery_capacity}% min_soc={min_discharge_soc}% max_soc={max_charge_soc}% pvlimit={pvlimit}W "
+            f"battery_charge={battery_charge}W"
         )
 
         # Optional probes (if available)

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -663,13 +663,13 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         max_step_w = int(datadict.get("export_feedback_max_w", 500) or 500)
 
         # Local copies
-        pvlimit = max(0, datadict.get("remotecontrol_current_pv_power_limit", setpvlimit))
+        cur_pvlimit = max(0, datadict.get("remotecontrol_current_pv_power_limit", setpvlimit))
         pushmode_power = 0  # + = discharge, - = charge
 
         # Debug inputs
         _LOGGER.debug(
             f"[Mode8 Negative Injection] inputs pv={pv}W hl={houseload}W hl_alt={houseload_alt}W (using hl) imp_lim={import_limit}W "
-            f"soc={battery_capacity}% min_soc={min_discharge_soc}% max_soc={max_charge_soc}% pvlimit={pvlimit}W "
+            f"soc={battery_capacity}% min_soc={min_discharge_soc}% max_soc={max_charge_soc}% cur_pvlimit={cur_pvlimit}W "
             f"battery_charge={battery_charge}W"
         )
 
@@ -677,7 +677,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         measured_power = datadict.get("measured_power", None)
         _LOGGER.debug(f"[Mode8 Negative Injection] probes: measured_power={measured_power if measured_power is not None else 'n/a'} ")
 
-        if pv >= hl or setpvlimit < hl:
+        if pv >= hl or cur_pvlimit < hl:
             # Surplus or limited pv path: battery is requested to charge at up to the rate
             # limit from PV alone then use measured export as the control signal to adjust PV limit.
             # Below target: PV should be reduced to prevent export.
@@ -692,15 +692,15 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
 
             if abs(error) <= export_deadband_w:
                 step_w = 0
-                pvlimit = setpvlimit
+                pvlimit = cur_pvlimit
                 control_reason = "hold"
             elif error > 0:
                 step_w = min(max_step_w, max(min_step_w, error))
-                pvlimit = max(0, setpvlimit - step_w)
+                pvlimit = max(0, cur_pvlimit - step_w)
                 control_reason = "decrease-pv"
             else:
                 step_w = min(max_step_w, max(min_step_w, -error))
-                pvlimit = min(30000, setpvlimit + step_w)
+                pvlimit = min(30000, cur_pvlimit + step_w)
                 control_reason = "increase-pv"
 
             _LOGGER.debug(

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -688,6 +688,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
 
             # Battery gets surplus up to BMS limit
             desired_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
+            pushmode_power = -desired_charge
 
             if abs(error) <= export_deadband_w:
                 step_w = 0


### PR DESCRIPTION
The previous control loop would fail if the maximum battery SoC was not 100% as it would keep trying to charge the battery from PV even through the battery is full. The net result is the power that was expected to charge the battery would actually be a grid export completely defeating the aim of the loop.

Now, using inspiration from the Export-First control loop, we have a control loop which uses the grid measured power as the input and pvlimit as the output. We still try to charge the battery as much as possible with surplus PV, but will temper the PV output if grid export is detected.

A tuneable bias is added to try to target a slight grid import as we want to prioritise no export over a slight import.

This is an attempt to fix #1945 whilst also improving the control loop behaviour.