### PR TITLE
Add Growatt SPF energy dashboard mapping

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,60 @@
+## Summary
+- add an SPF-specific Energy Dashboard mapping for Growatt off-grid models
+- suppress PV2 entities on known single-MPPT SPF serial families
+- add computed SPF solar total sensors used by the Energy Dashboard mapping
+- prefer real serial prefixes (including `KAM`) over firmware-branch-only fallback detection
+- hide unused Energy Dashboard diagnostic metadata sensors by default
+
+## Why
+Growatt SPF off-grid units expose semantics that do not match the existing grid-tied mappings.
+On the validated SPF5000ES setup used for testing:
+- `ac_input_power` reflects grid/bypass input
+- `ac_discharge_power` reflects AC power served to loads
+- `battery_power_charge` is signed (`+` discharge, `-` charge)
+- PV2 is not physically present on these single-MPPT units
+
+Without an SPF-specific mapping, Home Assistant creates Energy Dashboard helpers that are incomplete or misleading for this inverter family.
+
+## What changed
+### Growatt SPF detection and entity filtering
+- add `KAM` to the known single-MPPT SPF serial prefixes
+- keep `067` / `113` / `500` only as fallback branch detection when a real serial prefix is unavailable
+- blacklist PV2 sensors and PV2 energy counters for known single-MPPT SPF families
+- make serial parsing more robust by decoding the raw register bytes directly
+
+### SPF computed totals
+- add computed `pv_power_total`
+- add computed `today_s_solar_energy`
+- add computed `total_solar_energy`
+
+### Energy Dashboard mapping
+Add a Growatt `ENERGY_DASHBOARD_MAPPING` limited to `allowedtypes=SPF`:
+- `grid_power` <- `ac_input_power`
+- `solar_power` <- `pv_power_total`
+- `battery_power` <- `battery_power_charge`
+- `home_consumption_power` <- `ac_discharge_power`
+- `grid_to_battery_power` <- `ac_charge_power`
+- `grid_energy_import` <- Riemann sum of positive `ac_input_power`
+- `solar_energy_production` <- `today_s_solar_energy`
+- `home_consumption_energy` <- `today_s_ac_discharge`
+- `battery_energy_charge` <- Riemann sum of charge-only portion of `battery_power_charge`
+- `battery_energy_discharge` <- `today_s_battery_discharge`
+- `grid_to_battery_energy` <- `today_s_ac_charge`
+
+Intentionally not mapped:
+- `grid_energy_export`
+
+### Energy Dashboard metadata sensors
+Set the diagnostic metadata sensors to `entity_registry_enabled_default=False` so fresh installs do not expose unused `Unknown` metadata entities by default.
+
+## Validation
+- `python3 -m py_compile custom_components/solax_modbus/plugin_growatt.py custom_components/solax_modbus/energy_dashboard.py`
+- `git diff --check`
+- live validation on two parallel Growatt SPF5000ES units in Home Assistant:
+  - serial prefixes observed as `KAM...`
+  - PV2 absent physically and suppressed as expected
+  - `battery_soc`, `pv_power_1`, `grid_voltage`, `grid_frequency`, `output_voltage`, `output_frequency`, `battery_voltage`, and temperature sensors match live readings
+  - Energy Dashboard source entities update coherently with local system templates
+
+## Notes
+This keeps the PR scoped to SPF/off-grid semantics and avoids inventing unsupported grid export behaviour for systems that do not export to grid.

--- a/custom_components/solax_modbus/energy_dashboard.py
+++ b/custom_components/solax_modbus/energy_dashboard.py
@@ -360,6 +360,7 @@ def _create_energy_dashboard_diagnostic_sensors(
             allowedtypes=hub._invertertype,
             icon="mdi:swap-horizontal",
             entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
         ),
         BaseModbusSensorEntityDescription(
             key="energy_dashboard_inverter_count",
@@ -369,6 +370,7 @@ def _create_energy_dashboard_diagnostic_sensors(
             allowedtypes=hub._invertertype,
             icon="mdi:counter",
             entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
         ),
     ]
 
@@ -406,6 +408,7 @@ def _create_energy_dashboard_diagnostic_sensors(
                 allowedtypes=hub._invertertype,
                 icon="mdi:shuffle-variant",
                 entity_category=EntityCategory.DIAGNOSTIC,
+                entity_registry_enabled_default=False,
             )
         )
 

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -48,7 +48,7 @@ from custom_components.solax_modbus.const import (  # type: ignore[attr-defined]
     value_function_sync_rtc_ymd,
 )
 
