### PR TITLE
Fix EV Charger breaking changes from PR #2012

### DIFF
--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -519,9 +519,9 @@ SELECT_TYPES = [
         register=0x625,
         option_dict={
             0: "Three Phase",
-            1: "Phase A",
-            2: "Phase B",
-            3: "Phase C",
+            1: "L1 Phase",
+            2: "L2 Phase",
+            3: "L3 Phase",
         },
         entity_category=EntityCategory.CONFIG,
         icon="mdi:dip-switch",
@@ -533,9 +533,9 @@ SELECT_TYPES = [
         register=0x63B,
         option_dict={
             0: "Three Phase",
-            1: "Phase A",
-            2: "Phase B",
-            3: "Phase C",
+            1: "L1 Phase",
+            2: "L2 Phase",
+            3: "L3 Phase",
         },
         entity_category=EntityCategory.CONFIG,
         icon="mdi:dip-switch",
@@ -729,7 +729,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         name="Charge Phase",
         key="charge_phase",
         register=0x625,
-        scale={0: "Three Phase", 1: "Phase A", 2: "Phase B", 3: "Phase C"},
+        scale={0: "Three Phase", 1: "L1 Phase", 2: "L2 Phase", 3: "L3 Phase"},
         allowedtypes=X3,
         internal=True,
     ),
@@ -737,7 +737,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         name="Charge Phase Alt",
         key="charge_phase_alt",
         register=0x63B,
-        scale={0: "Three Phase", 1: "Phase A", 2: "Phase B", 3: "Phase C"},
+        scale={0: "Three Phase", 1: "L1 Phase", 2: "L2 Phase", 3: "L3 Phase"},
         allowedtypes=X3,
         internal=True,
     ),
@@ -823,13 +823,13 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
     ###
     #
     # Input — 0x0100+
-    # 0x0100-0x0102: ChargePowerA/B/C also available at 0x08-0x0A; exposed here with Alt suffix
+    # 0x0100-0x0102: ChargePower L1 (A) / L2 (B) / L3 (C) also available at 0x08-0x0A; exposed here with Alt suffix
     #
     ###
-    # ---- 0x0100–0x0102  Phase powers alt (same as 0x08-0x0A, disabled by default) ----
+    # ---- 0x0100–0x0102  Phase powers alt for L1 (A) / L2 (B) / L3 (C), disabled by default ----
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Power A Alt",
-        key="charge_power_a_alt",
+        name="Charge Power L1 Alt",
+        key="charge_power_l1_alt",
         register=0x100,
         register_type=REG_INPUT,
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -838,8 +838,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Power B Alt",
-        key="charge_power_b_alt",
+        name="Charge Power L2 Alt",
+        key="charge_power_l2_alt",
         register=0x101,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -849,8 +849,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Power C Alt",
-        key="charge_power_c_alt",
+        name="Charge Power L3 Alt",
+        key="charge_power_l3_alt",
         register=0x102,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -916,7 +916,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
     # Input
     #
     ###
