### PR TITLE
Add Solis S6-EH3P12K-H serial prefix

### DIFF
--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -2771,6 +2771,8 @@ class solis_plugin(plugin_base):
             invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  8kW - HV
         elif seriesnumber.startswith("103306"):
             invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  10kW - HV
+        elif seriesnumber.startswith("103314"):
+            invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  12kW - HV
         elif seriesnumber.startswith("110C"):
             invertertype = HYBRID | X3  # Hybrid Gen5 0CA2 / 0C92 10kW - HV
         elif seriesnumber.startswith("114C"):

--- a/custom_components/solax_modbus/plugin_solis_fb00.py
+++ b/custom_components/solax_modbus/plugin_solis_fb00.py
@@ -4507,6 +4507,8 @@ class solis_fb00_plugin(plugin_base):
             invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  8kW - HV
         elif seriesnumber.startswith("103306"):
             invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  10kW - HV
+        elif seriesnumber.startswith("103314"):
+            invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  12kW - HV
         elif seriesnumber.startswith("110C"):
             invertertype = HYBRID | X3  # Hybrid Gen5 0CA2 / 0C92 10kW - HV
         elif seriesnumber.startswith("114C"):


### PR DESCRIPTION
Adds support for Solis S6-EH3P12K-H in both Solis plugins by recognizing serial prefix 103314 as a Gen6 X3 hybrid inverter with 4 MPPTs.

Fixes #1995.