### PR TITLE
fix(solax): unify firmware version display and key naming across all inverter types

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -267,12 +267,12 @@ async def async_read_inverter_firmware_info(hub: Any) -> int:
         inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=0x7D, count=8)
         if inverter_data is not None and not inverter_data.isError():
             registers = inverter_data.registers
-            data["firmware_dsp"] = int(registers[0])
+            data["firmware_dsp_minor"] = int(registers[0])
             data["firmware_DSP_hardware_version"] = int(registers[1])
             data["firmware_dsp_major"] = int(registers[2])
             data["firmware_arm_major"] = int(registers[3])
             version = int(registers[5])
-            data["firmware_arm"] = int(registers[6])
+            data["firmware_arm_minor"] = int(registers[6])
             data["bootloader_version"] = int(registers[7])
     except Exception:
         _LOGGER.debug(f"{hub.name}: attempt to read inverter firmware info failed data: {inverter_data}", exc_info=True)
@@ -284,8 +284,8 @@ async def async_read_inverter_firmware_info(hub: Any) -> int:
     else:
         hub.modbus_protocol_version = None
         data.pop("modbus_protocol_version", None)
-        data.pop("firmware_version_dsp", None)
-        data.pop("firmware_version_arm", None)
+        data.pop("firmware_dsp", None)
+        data.pop("firmware_arm", None)
         _LOGGER.debug(f"{hub.name}: Modbus protocol document version unavailable")
         return 0
 
@@ -294,13 +294,13 @@ async def async_read_inverter_firmware_info(hub: Any) -> int:
         try:
             full_version_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=0x7B, count=2)
             if full_version_data is not None and not full_version_data.isError():
-                data["firmware_version_dsp"] = int(full_version_data.registers[0])
-                data["firmware_version_arm"] = int(full_version_data.registers[1])
+                data["firmware_dsp"] = int(full_version_data.registers[0])
+                data["firmware_arm"] = int(full_version_data.registers[1])
         except Exception:
             _LOGGER.debug(f"{hub.name}: attempt to read full firmware version failed data: {full_version_data}", exc_info=True)
     else:
-        data.pop("firmware_version_dsp", None)
-        data.pop("firmware_version_arm", None)
+        data.pop("firmware_dsp", None)
+        data.pop("firmware_arm", None)
 
     return version
 
