### PR TITLE
Revert changes to PV Power Total for GEN6

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -6154,20 +6154,21 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     ),
     #### Note regarding following totals registers
     # These should technically also be available on GEN4/GEN5 however
-    # they all return 0 in testing, so leaving as GEN6 only. Will keep
-    # the original calculated pv_power_total sensor for earlier gens.
-    SolaXModbusSensorEntityDescription(
-        name="PV Power Total",
-        key="pv_power_total",
-        native_unit_of_measurement=UnitOfPower.WATT,
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        register=0x32,
-        register_type=REG_INPUT,
-        register_data_type=REGISTER_U32,
-        allowedtypes=HYBRID | GEN6,
-        icon="mdi:solar-power-variant",
-    ),
+    # they all return 0 in testing, so leaving as GEN6 only. 
+    # Keep the original calculated pv_power_total sensor as this one
+    # doesn't appear to work on all GEN6 either.
+    # SolaXModbusSensorEntityDescription(
+    #     name="PV Power Total",
+    #     key="pv_power_total",
+    #     native_unit_of_measurement=UnitOfPower.WATT,
+    #     device_class=SensorDeviceClass.POWER,
+    #     state_class=SensorStateClass.MEASUREMENT,
+    #     register=0x32,
+    #     register_type=REG_INPUT,
+    #     register_data_type=REGISTER_U32,
+    #     allowedtypes=HYBRID | GEN6,
+    #     icon="mdi:solar-power-variant",
+    # ),
     SolaXModbusSensorEntityDescription(
         name="Total On-Grid Power",
         key="ongrid_power_total",
@@ -8219,7 +8220,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        allowedtypes=HYBRID | GEN | GEN2 | GEN3 | GEN4 | GEN5,
+        allowedtypes=HYBRID,
         blacklist=["PRI"],  # X1-FIT has no DC PV input
         depends_on=[
             "pv_power_1",

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -6154,7 +6154,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     ),
     #### Note regarding following totals registers
     # These should technically also be available on GEN4/GEN5 however
-    # they all return 0 in testing, so leaving as GEN6 only. 
+    # they all return 0 in testing, so leaving as GEN6 only.
     # Keep the original calculated pv_power_total sensor as this one
     # doesn't appear to work on all GEN6 either.
     # SolaXModbusSensorEntityDescription(


### PR DESCRIPTION
The new totals register doesn't appear to work on the G4-Pro systems which are also marked as GEN6, yet works fine on the VAST systems.

Revert to use the old approach of summing all individual PV power sensors for all systems as this seems more stable across firmware versions.

Fixes #2046 and fixes #2049.