-    # ---- 0x0000–0x0002  Phase voltages (GEN2 doc: VoltageA/B/C, 0.01V) ----
+    # ---- 0x0000–0x0002  Phase voltages L1 (A) / L2 (B) / L3 (C), 0.01V ----
     SolaXEVChargerModbusSensorEntityDescription(
         name="Charge Voltage",
         key="charge_voltage",
@@ -928,8 +928,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         allowedtypes=X1,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Voltage A",
-        key="charge_voltage_a",
+        name="Charge Voltage L1",
+        key="charge_voltage_l1",
         register=0x0,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -938,8 +938,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.VOLTAGE,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Voltage B",
-        key="charge_voltage_b",
+        name="Charge Voltage L2",
+        key="charge_voltage_l2",
         register=0x1,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -948,8 +948,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.VOLTAGE,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Voltage C",
-        key="charge_voltage_c",
+        name="Charge Voltage L3",
+        key="charge_voltage_l3",
         register=0x2,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -969,7 +969,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    # ---- 0x0004–0x0006  Phase currents (GEN2 doc: CurrentA/B/C, 0.01A) ----
+    # ---- 0x0004–0x0006  Phase currents L1 (A) / L2 (B) / L3 (C), 0.01A ----
     SolaXEVChargerModbusSensorEntityDescription(
         name="Charge Current",
         key="charge_current",
@@ -983,8 +983,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Current A",
-        key="charge_current_a",
+        name="Charge Current L1",
+        key="charge_current_l1",
         register=0x4,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -993,8 +993,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.CURRENT,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Current B",
-        key="charge_current_b",
+        name="Charge Current L2",
+        key="charge_current_l2",
         register=0x5,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -1003,8 +1003,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.CURRENT,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Current C",
-        key="charge_current_c",
+        name="Charge Current L3",
+        key="charge_current_l3",
         register=0x6,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -1023,7 +1023,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    # ---- 0x0008–0x000A  Phase powers (GEN2 doc: ChargePowerA/B/C, 1W) ----
+    # ---- 0x0008–0x000A  Phase powers L1 (A) / L2 (B) / L3 (C), 1W ----
     SolaXEVChargerModbusSensorEntityDescription(
         name="Charge Power",
         key="charge_power",
@@ -1036,8 +1036,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Power A",
-        key="charge_power_a",
+        name="Charge Power L1",
+        key="charge_power_l1",
         register=0x8,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -1047,8 +1047,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Power B",
-        key="charge_power_b",
+        name="Charge Power L2",
+        key="charge_power_l2",
         register=0x9,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -1058,8 +1058,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Power C",
-        key="charge_power_c",
+        name="Charge Power L3",
+        key="charge_power_l3",
         register=0xA,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -1078,7 +1078,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    # ---- 0x000C–0x000E  Phase frequencies (GEN2 doc: Freq_A/B/C, 0.01Hz) ----
+    # ---- 0x000C–0x000E  Phase frequencies L1 (A) / L2 (B) / L3 (C), 0.01Hz ----
     SolaXEVChargerModbusSensorEntityDescription(
         name="Charge Frequency",
         key="charge_frequency",
@@ -1090,8 +1090,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Frequency A",
-        key="charge_frequency_a",
+        name="Charge Frequency L1",
+        key="charge_frequency_l1",
         register=0xC,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -1101,8 +1101,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Frequency B",
-        key="charge_frequency_b",
+        name="Charge Frequency L2",
+        key="charge_frequency_l2",
         register=0xD,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -1112,8 +1112,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Charge Frequency C",
-        key="charge_frequency_c",
+        name="Charge Frequency L3",
+        key="charge_frequency_l3",
         register=0xE,
         register_type=REG_INPUT,
         allowedtypes=X3,
@@ -1156,7 +1156,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    # ---- 0x0012–0x0014  Grid currents S16 (GEN2 doc: ExternCurrentA/B/C, 0.01A) ----
+    # ---- 0x0012–0x0014  Grid currents L1 (A) / L2 (B) / L3 (C), S16, 0.01A ----
     SolaXEVChargerModbusSensorEntityDescription(
         name="Grid Current",
         key="grid_current",
@@ -1170,8 +1170,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Grid Current A",
-        key="grid_current_a",
+        name="Grid Current L1",
+        key="grid_current_l1",
         register=0x12,
         register_type=REG_INPUT,
         register_data_type=REGISTER_S16,
@@ -1183,8 +1183,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Grid Current B",
-        key="grid_current_b",
+        name="Grid Current L2",
+        key="grid_current_l2",
         register=0x13,
         register_type=REG_INPUT,
         register_data_type=REGISTER_S16,
@@ -1196,8 +1196,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Grid Current C",
-        key="grid_current_c",
+        name="Grid Current L3",
+        key="grid_current_l3",
         register=0x14,
         register_type=REG_INPUT,
         register_data_type=REGISTER_S16,
@@ -1208,7 +1208,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    # ---- 0x0015–0x0017  Grid powers S16 (GEN2 doc: ExternPowerA/B/C, 1W) ----
+    # ---- 0x0015–0x0017  Grid powers L1 (A) / L2 (B) / L3 (C), S16, 1W ----
     SolaXEVChargerModbusSensorEntityDescription(
         name="Grid Power",
         key="grid_power",
@@ -1222,8 +1222,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Grid Power A",
-        key="grid_power_a",
+        name="Grid Power L1",
+        key="grid_power_l1",
         register=0x15,
         register_type=REG_INPUT,
         register_data_type=REGISTER_S16,
@@ -1235,8 +1235,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Grid Power B",
-        key="grid_power_b",
+        name="Grid Power L2",
+        key="grid_power_l2",
         register=0x16,
         register_type=REG_INPUT,
         register_data_type=REGISTER_S16,
@@ -1248,8 +1248,8 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Grid Power C",
-        key="grid_power_c",
+        name="Grid Power L3",
+        key="grid_power_l3",
         register=0x17,
         register_type=REG_INPUT,
         register_data_type=REGISTER_S16,
@@ -1481,9 +1481,9 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         register_type=REG_INPUT,
         scale={
             0: "Three Phase",
-            1: "Phase A",
-            2: "Phase B",
-            3: "Phase C",
+            1: "L1 Phase",
+            2: "L2 Phase",
+            3: "L3 Phase",
         },
         icon="mdi:cable-data",
     ),

--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -1520,7 +1520,6 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         register=0x2B,
         register_type=REG_INPUT,
         register_data_type=REGISTER_U32,
-        order32="big",
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=UnitOfTime.SECONDS,

--- a/docs/developer/plugin-phase-naming.md
+++ b/docs/developer/plugin-phase-naming.md
@@ -1,0 +1,62 @@
+# Plugin Phase Naming Convention
+
+## Scope
+
+This note documents the electrical phase naming convention for SolaX plugin entity descriptions.
+
+## SolaX convention
+
+Within SolaX plugins, use `L1`, `L2`, `L3` for electrical phase entity names, keys and state labels.
+
+This applies especially to:
+
+- `plugin_solax.py`
+- `plugin_solax_a1j1.py`
+- `plugin_solax_ev_charger.py`
+- `plugin_solax_lv.py`
+- `plugin_solax_mega_forth.py`
+
+For new SolaX phase entities, prefer keys with `*_l1`, `*_l2`, `*_l3`. Do not rename existing Home Assistant entity keys without an explicit migration plan; entity keys are part of the generated Home Assistant unique ID.
+
+If vendor documentation labels the same SolaX registers as A/B/C, keep the integration naming first and put the vendor label in parentheses when useful:
+
+- `L1 (A)`
+- `L2 (B)`
+- `L3 (C)`
+
+## Known non-SolaX / historical differences
+
+The following plugins intentionally keep their original historical or vendor-specific phase naming (`A/B/C`, `R/S/T`, `R/Y/B`) in names and/or keys. This is a conscious compatibility difference and should not be changed as part of the SolaX naming convention cleanup:
+
+- `plugin_Enertech.py`
+- `plugin_sofar_old.py`
+- `plugin_solis_old.py`
+- `plugin_solinteg.py`
+- `plugin_sunway.py`
+
+These plugins are outside the current SolaX phase naming scope. If they are ever normalized, that should be a separate migration-aware change.
+
+## SolaX EV Charger audit
+
+The EV Charger plugin was checked after upstream PR #2012. It now consistently uses:
+
+- Phase select/readback values: `L1 Phase`, `L2 Phase`, `L3 Phase`
+- Three-phase sensor keys: `*_l1`, `*_l2`, `*_l3`
+- Three-phase sensor names: `... L1`, `... L2`, `... L3`
+- Register comments: `L1 (A) / L2 (B) / L3 (C)` where vendor A/B/C terminology is useful
+
+Covered EV Charger sensor groups:
+
+- Charge voltage
+- Charge current
+- Charge power
+- Charge power alt
+- Charge frequency
+- Grid current
+- Grid power
+- Active charge phase
+
+## Regression guards
+
+- `tests/unit/test_plugin_phase_naming.py` verifies that SolaX plugin user-facing phase names and new phase keys stay on `L1`/`L2`/`L3`, including the EV Charger plugin.
+

--- a/tests/unit/test_plugin_phase_naming.py
+++ b/tests/unit/test_plugin_phase_naming.py
@@ -1,0 +1,89 @@
+"""SolaX plugin audit for electrical phase naming."""
+
+import ast
+import pathlib
+import re
+from collections.abc import Iterable
+
+PLUGIN_DIR = pathlib.Path(__file__).parents[2] / "custom_components" / "solax_modbus"
+
+SOLAX_PLUGIN_FILES = {
+    "plugin_solax.py",
+    "plugin_solax_a1j1.py",
+    "plugin_solax_ev_charger.py",
+    "plugin_solax_lv.py",
+    "plugin_solax_mega_forth.py",
+}
+
+NON_L123_PHASE_NAME_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"\bPhase [ABC]\b",
+        r"\b[ABC] Phase\b",
+        r"\bGrid Phase [ABC]\b",
+        r"\bBackup A\b",
+        r"\b(?:Grid |Inverter |Output |Load )?(?:Voltage|Current|Power|Frequency) [ABC]\b",
+        r"\b(?:Grid |Inverter |Output |Load )?(?:Voltage|Current) [RSTYB]\b",
+    )
+)
+
+NON_L123_PHASE_KEY_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"(?:^|_)phase_[abc](?:_|$)",
+        r"(?:^|_)(?:voltage|current|power|frequency)_[abc](?:_|$)",
+        r"(?:^|_)[abc]_(?:voltage|current|power|frequency)(?:_|$)",
+        r"^backup_a_(?:voltage|current|power)$",
+        r"^(?:grid_)?(?:voltage|current)_[rst]$",
+        r"^grid_phase_[abc]_(?:voltage|current|power)$",
+    )
+)
+
+
+def _plugin_entity_literals(plugin_names: set[str]) -> Iterable[tuple[str, str | None, str | None]]:
+    for plugin_path in sorted(PLUGIN_DIR.glob("plugin_*.py")):
+        if plugin_path.name not in plugin_names:
+            continue
+
+        tree = ast.parse(plugin_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+
+            values: dict[str, str | None] = {"name": None, "key": None}
+            for keyword in node.keywords:
+                if keyword.arg not in values:
+                    continue
+                try:
+                    value = ast.literal_eval(keyword.value)
+                except ValueError:
+                    continue
+                if isinstance(value, str):
+                    values[keyword.arg] = value
+
+            if values["name"] is not None or values["key"] is not None:
+                yield plugin_path.name, values["name"], values["key"]
+
+
+def test_solax_plugin_phase_names_use_l1_l2_l3() -> None:
+    """SolaX electrical phase names should not expose A/B/C or R/S/T/Y/B labels."""
+
+    offenders = [
+        (plugin, key, name)
+        for plugin, name, key in _plugin_entity_literals(SOLAX_PLUGIN_FILES)
+        if name is not None and any(pattern.search(name) for pattern in NON_L123_PHASE_NAME_PATTERNS)
+    ]
+
+    assert offenders == []
+
+
+def test_solax_plugin_phase_keys_use_l1_l2_l3_for_new_entities() -> None:
+    """SolaX phase keys should stay on L1/L2/L3 naming, unless migrated explicitly."""
+
+    offenders = [
+        (plugin, key)
+        for plugin, _name, key in _plugin_entity_literals(SOLAX_PLUGIN_FILES)
+        if key is not None and any(pattern.search(key) for pattern in NON_L123_PHASE_KEY_PATTERNS)
+    ]
+
+    assert offenders == []


### PR DESCRIPTION
This PR fixes compatibility regressions introduced in #2012.

### Background
PR #2012 renamed several SolaX EV Charger phase entities from the integration-wide L1/L2/L3 convention to vendor-style A/B/C.

Across this integration, SolaX phase entities consistently use L1, L2, and L3. Changing EV Charger entity keys from *_l1, *_l2, *_l3 to *_a, *_b, *_c is a breaking change because Home Assistant unique IDs are based on entity keys.

For existing users, this can break:
- dashboards
- automations
- scripts
- history/statistics references
- custom cards and templates

### Changes
Restore SolaX EV Charger phase names and keys back to L1/L2/L3.
Keep vendor A/B/C wording only in code comments as L1 (A) / L2 (B) / L3 (C).
Add developer documentation for the SolaX phase naming convention.
Add a regression test to prevent SolaX plugin phase naming from drifting back to A/B/C.
Fix charge_duration Gen2 decoding by removing the incorrect order32="big" override, so the sensor uses the plugin default little-endian word order.

### Why
This keeps EV Charger entities compatible with existing Home Assistant installations and aligned with the rest of the SolaX integration.

### Tested on 
X3-HAC 11kW
Firmware: ARM v9.05