-from .pymodbus_compat import DataType, convert_from_registers
+from .energy_dashboard import EnergyDashboardMapping, EnergyDashboardSensorMapping
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,6 +95,11 @@ ALL_MPPT_GROUP = MPPT3 | MPPT4 | MPPT6 | MPPT8 | MPPT10
 
 ALLDEFAULT = 0  # should be equivalent to HYBRID | AC | GEN | GEN2 | GEN3 | GEN4 | X1 | X3
 
+# SPF models known to expose only one PV input / MPPT even if the generic SPF block defines PV2 sensors.
+# Prefer real serial prefixes when available (e.g. KAM observed live on Simone's SPF5000ES units);
+# keep firmware-branch fallbacks for installations where only legacy family identifiers are exposed.
+SPF_SINGLE_MPPT_SERIAL_PREFIXES = ["YRE", "TTJ", "BNJ", "KAM", "067", "113", "500"]
+
 # ======================= end of bitmask handling code =============================================
 
 # ====================== find inverter type and details ===========================================
@@ -105,9 +110,12 @@ async def async_read_serialnr(hub: Any, address: int) -> str | None:
     try:
         inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=address, count=5)
         if inverter_data and not inverter_data.isError():
-            raw = convert_from_registers(inverter_data.registers[0:5], DataType.STRING, "big")  # type: ignore[attr-defined]  # Dynamic enum aliasing
-            res = raw.decode("ascii", errors="ignore") if isinstance(raw, (bytes, bytearray)) else str(raw)
-            hub.seriesnumber = res
+            raw_bytes = bytearray()
+            for register in inverter_data.registers[0:5]:
+                raw_bytes.extend(int(register).to_bytes(2, byteorder="big", signed=False))
+            res = raw_bytes.decode("ascii", errors="ignore").rstrip("\x00").strip() or None
+            if res:
+                hub.seriesnumber = res
     except Exception:
         _LOGGER.warning(f"{hub.name}: attempt to read firmware failed at 0x{address:x}", exc_info=True)
     if not res:
@@ -385,6 +393,18 @@ def value_function_combined_bms_current(initval: int, descr: Any, datadict: dict
     else:
         result = 0
     return result
+
+
+def value_function_spf_pv_power_total(initval: Any, descr: Any, datadict: dict[str, Any]) -> int | float:
+    return float(datadict.get("pv_power_1", 0) or 0) + float(datadict.get("pv_power_2", 0) or 0)
+
+
+def value_function_spf_today_s_solar_energy(initval: Any, descr: Any, datadict: dict[str, Any]) -> int | float:
+    return float(datadict.get("today_s_solar_energy_pv1", 0) or 0) + float(datadict.get("today_s_solar_energy_pv2", 0) or 0)
+
+
+def value_function_spf_total_solar_energy(initval: Any, descr: Any, datadict: dict[str, Any]) -> int | float:
+    return float(datadict.get("total_solar_energy_pv1", 0) or 0) + float(datadict.get("total_solar_energy_pv2", 0) or 0)
 
 
 def value_function_module_status(initval: int, descr: Any, datadict: dict[str, Any]) -> str:
@@ -3100,9 +3120,9 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         key="grid_status",
         name="Grid Status",
         allowedtypes=GEN4,
-        value_function=lambda initval, descr, datadict: "Off (Výpadek - z baterie)"
-        if (datadict.get("register_3000", 0) & 0xFF) == 2
-        else "On (connected to net)",
+        value_function=lambda initval, descr, datadict: (
+            "Off (Výpadek - z baterie)" if (datadict.get("register_3000", 0) & 0xFF) == 2 else "On (connected to net)"
+        ),
         icon="mdi:transmission-tower",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -8989,6 +9009,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         scale=0.1,
         rounding=1,
         allowedtypes=SPF,
+        blacklist=SPF_SINGLE_MPPT_SERIAL_PREFIXES,
     ),
     GrowattModbusSensorEntityDescription(
         name="PV Power 1",
@@ -9016,6 +9037,18 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         scale=0.1,
         rounding=1,
         allowedtypes=SPF,
+        blacklist=SPF_SINGLE_MPPT_SERIAL_PREFIXES,
+        icon="mdi:solar-power-variant",
+    ),
+    GrowattModbusSensorEntityDescription(
+        name="PV Power Total",
+        key="pv_power_total",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        register=-1,
+        value_function=value_function_spf_pv_power_total,
+        allowedtypes=SPF,
         icon="mdi:solar-power-variant",
     ),
     GrowattModbusSensorEntityDescription(
@@ -9040,6 +9073,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         scale=0.1,
         rounding=1,
         allowedtypes=SPF,
+        blacklist=SPF_SINGLE_MPPT_SERIAL_PREFIXES,
         icon="mdi:current-dc",
     ),
     GrowattModbusSensorEntityDescription(
@@ -9338,6 +9372,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         scale=0.1,
         rounding=2,
         allowedtypes=SPF,
+        blacklist=SPF_SINGLE_MPPT_SERIAL_PREFIXES,
     ),
     GrowattModbusSensorEntityDescription(
         name="Total Solar Energy PV2",
@@ -9350,6 +9385,31 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         register_type=REG_INPUT,
         register_data_type=REGISTER_S32,
         scale=0.1,
+        rounding=2,
+        allowedtypes=SPF,
+        blacklist=SPF_SINGLE_MPPT_SERIAL_PREFIXES,
+    ),
+    GrowattModbusSensorEntityDescription(
+        name="Today's Solar Energy",
+        key="today_s_solar_energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:solar-power",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        register=-1,
+        value_function=value_function_spf_today_s_solar_energy,
+        rounding=2,
+        allowedtypes=SPF,
+    ),
+    GrowattModbusSensorEntityDescription(
+        name="Total Solar Energy",
+        key="total_solar_energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:solar-power",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        register=-1,
+        value_function=value_function_spf_total_solar_energy,
         rounding=2,
         allowedtypes=SPF,
     ),
