### PR TITLE
Revert SolaX Hybrid version number reporting to split registers

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1276,6 +1276,9 @@ def value_function_software_version_g3(initval: int, descr: Any, datadict: dict[
 
 
 def value_function_software_version_g4(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
+    if datadict.get("modbus_protocol_version", 0) >= 100:
+        # Use modern combined register if protocol version high enough
+        return value_function_software_version_full(initval, descr, datadict)
     return (
         f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '?')}."
         f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
@@ -1285,10 +1288,9 @@ def value_function_software_version_g4(initval: int, descr: Any, datadict: dict[
 
 
 def value_function_software_version_g5(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    if datadict.get("firmware_version_dsp"):
-        # Use modern combined register if it gives a sensible value
+    if datadict.get("modbus_protocol_version", 0) >= 100:
+        # Use modern combined register if protocol version high enough
         return value_function_software_version_full(initval, descr, datadict)
-    # Use the split approach if combined is unavailable.
     return (
         f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '???'):>03}."
         f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1285,6 +1285,10 @@ def value_function_software_version_g4(initval: int, descr: Any, datadict: dict[
 
 
 def value_function_software_version_g5(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
+    if datadict.get("firmware_version_dsp"):
+        # Use modern combined register if it gives a sensible value
+        return value_function_software_version_full(initval, descr, datadict)
+    # Use the split approach if combined is unavailable.
     return (
         f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '???'):>03}."
         f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
@@ -8290,8 +8294,14 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     ),
     SolaXModbusSensorEntityDescription(
         key="software_version",
-        value_function=value_function_software_version_full,
-        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        value_function=value_function_software_version_g4,
+        allowedtypes=AC | HYBRID | GEN4,
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
+        key="software_version",
+        value_function=value_function_software_version_g5,
+        allowedtypes=AC | HYBRID | GEN5 | GEN6,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -3987,7 +3987,6 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     SolaXModbusSensorEntityDescription(
         name="Modbus Protocol Version",
         key="modbus_protocol_version",
-        entity_registry_enabled_default=False,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         register=0x82,
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1278,33 +1278,17 @@ def value_function_software_version_g3(initval: int, descr: Any, datadict: dict[
 def value_function_software_version_g4(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
     if datadict.get("modbus_protocol_version", 0) >= 100:
         # Use modern combined register if protocol version high enough
-        return value_function_software_version_full(initval, descr, datadict)
+        dsp = datadict.get("firmware_version_dsp")
+        arm = datadict.get("firmware_version_arm")
+        dsp_str = f"{dsp // 100}.{dsp % 100:02d}" if dsp is not None else "?.??"
+        arm_str = f"{arm // 100}.{arm % 100:02d}" if arm is not None else "?.??"
+        return f"DSP {dsp_str} ARM {arm_str}"
     return (
         f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '?')}."
         f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
         f"ARM {value_str_default(datadict.get('firmware_arm_major'), '?')}."
         f"{value_str_default(datadict.get('firmware_arm'), '??'):>02}"
     )
-
-
-def value_function_software_version_g5(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    if datadict.get("modbus_protocol_version", 0) >= 100:
-        # Use modern combined register if protocol version high enough
-        return value_function_software_version_full(initval, descr, datadict)
-    return (
-        f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '???'):>03}."
-        f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
-        f"ARM {value_str_default(datadict.get('firmware_arm_major'), '???'):>03}."
-        f"{value_str_default(datadict.get('firmware_arm'), '??'):>02}"
-    )
-
-
-def value_function_software_version_full(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    dsp = datadict.get("firmware_version_dsp")
-    arm = datadict.get("firmware_version_arm")
-    dsp_str = f"{dsp // 100}.{dsp % 100:02d}" if dsp is not None else "?.??"
-    arm_str = f"{arm // 100}.{arm % 100:02d}" if arm is not None else "?.??"
-    return f"DSP {dsp_str} ARM {arm_str}"
 
 
 def value_function_software_version_air_g3(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
@@ -8296,13 +8280,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     SolaXModbusSensorEntityDescription(
         key="software_version",
         value_function=value_function_software_version_g4,
-        allowedtypes=AC | HYBRID | GEN4,
-        internal=True,
-    ),
-    SolaXModbusSensorEntityDescription(
-        key="software_version",
-        value_function=value_function_software_version_g5,
-        allowedtypes=AC | HYBRID | GEN5 | GEN6,
+        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(


### PR DESCRIPTION
In #2000 version number reporting was changed to use the combined major/minor registers 0x7B and 0x7C which now exist in the latest protocol docs. However this doesn't work for older inverters and ones with outdated firmware (X1-IES, X3-G4-Pro, etc), meaning the version number reports back as 0.00.

For GEN4 revert to the old split registers approach.

For GEN5/6 use the new combined register if its value is non-zero, else use the old split register approach.

(#2046 shows example of incorrect version number decoding)