### PR TITLE
Add export limit exceptions for SolaX G4-Pro

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1707,6 +1707,13 @@ MAX_EXPORT: list[tuple[str, int | float]] = [
     ("H3BG20", 20000),  # Gen5 X3 Ultra G
     ("H3BG25", 25000),  # Gen5 X3 Ultra G
     ("H3BG30", 30000),  # Gen5 X3 Ultra G
+    ("10K04", 4000),  # Gen6 X3-Pro-G4
+    ("10K05", 5000),  # Gen6 X3-Pro-G4
+    ("10K06", 6000),  # Gen6 X3-Pro-G4
+    ("10K08", 8000),  # Gen6 X3-Pro-G4
+    ("10K0A", 10000),  # Gen6 X3-Pro-G4
+    ("10K0C", 12000),  # Gen6 X3-Pro-G4
+    ("10K0F", 15000),  # Gen6 X3-Pro-G4
     ("8021", 60000),  # X3-Aelio #1555
     ### All known Inverters added
 ]


### PR DESCRIPTION
The G4-Pro series was missing maximum export exceptions meaning larger inverters were limited to the default 6000.

Fixes #2057.