### PR TITLE
fix(solax): add missing H3BC20L/H3BD20L/H3BF20L/H3BG20L serial patterns with MPPT3

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -10026,6 +10026,9 @@ class solax_plugin(plugin_base):
         elif seriesnumber.startswith("H3BC19"):
             invertertype = HYBRID | GEN5 | X3  # X3 Ultra C
             self.inverter_model = "X3-Ultra-19.9kW"
+        elif seriesnumber.startswith("H3BC20L"):
+            invertertype = HYBRID | GEN5 | MPPT3 | X3  # X3 Ultra 20KP C
+            self.inverter_model = "X3-Ultra-20kW"
         elif seriesnumber.startswith("H3BC20K"):
             invertertype = HYBRID | GEN5 | MPPT3 | X3  # X3 Ultra 20KP C #1668
             self.inverter_model = "X3-Ultra-20kW"
@@ -10047,6 +10050,9 @@ class solax_plugin(plugin_base):
         elif seriesnumber.startswith("H3BD19"):
             invertertype = HYBRID | GEN5 | X3  # X3 Ultra D
             self.inverter_model = "X3-Ultra-19.9kW"
+        elif seriesnumber.startswith("H3BD20L"):
+            invertertype = HYBRID | GEN5 | MPPT3 | X3  # X3 Ultra 20KP D
+            self.inverter_model = "X3-Ultra-20kW"
         elif seriesnumber.startswith("H3BD20K"):
             invertertype = HYBRID | GEN5 | MPPT3 | X3  # X3 Ultra 20KP D #1668
             self.inverter_model = "X3-Ultra-20kW"
@@ -10068,6 +10074,9 @@ class solax_plugin(plugin_base):
         elif seriesnumber.startswith("H3BF19"):
             invertertype = HYBRID | GEN5 | X3  # X3 Ultra F
             self.inverter_model = "X3-Ultra-19.9kW"
+        elif seriesnumber.startswith("H3BF20L"):
+            invertertype = HYBRID | GEN5 | MPPT3 | X3  # X3 Ultra 20KP F
+            self.inverter_model = "X3-Ultra-20kW"
         elif seriesnumber.startswith("H3BF20K"):
             invertertype = HYBRID | GEN5 | MPPT3 | X3  # X3 Ultra 20KP F #1668
             self.inverter_model = "X3-Ultra-20kW"
@@ -10089,6 +10098,9 @@ class solax_plugin(plugin_base):
         elif seriesnumber.startswith("H3BG19"):
             invertertype = HYBRID | GEN5 | X3  # X3 Ultra G
             self.inverter_model = "X3-Ultra-19.9kW"
+        elif seriesnumber.startswith("H3BG20L"):
+            invertertype = HYBRID | GEN5 | MPPT3 | X3  # X3 Ultra 20KP G
+            self.inverter_model = "X3-Ultra-20kW"
         elif seriesnumber.startswith("H3BG20K"):
             invertertype = HYBRID | GEN5 | MPPT3 | X3  # X3 Ultra 20KP G #1668
             self.inverter_model = "X3-Ultra-20kW"


### PR DESCRIPTION
## Summary
Add missing `20L` serial number patterns for SolaX X3 Ultra 20kW Gen5 inverters (C, D, F, G variants) that were falling through to the generic `20` catch-all without the `MPPT3` flag, causing PV3 to go undetected.
## Problem
Your inverter serial is `H3BC20LA018018` (X3-Ultra-20kW, Gen5). In `async_determineInverterType`, it matched `H3BC20` at line 10032 which sets:
```python
invertertype = HYBRID | GEN5 | X3  # NO MPPT3 flag
```

But PV3 sensors require MPPT3 in their allowedtypes:
```python
allowedtypes=HYBRID | GEN5 | MPPT3 | MPPT5 | MPPT6
```

Without MPPT3, all PV3 sensors (voltage, current, power) are excluded from registration. The pv_power_total calculation breaks when pv_power_3 is None, so it only sums PV1 + PV2.


What changed
Added 4 missing serial patterns in plugin_solax.py before their respective 20 catch-alls:
- H3BC20L — X3 Ultra 20KP C
- H3BD20L — X3 Ultra 20KP D
- H3BF20L — X3 Ultra 20KP F
- H3BG20L — X3 Ultra 20KP G

Each includes MPPT3 in the inverter type flags, following the same pattern as the existing 20K variants.

Tested on
- Device: X3-Ultra-20kW Gen5
- Serial: H3BC20LA01xxxx
- Firmware: DSP 031.04 ARM 031.04
- HA: 2026.4.3 (container)