### PR TITLE
Fix firmware version display for X3-MIC GEN2, Hybrid GEN4/5/6 and EVC GEN1

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1240,6 +1240,14 @@ def value_function_software_version_g5(initval: int, descr: Any, datadict: dict[
     )
 
 
+def value_function_software_version_full(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
+    dsp = datadict.get('firmware_version_dsp')
+    arm = datadict.get('firmware_version_arm')
+    if dsp is None or arm is None:
+        return None
+    return f"DSP {dsp // 100}.{dsp % 100:02d} ARM {arm // 100}.{arm % 100:02d}"
+
+
 def value_function_software_version_air_g3(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
     return f"DSP v2.{datadict.get('firmware_dsp')} ARM v1.{datadict.get('firmware_arm')}"
 
@@ -3878,6 +3886,18 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         icon="mdi:dip-switch",
     ),
     SolaXModbusSensorEntityDescription(
+        key="firmware_version_dsp",
+        register=0x7B,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
+        key="firmware_version_arm",
+        register=0x7C,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
         key="firmware_dsp",
         register=0x7D,
         allowedtypes=AC | HYBRID,
@@ -3905,19 +3925,10 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(
-        name="Firmware Version Modbus TCP Major",
-        key="firmwareversion_modbustcp_major",
+        name="Modbus Protocol Version",
+        key="modbus_protocol_version",
         entity_registry_enabled_default=False,
-        register=0x81,
-        allowedtypes=AC | HYBRID | GEN5,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:information",
-    ),
-    SolaXModbusSensorEntityDescription(
-        name="Firmware Version Modbus TCP Minor",
-        key="firmwareversion_modbustcp_minor",
-        entity_registry_enabled_default=False,
-        allowedtypes=AC | HYBRID | GEN5,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         register=0x82,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:information",
@@ -8243,13 +8254,13 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     ),
     SolaXModbusSensorEntityDescription(
         key="software_version",
-        value_function=value_function_software_version_g4,
+        value_function=value_function_software_version_full,
         allowedtypes=AC | HYBRID | GEN4,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(
         key="software_version",
-        value_function=value_function_software_version_g5,
+        value_function=value_function_software_version_full,
         allowedtypes=AC | HYBRID | GEN5 | GEN6,
         internal=True,
     ),
@@ -9707,11 +9718,17 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     ),
     SolaXModbusSensorEntityDescription(
         key="software_version",
-        value_function=value_function_software_version_g4,
-        allowedtypes=MIC | GEN | GEN2 | X3,
+        value_function=value_function_software_version_air_g4,
+        allowedtypes=MIC | GEN | X3,
         blacklist=[
             "MU802T",
         ],
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
+        key="software_version",
+        value_function=value_function_software_version_g2,
+        allowedtypes=MIC | GEN2 | X3,
         internal=True,
     ),
 ]
@@ -10210,7 +10227,6 @@ class solax_plugin(plugin_base):
         elif seriesnumber.startswith("MC208T"):
             invertertype = MIC | GEN2 | X3  # MIC X3
             self.inverter_model = "X3-MIC"
-            self.software_version = "Unknown"
         elif seriesnumber.startswith("MC210T"):
             invertertype = MIC | GEN2 | X3  # MIC X3
             self.inverter_model = "X3-MIC"

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -8255,13 +8255,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     SolaXModbusSensorEntityDescription(
         key="software_version",
         value_function=value_function_software_version_full,
-        allowedtypes=AC | HYBRID | GEN4,
-        internal=True,
-    ),
-    SolaXModbusSensorEntityDescription(
-        key="software_version",
-        value_function=value_function_software_version_full,
-        allowedtypes=AC | HYBRID | GEN5 | GEN6,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1243,9 +1243,9 @@ def value_function_software_version_g5(initval: int, descr: Any, datadict: dict[
 def value_function_software_version_full(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
     dsp = datadict.get('firmware_version_dsp')
     arm = datadict.get('firmware_version_arm')
-    if dsp is None or arm is None:
-        return None
-    return f"DSP {dsp // 100}.{dsp % 100:02d} ARM {arm // 100}.{arm % 100:02d}"
+    dsp_str = f"{dsp // 100}.{dsp % 100:02d}" if dsp is not None else "?.??"
+    arm_str = f"{arm // 100}.{arm % 100:02d}" if arm is not None else "?.??"
+    return f"DSP {dsp_str} ARM {arm_str}"
 
 
 def value_function_software_version_air_g3(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:

--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -975,7 +975,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         register=0x25,
         register_type=REG_INPUT,
         icon="mdi:numeric",
-        allowedtypes=GEN2,
+        allowedtypes=GEN1 | GEN2,
         register_data_type=REGISTER_U16,
         scale=value_function_firmware_decimal_hundredths,
     ),


### PR DESCRIPTION
## What changed

**plugin_solax.py — Hybrid / MIC inverters:**

- **Fix X3-MIC GEN2 firmware display** — was showing `DSP ?.136 ARM ?.136` because `value_function_software_version_g4` was applied to all MIC X3 devices, but that function reads `firmware_dsp_major` (FC03 0x7F) which only exists on AC/HYBRID. Split the MIC X3 `software_version` sensor into two entries: GEN1 uses `value_function_software_version_air_g4` (plain `DSP 136 ARM 136`), GEN2 uses `value_function_software_version_g2` (formatted `DSP v2.136 ARM v2.136`). `MU802T` blacklist moved to the GEN1 entry where it belongs.
- **Add FC03 0x7B / 0x7C** (`firmware_version_dsp` / `firmware_version_arm`) as internal sensors for `AC | HYBRID | GEN4 | GEN5 | GEN6` — these are the PDF-documented full-version registers (`FirmwareVersionDSP = DSPMajor×100+DSPMinor`). New `value_function_software_version_full` decodes them cleanly (e.g. raw 157 → `1.57`). GEN4 and GEN5/GEN6 `software_version` now use this function instead of the 4-register split approach. Degrades gracefully to `DSP ?.?? ARM ?.??` if a register read fails.
- **Remove FC03 0x81** (`firmwareversion_modbustcp_major`) — not present in Modbus RTU V1.02 documentation; confirmed always returns 0 on live hardware (X3-Hybrid G4 PRO).
- **Rename FC03 0x82** from `firmwareversion_modbustcp_minor` → `modbus_protocol_version` — this register holds the Modbus protocol document version (e.g. 100 = V001.00), not a TCP firmware version. Extended `allowedtypes` to include GEN4/GEN5/GEN6.
- **Remove dead code** — `self.software_version = "Unknown"` in the `MC208T` branch of `async_determineInverterType` (field is never read).

**plugin_solax_ev_charger.py — EV Charger:**

- **Fix EVC GEN1 firmware sensor** — FC04 0x25 (`firmware_version`) was restricted to `allowedtypes=GEN2` only. GEN1 devices (C311/C322 series with firmware < 7.0) respond correctly to this register. Confirmed live on X3-EVC-11kW GEN1 returning raw 117 → `1.17`.

## Why

- The MIC GEN2 display bug affects all X3-MIC GEN2 users — the `?` major version was caused by a missing register, not a firmware issue.
- Registers 0x7B/0x7C are the primary firmware version registers documented in the official SolaX Modbus RTU V1.02 spec; the split approach reading four registers separately was working but unnecessarily complex for GEN4+.
- Register 0x81 was never in any official documentation and is always 0 — it caused confusion with the misnamed 0x82.
- EVC GEN1 users had no firmware version visible in HA despite the register being fully readable.

## Tested on live hardware

| Device | Serial prefix | Result |
|---|---|---|
| X3-MIC (GEN2) | MC208T | `DSP v2.136 ARM v2.136` ✓ |
| X3-Hybrid G4 PRO 15kW (GEN4) | H34A15 | `DSP 1.57 ARM 1.56` ✓ |
| X3-EVC-11kW (GEN1) | C31103 | `sensor.ev_firmware_version: 1.17` ✓ |

**Reference:** SolaX Hybrid X1&X3 ESS Modbus RTU V1.02 (Nov 2025) — registers 0x7B, 0x7C, 0x7D, 0x7F, 0x80, 0x82, 0x83