### PR TITLE
Add Damping to Mode8 Negative Injection Control Loop

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -690,10 +690,13 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
 
             # Battery gets surplus up to BMS limit
             desired_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
-            pushmode_power = -desired_charge
+
+            # Simple moving average filter to slow down changes to battery
+            selected_charge = (cur_push * 4 + desired_charge) / 5
+            pushmode_power = -selected_charge
 
             # Any surplus not able to feed into the battery needs to be corrected through PV limiting
-            error = surplus - desired_charge
+            error = surplus - selected_charge
 
             if abs(error) <= export_deadband_w:
                 target_pvlimit = cur_pvlimit
@@ -713,12 +716,13 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
                 control_reason = "increase-pv"
 
             # Simple moving average filter to slow down changes to PV limit
-            pvlimit = (cur_pvlimit * 7 + target_pvlimit) / 8
+            pvlimit = (cur_pvlimit * 4 + target_pvlimit) / 5
 
             _LOGGER.debug(
                 f"[Mode8 Negative Injection] {control_state}: surplus={surplus}W measured_power={measured_power}W "
                 f"export_target={export_target}W error={error}W pvtarget={target_pvlimit}W reason={control_reason} "
-                f"bms_cap≈{bms_cap_w}W pct_cap={pct_cap_w}W -> charge={desired_charge}W pvlimit={pvlimit}W hl={hl}W"
+                f"bms_cap≈{bms_cap_w}W pct_cap={pct_cap_w}W desired_charge={desired_charge}W -> charge={selected_charge}W "
+                f"pvlimit={pvlimit}W hl={hl}W"
             )
 
         else:

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -553,7 +553,7 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
     return {"action": WRITE_MULTI_MODBUS, "data": res}
 
 
-def autorepeat_bms_charge(datadict: dict[str, Any], battery_capacity: float, max_charge_soc: float, available: float) -> tuple[int, int, int]:
+def autorepeat_bms_charge(datadict: dict[str, Any], battery_capacity: float, max_charge_soc: float, available: float) -> tuple[int, int, int, int]:
     # Determines max rate for charging battery
 
     # User cap (% of BMS max charge power).
@@ -590,12 +590,14 @@ def autorepeat_bms_charge(datadict: dict[str, Any], battery_capacity: float, max
     if battery_capacity < max_charge_soc:
         # Limit to charge rate to lesser of the available
         # power and the %age capped charge limit.
+        max_charge = int(max(0, pct_cap_w))
         desired_charge = int(max(0, min(available, pct_cap_w)))
     else:
         # Can't charge the battery
+        max_charge = 0
         desired_charge = 0
 
-    return desired_charge, bms_cap_w, pct_cap_w
+    return desired_charge, max_charge, bms_cap_w, pct_cap_w
 
 
 def autorepeat_setpoint_filter(current_value: float, desired_value: float, steps: int = 5) -> float:
@@ -695,7 +697,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
             control_state = "surplus" if pv >= hl else "clipping"
 
             # Battery gets surplus up to BMS limit
-            desired_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
+            desired_charge, max_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
 
             # Setpoint filter to slow down changes to battery
             selected_charge = autorepeat_setpoint_filter(current_charge, desired_charge)
@@ -777,7 +779,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
             surplus = pv - houseload
 
             # Battery gets surplus PV up to BMS limit
-            desired_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
+            desired_charge, max_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
             pushmode_power = -desired_charge
 
             # If there is any left over, it goes to the grid
@@ -789,7 +791,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
                 surplus_export = export_limit
 
             _LOGGER.debug(
-                f"[Mode8 No-Discharge] charge-first: surplus={surplus}W within_bms={desired_charge}W "
+                f"[Mode8 No-Discharge] charge-first: surplus={surplus}W within_bms={max_charge}W "
                 f"surplus_export={surplus_export}W within_cap={export_within_cap}W pvlimit={pvlimit}W "
                 f"bms_cap≈{bms_cap_w}W pct_cap={pct_cap_w}W -> charge={desired_charge}W"
             )
@@ -873,7 +875,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
             error = measured_export - export_target
 
             # Extract BMS/user charge caps once; control law below only changes the requested charge.
-            _, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, 10**9)
+            _, max_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, 10**9)
 
             if battery_capacity >= max_charge_soc:
                 desired_charge = 0
@@ -892,7 +894,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
                 desired_charge = max(0, current_charge - step_w)
                 control_reason = "decrease-charge"
 
