### PR TITLE
Mark Modbus sensor and number entities as push-updated

### DIFF
--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -159,6 +159,11 @@ class SolaXModbusNumber(NumberEntity):
         self.async_write_ha_state()
 
     @property
+    def should_poll(self) -> bool:
+        """Data is delivered by the hub."""
+        return False
+
+    @property
     def name(self) -> str:
         """Return the name."""
         return f"{self._platform_name} {self._name}"

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -599,6 +599,11 @@ class SolaXModbusSensor(SensorEntity):
         return None
 
     @property
+    def should_poll(self) -> bool:
+        """Data is delivered by the hub."""
+        return False
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         attrs = dict(self._attr_extra_state_attributes)
         if self.entity_description.key == "communication_health":


### PR DESCRIPTION
Set should_poll=False for sensor and number entities because their state is updated by the integration hub. This avoids redundant Home Assistant polling while preserving the existing Modbus polling and push update flow.