@@ -9638,6 +9698,8 @@ class growatt_plugin(plugin_base):
             invertertype = HYBRID | SPF | X1  # SPF 5000 ES, 1 MPPT
         elif seriesnumber.startswith("BNJ"):
             invertertype = HYBRID | SPF | X1  # SPF 3000 TL LVM 24P, 1 MPPT
+        elif seriesnumber.startswith("KAM"):
+            invertertype = HYBRID | SPF | X1  # SPF 5000 ES observed live, 1 MPPT
         elif seriesnumber.startswith("NUK"):
             invertertype = HYBRID | SPF | X1  # SPF 12000T DVM-US MPV, 2 MPPT
 
@@ -9763,9 +9825,9 @@ class growatt_plugin(plugin_base):
                 invertertype = HYBRID | GEN4 | X3  # Hybrid TL3-XH (BP) 3kW - 10kW (MOD), 11kW - 30kW (MID)
             elif seriesnumber.startswith("V"):
                 invertertype = HYBRID | GEN4 | X3  # Hybrid TL3-XH 3kW - 10kW (MOD)
-            # Include additional SPF5000ES firmware branches for auto-detection (e.g. 113).
+            # Include additional SPF5000ES firmware branches only as fallback when the real serial prefix is unavailable.
             elif seriesnumber.startswith(("067", "113", "500")):
-                invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW
+                invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW / SPF5000ES branch, treated as 1 MPPT
             else:
                 invertertype = 0
                 _LOGGER.error(f"unrecognized {hub.name} inverter type - firmware version : {seriesnumber}")
@@ -9802,6 +9864,86 @@ class growatt_plugin(plugin_base):
         return (genmatch and xmatch and hybmatch and epsmatch and dcbmatch and mpptmatch) and not blacklisted
 
 
