### PR TITLE
fix: key today_s_solar_energy renamed to today_s_yield

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -10590,14 +10590,21 @@ ENERGY_DASHBOARD_MAPPING = EnergyDashboardMapping(
             needs_aggregation=True,
             allowedtypes=GEN3 | GEN4 | GEN5 | GEN6,
         ),
-        # Solar Production Energy (GEN2-6 today)
+        # Solar Production Energy (AC and Hybrid GEN2-6 today)
         # Aggregate energy totals across Primary + Secondary in parallel mode.
         EnergyDashboardSensorMapping(
             source_key="today_s_solar_energy",
             target_key="solar_energy_production",
             name="Solar Production Energy",
             needs_aggregation=True,
-            allowedtypes=GEN2 | GEN3 | GEN4 | GEN5 | GEN6,
+            allowedtypes=AC | HYBRID | GEN2 | GEN3 | GEN4 | GEN5 | GEN6,
+        ),
+        # Solar Production Energy ( MIC today)
+        EnergyDashboardSensorMapping(
+            source_key="today_s_yield",
+            target_key="solar_energy_production",
+            name="Solar Production Energy",
+            allowedtypes=MIC | GEN | GEN2 | GEN4,
         ),
         # Solar Production Energy (GEN1 Riemann sum)
         # GEN1 lacks native energy counters; integrate power and aggregate in parallel mode.
@@ -10608,7 +10615,7 @@ ENERGY_DASHBOARD_MAPPING = EnergyDashboardMapping(
             use_riemann_sum=True,
             filter_function=lambda v: max(0, v),
             needs_aggregation=True,
-            allowedtypes=GEN,
+            allowedtypes=AC | HYBRID | GEN,
         ),
     ],
 )


### PR DESCRIPTION
Renamed key in energy dashboard for solar production energy from "today_s_solar_energy" renamed to "today_s_yield"

This was needed for my X3-MIC-G2 and tested to work