@@ -1351,7 +1351,8 @@ def value_function_battery_capacity_gen5(initval: int, descr: Any, datadict: dic
 
 
 def value_function_software_version_g2(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    return f"DSP v2.{datadict.get('firmware_dsp')} ARM v2.{datadict.get('firmware_arm')}"
+    # AC/HYBRID GEN2: split registers hold raw minor versions with a fixed major of 2
+    return f"DSP v2.{datadict.get('firmware_dsp_minor')} ARM v2.{datadict.get('firmware_arm_minor')}"
 
 
 def value_function_firmware_major_default(val: Any, default: int) -> Any:
@@ -1361,27 +1362,9 @@ def value_function_firmware_major_default(val: Any, default: int) -> Any:
 def value_function_software_version_g3(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
     return (
         f"DSP v{value_function_firmware_major_default(datadict.get('firmware_dsp_major'), 3)}."
-        f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
+        f"{value_str_default(datadict.get('firmware_dsp_minor'), '??'):>02} "
         f"ARM v{value_function_firmware_major_default(datadict.get('firmware_arm_major'), 3)}."
-        f"{value_str_default(datadict.get('firmware_arm'), '??'):>02}"
-    )
-
-
-def value_function_software_version_g4(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    return (
-        f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '?')}."
-        f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
-        f"ARM {value_str_default(datadict.get('firmware_arm_major'), '?')}."
-        f"{value_str_default(datadict.get('firmware_arm'), '??'):>02}"
-    )
-
-
-def value_function_software_version_g5(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    return (
-        f"DSP {value_str_default(datadict.get('firmware_dsp_major'), '???'):>03}."
-        f"{value_str_default(datadict.get('firmware_dsp'), '??'):>02} "
-        f"ARM {value_str_default(datadict.get('firmware_arm_major'), '???'):>03}."
-        f"{value_str_default(datadict.get('firmware_arm'), '??'):>02}"
+        f"{value_str_default(datadict.get('firmware_arm_minor'), '??'):>02}"
     )
 
 
@@ -1392,31 +1375,68 @@ def value_function_modbus_protocol_version(datadict: dict[str, Any]) -> int:
         return 0
 
 
-def value_function_software_version_full(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    dsp = datadict.get("firmware_version_dsp")
-    arm = datadict.get("firmware_version_arm")
-    dsp_str = f"{dsp // 100}.{dsp % 100:02d}" if dsp is not None else "?.??"
-    arm_str = f"{arm // 100}.{arm % 100:02d}" if arm is not None else "?.??"
+def value_function_software_version_mic(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
+    """MIC firmware version. firmware_dsp / firmware_arm hold the full version ÷100 encoded.
+
+    GEN1 — 0x33D/0x33E   GEN2 — 0x352/0x353 (+ 0x354 ARM boot, ÷100)   GEN4 — 0x394/0x390
+    Example (X3-MIC/PRO-G2): 136 → "DSP 1.36 ARM 1.36-1.00", matching SolaX Cloud.
+    """
+    dsp = datadict.get("firmware_dsp") or 0
+    arm = datadict.get("firmware_arm") or 0
+    dsp_str = f"{dsp // 100}.{dsp % 100:02d}" if dsp else "?.??"
+    arm_str = f"{arm // 100}.{arm % 100:02d}" if arm else "?.??"
+    arm_boot = datadict.get("firmware_arm_boot")
+    if arm_boot is not None:
+        arm_str += f"-{arm_boot // 100}.{arm_boot % 100:02d}"  # 0x354 is ÷100 encoded
     return f"DSP {dsp_str} ARM {arm_str}"
 
 
-def value_function_software_version_protocol_aware(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    # FirmwareVersionModbus 100 means V001.00; newer protocol versions can use the combined 0x7B/0x7C registers.
-    if (
-        value_function_modbus_protocol_version(datadict) >= 100
-        and datadict.get("firmware_version_dsp") is not None
-        and datadict.get("firmware_version_arm") is not None
-    ):
-        return value_function_software_version_full(initval, descr, datadict)
-    return value_function_software_version_g4(initval, descr, datadict)
+def value_function_software_version_hybrid_legacy(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
+    """AC/HYBRID with modbus protocol < 100: version is major.minor from split registers.
+
+    DSP = firmware_dsp_major (0x7F) . firmware_dsp_minor (0x7D)
+    ARM = firmware_arm_major (0x80) . firmware_arm_minor (0x83), boot suffix from
+          bootloader_version (0x84, raw minor) — e.g. "ARM 1.58-1.15" (SolaX Cloud).
+    """
+    dsp_maj = datadict.get("firmware_dsp_major")
+    dsp_min = datadict.get("firmware_dsp_minor")
+    arm_maj = datadict.get("firmware_arm_major")
+    arm_min = datadict.get("firmware_arm_minor")
+    dsp_str = f"{dsp_maj}.{dsp_min:02d}" if dsp_maj is not None and dsp_min is not None else "?.??"
+    arm_str = f"{arm_maj}.{arm_min:02d}" if arm_maj is not None and arm_min is not None else "?.??"
+    arm_boot = datadict.get("bootloader_version")
+    if arm_maj is not None and arm_boot is not None:
+        arm_str += f"-{arm_maj}.{arm_boot:02d}"
+    return f"DSP {dsp_str} ARM {arm_str}"
 
 
-def value_function_software_version_air_g3(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    return f"DSP v2.{datadict.get('firmware_dsp')} ARM v1.{datadict.get('firmware_arm')}"
+def value_function_software_version_hybrid_full(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
+    """AC/HYBRID with modbus protocol >= 100: full version ÷100 from combined registers.
+
+    DSP = firmware_dsp (0x7B), ARM = firmware_arm (0x7C), both ÷100 encoded.
+    ARM boot suffix from firmware_arm_major (0x80) + bootloader_version (0x84, raw minor).
+    """
+    dsp = datadict.get("firmware_dsp")
+    arm = datadict.get("firmware_arm")
+    dsp_str = f"{dsp // 100}.{dsp % 100:02d}" if dsp else "?.??"
+    arm_str = f"{arm // 100}.{arm % 100:02d}" if arm else "?.??"
+    arm_maj = datadict.get("firmware_arm_major")
+    arm_boot = datadict.get("bootloader_version")
+    if arm_maj is not None and arm_boot is not None:
+        arm_str += f"-{arm_maj}.{arm_boot:02d}"
+    return f"DSP {dsp_str} ARM {arm_str}"
 
 
-def value_function_software_version_air_g4(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
-    return f"DSP {datadict.get('firmware_dsp')} ARM {datadict.get('firmware_arm')}"
+def value_function_software_version(initval: int, descr: Any, datadict: dict[str, Any]) -> str | None:
+    """AC/HYBRID dispatcher: pick the full or legacy formatter by modbus protocol version.
+
+    Protocol >= 100 exposes the combined full-version registers (0x7B/0x7C); older
+    firmware only has the split major/minor registers.
+    """
+    proto = datadict.get("modbus_protocol_version") or 0
+    if proto >= 100 and datadict.get("firmware_dsp") is not None:
+        return value_function_software_version_hybrid_full(initval, descr, datadict)
+    return value_function_software_version_hybrid_legacy(initval, descr, datadict)
 
 
 def value_function_battery_voltage_cell_difference(initval: int, descr: Any, datadict: dict[str, Any]) -> int | float:
@@ -3877,21 +3897,21 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         icon="mdi:solar-power-variant",
     ),
     SolaXModbusSensorEntityDescription(
-        key="firmware_version_dsp",
+        key="firmware_dsp",
         register=0x7B,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         modbus_min=100,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(
-        key="firmware_version_arm",
+        key="firmware_arm",
         register=0x7C,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         modbus_min=100,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(
-        key="firmware_dsp",
+        key="firmware_dsp_minor",
         register=0x7D,
         allowedtypes=AC | HYBRID,
         internal=True,
@@ -3925,7 +3945,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         icon="mdi:information",
     ),
     SolaXModbusSensorEntityDescription(
-        key="firmware_arm",
+        key="firmware_arm_minor",
         register=0x83,
         allowedtypes=AC | HYBRID,
         internal=True,
@@ -9323,7 +9343,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     SolaXModbusSensorEntityDescription(
         name="Software Version",
         key="software_version",
-        value_function=value_function_software_version_protocol_aware,
+        value_function=value_function_software_version,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:information",
@@ -9427,6 +9447,12 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     SolaXModbusSensorEntityDescription(
         key="firmware_arm",
         register=0x353,
+        allowedtypes=MIC | GEN2,
+        internal=True,
+    ),
+    SolaXModbusSensorEntityDescription(
+        key="firmware_arm_boot",
+        register=0x354,
         allowedtypes=MIC | GEN2,
         internal=True,
     ),
@@ -10781,35 +10807,11 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     SolaXModbusSensorEntityDescription(
         name="Software Version",
         key="software_version",
-        value_function=value_function_software_version_air_g3,
-        allowedtypes=MIC | GEN2 | X1,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:information",
-    ),
-    SolaXModbusSensorEntityDescription(
-        name="Software Version",
-        key="software_version",
-        value_function=value_function_software_version_air_g4,
-        allowedtypes=MIC | GEN4 | X1,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:information",
-    ),
-    SolaXModbusSensorEntityDescription(
-        name="Software Version",
-        key="software_version",
-        value_function=value_function_software_version_air_g4,
-        allowedtypes=MIC | GEN | X3,
+        value_function=value_function_software_version_mic,
+        allowedtypes=MIC,
         blacklist=[
             "MU802T",
         ],
-        entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:information",
-    ),
-    SolaXModbusSensorEntityDescription(
-        name="Software Version",
-        key="software_version",
-        value_function=value_function_software_version_g2,
-        allowedtypes=MIC | GEN2 | X3,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:information",
     ),
@@ -11673,8 +11675,8 @@ class solax_plugin(plugin_base):
                     hub.data["hardware_version"] = value_function_hardware_version_g5(0, None, hub.data)
                 elif invertertype & GEN6:
                     hub.data["hardware_version"] = value_function_hardware_version_g6(0, None, hub.data)
-                if "firmware_dsp" in hub.data or "firmware_version_dsp" in hub.data:
-                    hub.data["software_version"] = value_function_software_version_protocol_aware(0, None, hub.data)
+                if "firmware_dsp" in hub.data or "firmware_dsp_minor" in hub.data:
+                    hub.data["software_version"] = value_function_software_version(0, None, hub.data)
 
             read_eps = configdict.get(CONF_READ_EPS, DEFAULT_READ_EPS)
             read_dcb = configdict.get(CONF_READ_DCB, DEFAULT_READ_DCB)


### PR DESCRIPTION
## Related PRs

- #1839 — established the split-register approach for older protocol (Gen4/Gen5)
- #2014 — extended split-register pattern to GEN3
- #2000 — introduced combined registers 0x7B/0x7C for GEN4/5/6, but was too aggressive (see #2051)
- #2051 — reported that unconditional combined registers break older GEN4/X1-IES firmware
- #2054 — proposed `modbus_min`/`modbus_max` read-time register gating — **this has since landed in 2026.06.7**, and this PR now builds directly on it

## Problem

Firmware version sensors didn't match SolaX Cloud, and firmware key naming was inconsistent across inverter families:

1. **MIC GEN2** (X1 & X3): registers 0x352/0x353 hold the full version ÷100 encoded (136 = 1.36), but the display functions treated them as raw minors with hardcoded prefixes → `DSP v2.136 ARM v2.136`
2. **AC/HYBRID GEN4+**: the ARM bootloader suffix shown by SolaX Cloud (e.g. `1.58-1.15`) was missing even though both source registers were already polled
3. **Key naming**: `firmware_dsp` meant "minor version" for AC/HYBRID (0x7D) but "full version" for MIC (0x352) — no rule to know which was which

## Solution (aligned with 2026.06.7)

This PR is rebased onto 2026.06.7 and **builds on the infrastructure that release introduced** rather than duplicating it:

- **Read-time gating stays**: 0x7B/0x7C keep `modbus_min=100`, so the wrong register set is filtered out before polling — exactly the approach discussed with @rosenrot00 above
- **Early firmware read stays**: `async_read_inverter_firmware_info` is kept, only its output keys are renamed to follow the new naming rule

**Naming rule established**: `firmware_dsp` / `firmware_arm` always hold the full ÷100 value, everywhere. Split components are `firmware_dsp_minor` / `firmware_arm_minor` (0x7D/0x83). The name now states exactly what the register holds.

**One unified `value_function_software_version`** replaces `g4`/`g5`/`full`/`protocol_aware`/`air_g3`/`air_g4` for AC/HYBRID GEN4+ and all MIC:

- AC/HYBRID, proto ≥ 100: full values from 0x7B/0x7C
- AC/HYBRID, proto < 100 or 0x7B unavailable: major × 100 + minor (split registers) — no regression for older firmware (#2051 scenario)
- ARM bootloader suffix from `firmware_arm_major` (0x80) + `bootloader_version` (0x84) → `1.58-1.15`, matching SolaX Cloud
- MIC: full ÷100 values directly; GEN2 adds the boot suffix from new internal sensor 0x354 (÷100) → `1.36-1.00`, matching SolaX Cloud
- `MU802T` blacklist preserved on the collapsed MIC entry

**Deliberately conservative**: AC/HYBRID GEN2/GEN3 keep their legacy per-gen display functions (adapted to the renamed keys). Their split registers hold raw minors with implicit majors ("v2.x"/"v3.x") and no device data confirms the unified format for them — changing their output without evidence would be guesswork.

## Register Map

**AC/HYBRID** (gated on `modbus_protocol_version`, register 0x82):
```
0x7B  firmware_dsp          full ÷100 value      modbus_min=100
0x7C  firmware_arm          full ÷100 value      modbus_min=100
0x7D  firmware_dsp_minor    split minor          (renamed from firmware_dsp)
0x7F  firmware_dsp_major    split major
0x80  firmware_arm_major    split major / boot major
0x83  firmware_arm_minor    split minor          (renamed from firmware_arm)
0x84  bootloader_version    boot minor           (existing sensor, now used in display)
```

**MIC** (no 0x82; registers hold full ÷100 values):
```
GEN1  0x33D/0x33E   firmware_dsp / firmware_arm
GEN2  0x352/0x353   firmware_dsp / firmware_arm   + 0x354 firmware_arm_boot (new, ÷100)
GEN4  0x394/0x390   firmware_dsp / firmware_arm
```

Note: 0x354 is not in the MIC-G2/PRO-G2 Modbus V3.1 document, but a real X3-MIC/PRO-G2 returns the boot version there, matching the "ARM Version 1.36-1.00" shown in SolaX Cloud.

## Verified on real devices (SolaX Cloud vs HA side by side)

| Device | Before | After | SolaX Cloud |
|---|---|---|---|
| X3-MIC/PRO-G2 8kW | `DSP v2.136 ARM v2.136` | `DSP 1.36 ARM 1.36-1.00` | MDSP 1.36 / ARM 1.36-1.00 |
| X3-Hybrid-G4 15kW (proto=100) | `DSP 1.60 ARM 1.58` | `DSP 1.60 ARM 1.58-1.15` | MDSP 1.60 / ARM 1.58-1.15 |

Function-level tests additionally cover: legacy protocol path (proto < 100), proto ≥ 100 with failed 0x7B read (falls back to split), MIC GEN4, and partial/empty data (`?.??` placeholders, no exceptions).

## Reference Documents

| Document | Version | Relevance |
|---|---|---|
| Solax Hybrid X1/X3 ESS Modbus RTU | V1.02 (Nov 2025) | ✅ Primary source — confirms 0x7B–0x84 and the 0x82 gate |
| Solax MIC-G2/PRO-G2 Modbus RTU | V3.1 | ✅ Confirms MIC GEN2 registers 0x352/0x353 |
| Solax X1-MINI/BOOST-G4 Modbus RTU | V2.3 | ✅ Confirms MIC GEN4 registers 0x390/0x394 |

## Testing wanted

Confirmation welcome from: GEN3, GEN5, GEN6, older GEN4 with proto < 100 (X1-IES), MIC GEN1, MIC GEN4. Please report your 0x82 value and whether the displayed version matches your SolaX Cloud "Device Info" page.