+ENERGY_DASHBOARD_MAPPING = EnergyDashboardMapping(
+    plugin_name="growatt",
+    mappings=[
+        EnergyDashboardSensorMapping(
+            source_key="ac_input_power",
+            target_key="grid_power",
+            name="Grid Power",
+            icon="mdi:transmission-tower-import",
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="pv_power_total",
+            target_key="solar_power",
+            name="Solar Power",
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="battery_power_charge",
+            target_key="battery_power",
+            name="Battery Power",
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="ac_discharge_power",
+            target_key="home_consumption_power",
+            name="Home Consumption Power",
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="ac_charge_power",
+            target_key="grid_to_battery_power",
+            name="Grid to Battery Power",
+            icon="mdi:transmission-tower-export",
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="ac_input_power",
+            target_key="grid_energy_import",
+            name="Grid Import Energy",
+            use_riemann_sum=True,
+            filter_function=lambda v: max(0, v),
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="today_s_solar_energy",
+            target_key="solar_energy_production",
+            name="Solar Production Energy",
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="today_s_ac_discharge",
+            target_key="home_consumption_energy",
+            name="Home Consumption Energy",
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="battery_power_charge",
+            target_key="battery_energy_charge",
+            name="Battery Charge Energy",
+            use_riemann_sum=True,
+            filter_function=lambda v: abs(min(0, v)),
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="today_s_battery_discharge",
+            target_key="battery_energy_discharge",
+            name="Battery Discharge Energy",
+            allowedtypes=SPF,
+        ),
+        EnergyDashboardSensorMapping(
+            source_key="today_s_ac_charge",
+            target_key="grid_to_battery_energy",
+            name="Grid to Battery Energy",
+            icon="mdi:transmission-tower-export",
+            allowedtypes=SPF,
+        ),
+    ],
+)
+
+
 plugin_instance = growatt_plugin(
     plugin_name="Growatt",
     plugin_manufacturer="Growatt New Energy",
@@ -9811,6 +9953,7 @@ plugin_instance = growatt_plugin(
     SELECT_TYPES=SELECT_TYPES,
     SWITCH_TYPES=[],
     TIME_TYPES=[],
+    ENERGY_DASHBOARD_MAPPING=ENERGY_DASHBOARD_MAPPING,
     block_size=100,
     # order16 = "big",
     order32="big",


### PR DESCRIPTION
## Summary
- add an SPF-specific Energy Dashboard mapping for Growatt off-grid models
- suppress PV2 entities on known single-MPPT SPF serial families
- add computed SPF solar total sensors used by the Energy Dashboard mapping
- prefer real serial prefixes (including `KAM`) over firmware-branch-only fallback detection
- hide unused Energy Dashboard diagnostic metadata sensors by default

## Why
Growatt SPF off-grid units expose semantics that do not match the existing grid-tied mappings.
On the validated SPF5000ES setup used for testing:
- `ac_input_power` reflects grid/bypass input
- `ac_discharge_power` reflects AC power served to loads
- `battery_power_charge` is signed (`+` discharge, `-` charge)
- PV2 is not physically present on these single-MPPT units

Without an SPF-specific mapping, Home Assistant creates Energy Dashboard helpers that are incomplete or misleading for this inverter family.

## What changed
### Growatt SPF detection and entity filtering
- add `KAM` to the known single-MPPT SPF serial prefixes
- keep `067` / `113` / `500` only as fallback branch detection when a real serial prefix is unavailable
- blacklist PV2 sensors and PV2 energy counters for known single-MPPT SPF families
- make serial parsing more robust by decoding the raw register bytes directly

### SPF computed totals
- add computed `pv_power_total`
- add computed `today_s_solar_energy`
- add computed `total_solar_energy`

### Energy Dashboard mapping
Add a Growatt `ENERGY_DASHBOARD_MAPPING` limited to `allowedtypes=SPF`:
- `grid_power` <- `ac_input_power`
- `solar_power` <- `pv_power_total`
- `battery_power` <- `battery_power_charge`
- `home_consumption_power` <- `ac_discharge_power`
- `grid_to_battery_power` <- `ac_charge_power`
- `grid_energy_import` <- Riemann sum of positive `ac_input_power`
- `solar_energy_production` <- `today_s_solar_energy`
- `home_consumption_energy` <- `today_s_ac_discharge`
- `battery_energy_charge` <- Riemann sum of charge-only portion of `battery_power_charge`
- `battery_energy_discharge` <- `today_s_battery_discharge`
- `grid_to_battery_energy` <- `today_s_ac_charge`

Intentionally not mapped:
- `grid_energy_export`

### Energy Dashboard metadata sensors
Set the diagnostic metadata sensors to `entity_registry_enabled_default=False` so fresh installs do not expose unused `Unknown` metadata entities by default.

## Validation
- `python3 -m py_compile custom_components/solax_modbus/plugin_growatt.py custom_components/solax_modbus/energy_dashboard.py`
- `git diff --check`
- live validation on two parallel Growatt SPF5000ES units in Home Assistant:
  - serial prefixes observed as `KAM...`
  - PV2 absent physically and suppressed as expected
  - `battery_soc`, `pv_power_1`, `grid_voltage`, `grid_frequency`, `output_voltage`, `output_frequency`, `battery_voltage`, and temperature sensors match live readings
  - Energy Dashboard source entities update coherently with local system templates

## Notes
This keeps the PR scoped to SPF/off-grid semantics and avoids inventing unsupported grid export behaviour for systems that do not export to grid.