-            desired_charge = int(min(desired_charge, pct_cap_w))
+            desired_charge = int(min(desired_charge, max_charge))
             pushmode_power = -desired_charge
 
             # Export-First in this mode should not directly clamp PV.

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -600,9 +600,9 @@ def autorepeat_bms_charge(datadict: dict[str, Any], battery_capacity: float, max
     return desired_charge, max_charge, bms_cap_w, pct_cap_w
 
 
-def autorepeat_setpoint_filter(current_value: float, desired_value: float, steps: int = 5) -> float:
+def autorepeat_setpoint_filter(current_value: int, desired_value: int, steps: int = 5) -> int:
     # Simple rolling average filter for updating control setpoints to avoid oscillation
-    return (current_value * (steps - 1) + desired_value) / steps
+    return int((current_value * (steps - 1) + desired_value) / steps)
 
 
 def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -664,8 +664,9 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         pvlimit = setpvlimit
         pv_threshold = pv + pv_unlimited_step  # point at which PV is considered to be not actively limited
         cur_pvlimit = max(0, setpvlimit if (cur_pvlimit := datadict.get("remotecontrol_current_pv_power_limit", None)) is None else cur_pvlimit)
-        cur_push = max(0, battery_charge if (cur_push := datadict.get("remotecontrol_current_pushmode_power", None)) is None else (0 - cur_push))
+        cur_push = max(0, (-battery_charge) if (cur_push := datadict.get("remotecontrol_current_pushmode_power", None)) is None else cur_push)
         pushmode_power = 0  # + = discharge, - = charge
+        current_charge = -cur_push
 
         # Debug inputs
         _LOGGER.debug(
@@ -685,14 +686,14 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
             # At/above target: PV can be increased to reduce import in bounded steps.
             # If PV is being actively limited, continue in this loop to release PV restriction slowly.
             measured_power = int(measured_power or 0)
-            surplus = cur_push + measured_power - export_target
+            surplus = current_charge + measured_power - export_target
             control_state = "surplus" if pv >= hl else "clipping"
 
             # Battery gets surplus up to BMS limit
             desired_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
 
             # Simple moving average filter to slow down changes to battery
-            selected_charge = (cur_push * 4 + desired_charge) / 5
+            selected_charge = (current_charge * 4 + desired_charge) / 5
             pushmode_power = -selected_charge
 
             # Any surplus not able to feed into the battery needs to be corrected through PV limiting

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -598,6 +598,11 @@ def autorepeat_bms_charge(datadict: dict[str, Any], battery_capacity: float, max
     return desired_charge, bms_cap_w, pct_cap_w
 
 
+def autorepeat_setpoint_filter(current_value: float, desired_value: float, steps: int = 5) -> float:
+    # Simple rolling average filter for updating control setpoints to avoid oscillation
+    return (current_value * (steps - 1) + desired_value) / steps
+
+
 def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
     # initval = BUTTONREPEAT_FIRST means first run;
     # initval = BUTTONREPEAT_LOOP means subsequent runs for button autorepeat value functions
@@ -692,8 +697,8 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
             # Battery gets surplus up to BMS limit
             desired_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, surplus)
 
-            # Simple moving average filter to slow down changes to battery
-            selected_charge = (current_charge * 4 + desired_charge) / 5
+            # Setpoint filter to slow down changes to battery
+            selected_charge = autorepeat_setpoint_filter(current_charge, desired_charge)
             pushmode_power = -selected_charge
 
             # Any surplus not able to feed into the battery needs to be corrected through PV limiting
@@ -716,8 +721,8 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
                 target_pvlimit = min(setpvlimit, cur_pvlimit - error)
                 control_reason = "increase-pv"
 
-            # Simple moving average filter to slow down changes to PV limit
-            pvlimit = (cur_pvlimit * 4 + target_pvlimit) / 5
+            # Filter the setpoint to avoid oscillation
+            pvlimit = autorepeat_setpoint_filter(cur_pvlimit, target_pvlimit)
 
             _LOGGER.debug(
                 f"[Mode8 Negative Injection] {control_state}: surplus={surplus}W measured_power={measured_power}W "

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -737,12 +737,15 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
             # the limited pv path and we therefore have insufficient PV to cover the load.
             deficit = hl + export_target - pv
             if battery_capacity > min_discharge_soc:
-                pushmode_power = min(deficit, 30000)
+                desired_charge = min(deficit, 30000)
+                selected_charge = autorepeat_setpoint_filter(current_charge, desired_charge)
+                pushmode_power = -selected_charge
             else:
+                desired_charge = 0
                 pushmode_power = 0
             _LOGGER.debug(
                 f"[Mode8 Negative Injection] deficit: deficit={deficit}W export_target={export_target}W "
-                f"soc={battery_capacity}% chosen_push={pushmode_power}W"
+                f"soc={battery_capacity}% desired_charge={desired_charge}W -> chosen_push={pushmode_power}W"
             )
 
     elif power_control == "Negative Injection and Consumption Price":  # disable PV, charge from grid

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -661,6 +661,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         # SOC bounds
         min_discharge_soc = datadict.get("selfuse_discharge_min_soc", 10)
         max_charge_soc = min(target_soc, datadict.get("battery_charge_upper_soc", 100))
+        charge_soc_hysteresis = datadict.get("negative_injection_battery_hysteresis", 2)
         # bias towards import
         export_target = int(datadict.get("negative_injection_bias_w", -50) or -50)
         export_deadband_w = int(datadict.get("export_feedback_deadband_w", 50) or 50)
@@ -708,9 +709,10 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
 
             if abs(error) <= export_deadband_w:
                 target_pvlimit = cur_pvlimit
-                if desired_charge < max_charge:
+                if desired_charge < max_charge and battery_capacity < max_charge_soc - charge_soc_hysteresis:
                     # If the battery can be charged more than it currently is being, then once stable
-                    # allow the limit to be increased to see if we can absorb more output from the PV.
+                    # allow the limit to be increased to see if we can absorb more output from the PV,
+                    # but only if the battery has plenty of headroom to absorb an increase.
                     control_reason = "hold-increase-pv"
                     target_pvlimit = min(setpvlimit, cur_pvlimit + (max_charge - desired_charge))
                 else:

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -669,7 +669,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         pvlimit = setpvlimit
         pv_threshold = pv + pv_unlimited_step  # point at which PV is considered to be not actively limited
         cur_pvlimit = max(0, setpvlimit if (cur_pvlimit := datadict.get("remotecontrol_current_pv_power_limit", None)) is None else cur_pvlimit)
-        cur_push = min(0, (-battery_charge) if (cur_push := datadict.get("remotecontrol_current_pushmode_power", None)) is None else cur_push)
+        cur_push = (-battery_charge) if (cur_push := datadict.get("remotecontrol_current_pushmode_power", None)) is None else cur_push
         pushmode_power = 0  # + = discharge, - = charge
         current_charge = -cur_push
 

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -657,9 +657,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         # bias towards import
         export_target = int(datadict.get("negative_injection_bias_w", -50) or -50)
         export_deadband_w = int(datadict.get("export_feedback_deadband_w", 50) or 50)
-        min_step_w = int(datadict.get("export_first_step_min_w", 100) or 100)
-        max_step_w = int(datadict.get("export_feedback_max_w", 500) or 500)
-        pv_unlimited_step = max(2 * max_step_w, int(datadict.get("pv_unlimited_delta_w", 1000) or 1000))
+        pv_unlimited_step = int(datadict.get("pv_unlimited_delta_w", 1000) or 1000)
 
         # Local copies
         battery_charge = max(0, int(datadict.get("battery_power_charge", 0) or 0))
@@ -698,8 +696,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
             error = surplus - desired_charge
 
             if abs(error) <= export_deadband_w:
-                step_w = 0
-                pvlimit = cur_pvlimit
+                target_pvlimit = cur_pvlimit
                 control_reason = "hold"
             elif error > 0:
                 if cur_pvlimit > pv_threshold:
@@ -710,16 +707,17 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
                     control_reason = "decrease-pv-fast"
                 else:
                     control_reason = "decrease-pv"
-                step_w = min(max_step_w, max(min_step_w, error))
-                pvlimit = max(0, cur_pvlimit - step_w)
+                target_pvlimit = max(0, cur_pvlimit - error)
             else:
-                step_w = min(max_step_w, max(min_step_w, -error))
-                pvlimit = min(setpvlimit, cur_pvlimit + step_w)
+                target_pvlimit = min(setpvlimit, cur_pvlimit - error)
                 control_reason = "increase-pv"
+
+            # Simple moving average filter to slow down changes to PV limit
+            pvlimit = (cur_pvlimit * 7 + target_pvlimit) / 8
 
             _LOGGER.debug(
                 f"[Mode8 Negative Injection] {control_state}: surplus={surplus}W measured_power={measured_power}W "
-                f"export_target={export_target}W error={error}W step={step_w}W reason={control_reason} "
+                f"export_target={export_target}W error={error}W pvtarget={target_pvlimit}W reason={control_reason} "
                 f"bms_cap≈{bms_cap_w}W pct_cap={pct_cap_w}W -> charge={desired_charge}W pvlimit={pvlimit}W hl={hl}W"
             )
 

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -757,10 +757,34 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
                 f"[Mode8 Negative Injection] deficit: deficit={deficit}W export_target={export_target}W "
                 f"soc={battery_capacity}% desired_charge={desired_charge}W -> chosen_push={pushmode_power}W"
             )
-
-    elif power_control == "Negative Injection and Consumption Price":  # disable PV, charge from grid
+    elif power_control == "Negative Injection and Consumption Price":
+        # Disables PV and charges as fast as possible from the grid
         pvlimit = 0
-        pushmode_power = houseload - import_limit
+        # Set maximum charge limit, respecting optional target SoC
+        max_charge_soc = min(target_soc, datadict.get("battery_charge_upper_soc", 100))
+        # Determine currently requested charge rate to allow filtering
+        battery_charge = max(0, int(datadict.get("battery_power_charge", 0) or 0))
+        cur_push = (-battery_charge) if (cur_push := datadict.get("remotecontrol_current_pushmode_power", None)) is None else cur_push
+        current_charge = -cur_push
+        # Debug inputs
+        _LOGGER.debug(
+            f"[Mode8 Negative Injection and Consumption Price] inputs hl={houseload}W hl_alt={houseload_alt}W (using hl) imp_lim={import_limit}W "
+            f"soc={battery_capacity}% max_soc={max_charge_soc}% last_push={current_charge}W battery_charge={battery_charge}W"
+        )
+        # Use the alternative house load for house load measurement, clamping to strict positive values,
+        # to determine maximum available power from the grid
+        hl = max(0, int(houseload_alt))
+        available = max(import_limit - hl, 0)
+        # Request maximum allowed charge rate based on current SoC
+        desired_charge, max_charge, bms_cap_w, pct_cap_w = autorepeat_bms_charge(datadict, battery_capacity, max_charge_soc, available)
+        # Setpoint filter to slow down changes to battery
+        selected_charge = autorepeat_setpoint_filter(current_charge, desired_charge)
+        pushmode_power = -selected_charge
+
+        _LOGGER.debug(
+            f"[Mode8 Negative Injection and Consumption Price] charge: available={available}W within_bms={max_charge}W "
+            f"bms_cap≈{bms_cap_w}W pct_cap={pct_cap_w}W -> charge={desired_charge}W"
+        )
     elif power_control == "Enabled Feedin Priority":
         pvlimit = setpvlimit
         pushmode_power = max(houseload - pv, 0.0)

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -708,20 +708,28 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
 
             if abs(error) <= export_deadband_w:
                 target_pvlimit = cur_pvlimit
-                control_reason = "hold"
+                if desired_charge < max_charge:
+                    # If the battery can be charged more than it currently is being, then once stable
+                    # allow the limit to be increased to see if we can absorb more output from the PV.
+                    control_reason = "hold-increase-pv"
+                    target_pvlimit = min(setpvlimit, cur_pvlimit + (max_charge - desired_charge))
+                else:
+                    # Otherwise hold
+                    control_reason = "hold"
+                    target_pvlimit = cur_pvlimit
             elif error > 0:
                 if cur_pvlimit > pv_threshold:
                     # If the current PV limit is above any active PV limiting, then we will make
                     # a much larger step to allow for a faster response. Otherwise the steps will
                     # not actually achieve anything for several loops.
                     cur_pvlimit = pv_threshold
-                    control_reason = "decrease-pv-fast"
+                    control_reason = "error-decrease-pv-fast"
                 else:
-                    control_reason = "decrease-pv"
+                    control_reason = "error-decrease-pv"
                 target_pvlimit = max(0, cur_pvlimit - error)
             else:
                 target_pvlimit = min(setpvlimit, cur_pvlimit - error)
-                control_reason = "increase-pv"
+                control_reason = "error-increase-pv"
 
             # Filter the setpoint to avoid oscillation
             pvlimit = autorepeat_setpoint_filter(cur_pvlimit, target_pvlimit)

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -669,7 +669,7 @@ def autorepeat_function_powercontrolmode8_recompute(initval: int, descr: Any, da
         pvlimit = setpvlimit
         pv_threshold = pv + pv_unlimited_step  # point at which PV is considered to be not actively limited
         cur_pvlimit = max(0, setpvlimit if (cur_pvlimit := datadict.get("remotecontrol_current_pv_power_limit", None)) is None else cur_pvlimit)
-        cur_push = max(0, (-battery_charge) if (cur_push := datadict.get("remotecontrol_current_pushmode_power", None)) is None else cur_push)
+        cur_push = min(0, (-battery_charge) if (cur_push := datadict.get("remotecontrol_current_pushmode_power", None)) is None else cur_push)
         pushmode_power = 0  # + = discharge, - = charge
         current_charge = -cur_push
 


### PR DESCRIPTION
Further improvements to improve stability in the Mode 8 Negative Injection mode. This aims to remove oscillation behaviour seen due to there being no damping on the new set-points values being calculated.

Based on discussions in https://github.com/wills106/homeassistant-solax-modbus/discussions/2017

Example execution:

<img width="1179" height="922" alt="image" src="https://github.com/user-attachments/assets/73615d88-07b6-4aa4-804a-cf7f7db815b0" />

Close-up of grid port - largely hovering around the target ~50W import bias. Some short export periods caused by damped response, but that is to be expected.

<img width="1045" height="398" alt="image" src="https://github.com/user-attachments/assets/6bf53d66-5d10-4bde-b3ab-f79ddfb1fe13" />
