### PR TITLE
Fix local entity state restore after number polling was disabled

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -129,7 +129,6 @@ COMM_BLOCK_FAILURE_THRESHOLD = 3
 COMM_BLOCK_FAILURE_WINDOW = 600
 COMM_RECOVERY_INTERVAL = 300
 INFLIGHT_CANCEL_TIMEOUT = 2.0
-CONNECT_RETRY_DELAY = 1.0
 
 
 try:
@@ -530,8 +529,6 @@ class SolaXModbusHub:
             # Fallback dummy client for unrecognized interface types
             self._client = SimpleNamespace(connected=False, comm_params=SimpleNamespace(host="", port=""))
         self._lock = asyncio.Lock()
-        self._connect_lock = asyncio.Lock()
-        self._next_connect_attempt = 0.0
         self._name: str = name
         # following call will modify and extend client in case old modbus API needs to be used
         _LOGGER.debug(f"{name}: using pymodbus version {pymodbus_version_info()}")
@@ -1228,31 +1225,11 @@ class SolaXModbusHub:
     async def _check_connection(self) -> bool:
         if getattr(self, "_stopping", False):
             return False
-        if self._client.connected:
-            return True
-        now = _mtime.monotonic()
-        if now < self._next_connect_attempt:
-            return False
-        async with self._connect_lock:
-            if getattr(self, "_stopping", False):
-                return False
-            if self._client.connected:
-                return True
-            now = _mtime.monotonic()
-            if now < self._next_connect_attempt:
-                return False
+        if not self._client.connected:
             _LOGGER.debug(f"{self._name}: Inverter is not connected, trying to connect")
-            try:
-                await self.async_connect()
-            except Exception as ex:
-                self._next_connect_attempt = _mtime.monotonic() + CONNECT_RETRY_DELAY
-                _LOGGER.debug(f"{self._name}: connect attempt failed: {ex}")
-                return False
-            if not self._client.connected:
-                self._next_connect_attempt = _mtime.monotonic() + CONNECT_RETRY_DELAY
-                return False
-            self._next_connect_attempt = 0.0
-            return True
+            await self.async_connect()
+            await asyncio.sleep(1)
+        return self._client.connected
 
     async def is_online(self) -> bool:
         return self._client.connected and (self.slowdown == 1)
@@ -1270,11 +1247,10 @@ class SolaXModbusHub:
 
     async def async_read_holding_registers(self, unit: int, address: int, count: int) -> Any:
         """Read holding registers using high-level pymodbus API."""
-        if not await self._check_connection():
-            return None
         async with self._lock:
             if getattr(self, "_stopping", False):
                 return None
+            await self._check_connection()
             if not self._client.connected:
                 return None
             try:
@@ -1293,17 +1269,15 @@ class SolaXModbusHub:
                     return None
                 _LOGGER.debug(f"{self._name}: ModbusException – closing transport and deferring reconnect")
                 self._client.close()
-                self._next_connect_attempt = _mtime.monotonic() + CONNECT_RETRY_DELAY
                 return None
         return resp
 
     async def async_read_input_registers(self, unit: int, address: int, count: int) -> Any:
         """Read input registers using high-level pymodbus API."""
-        if not await self._check_connection():
-            return None
         async with self._lock:
             if getattr(self, "_stopping", False):
                 return None
+            await self._check_connection()
             if not self._client.connected:
                 return None
             try:
@@ -1322,7 +1296,6 @@ class SolaXModbusHub:
                     return None
                 _LOGGER.debug(f"{self._name}: ModbusException – closing transport and deferring reconnect")
                 self._client.close()
-                self._next_connect_attempt = _mtime.monotonic() + CONNECT_RETRY_DELAY
                 return None
         return resp
 
@@ -1332,11 +1305,8 @@ class SolaXModbusHub:
             regs = convert_to_registers(int(payload), DataType.UINT16, self.plugin.order32)  # type: ignore[attr-defined]
         else:
             regs = convert_to_registers(int(payload), DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
-        if not await self._check_connection():
-            return None
         async with self._lock:
-            if not self._client.connected:
-                return None
+            await self._check_connection()
             try:
                 resp = await self._track_task(self._client.write_register(address=address, value=regs[0], **kwargs))  # type: ignore[arg-type]
                 # Plugin-level logging hook
@@ -1381,11 +1351,8 @@ class SolaXModbusHub:
         else:
             regs = convert_to_registers(int(payload), DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
         kwargs = {ADDR_KW: unit} if unit is not None else {}
-        if not await self._check_connection():
-            return None
         async with self._lock:
-            if not self._client.connected:
-                return None
+            await self._check_connection()
             try:
                 resp = await self._track_task(self._client.write_registers(address=address, values=regs, **kwargs))  # type: ignore[arg-type]
             except (ConnectionException, ModbusIOException) as e:
@@ -2346,53 +2313,67 @@ class SolaXCoreModbusHub(SolaXModbusHub, CoreModbusHub):  # type: ignore[misc]
             self._hub = None
 
     async def async_connect(self, hub: Any = None) -> Any:
-        if getattr(self, "_stopping", False):
-            return None
-        now = _mtime.monotonic()
-        if now < self._next_connect_attempt:
-            return None
-        async with self._connect_lock:
-            if getattr(self, "_stopping", False):
-                return None
-            now = _mtime.monotonic()
-            if now < self._next_connect_attempt:
-                return None
-            if hub is None and self._hub is not None:
-                hub = self._hub()
-            if hub is None:
+        delay = True
+        while True:
+            # check if strong reference to
+            # get one.
+            if hub is not None or (self._hub is not None and (hub := self._hub()) is not None):
+                port = hub._pb_params.get("port", 0)
+                host = hub._pb_params.get("host", port)
+                # TODO just wait some time and recheck again if client connected before
+                # giving up
+                await hub._lock.acquire()
+                try:
+                    if hub._client and hub._client.connected:
+                        hub._lock.release()
+                        _LOGGER.debug(
+                            "Inverter connected at %s:%s",
+                            host,
+                            port,
+                        )
+                        return hub
+                except (TypeError, AttributeError):
+                    pass
+                hub._lock.release()
+                if not delay:
+                    reason = " core modbus hub '{self._core_hub}' not ready" if hub._config_delay else ""
+                    _LOGGER.warning(f"Unable to connect to Inverter at {host}:{port}.{reason}")
+                    return None
+            else:
+                # get hold of current CoreModbusHub object with
+                # provided entity name
                 try:
                     hub = get_core_hub(self._hass, self._core_hub)
                 except KeyError:
-                    _LOGGER.warning(f"CoreModbusHub '{self._core_hub}' not available")
-                    self._next_connect_attempt = _mtime.monotonic() + CONNECT_RETRY_DELAY
+                    _LOGGER.warning(
+                        f"CoreModbusHub '{self._core_hub}' not available",
+                    )
                     return None
-                if not hub:
-                    _LOGGER.warning("Unable to join core modbus %s", self._core_hub)
-                    self._next_connect_attempt = _mtime.monotonic() + CONNECT_RETRY_DELAY
+                else:
+                    if hub:
+                        # update weak reference handle to refer to
+                        # the actual CoreModbusHub object
+                        self._hub = WeakRef(hub, self._hub_closed_now)
+                        continue
+                if not delay:
+                    _LOGGER.warning(
+                        "Unable to join core modbus %s",
+                        self._core_hub,
+                    )
                     return None
-                self._hub = WeakRef(hub, self._hub_closed_now)
-
-            port = hub._pb_params.get("port", 0)
-            host = hub._pb_params.get("host", port)
-            try:
-                async with hub._lock:
-                    if hub._client and hub._client.connected:
-                        _LOGGER.debug("Inverter connected at %s:%s", host, port)
-                        self._next_connect_attempt = 0.0
-                        return hub
-            except (TypeError, AttributeError):
-                pass
-            reason = f" core modbus hub '{self._core_hub}' not ready" if getattr(hub, "_config_delay", False) else ""
-            _LOGGER.debug(f"Unable to connect to Inverter at {host}:{port}.{reason}")
-            self._next_connect_attempt = _mtime.monotonic() + CONNECT_RETRY_DELAY
-            return None
+            # wait some time (TODO make configurable) before
+            # rechecking if CoreModbusHub object has been created and
+            # connected
+            delay = False
+            await asyncio.sleep(10)
 
     async def async_read_holding_registers(self, unit: int, address: int, count: int) -> Any:
         """Read holding registers."""
         kwargs = {ADDR_KW: unit} if unit is not None else {}
         if getattr(self, "_stopping", False):
             return None
-        hub = await self._check_connection()
+        async with self._lock:
+            hub = await self._check_connection()
         try:
             if not hub or getattr(hub, "_config_delay", False):
                 return None
@@ -2414,7 +2395,8 @@ class SolaXCoreModbusHub(SolaXModbusHub, CoreModbusHub):  # type: ignore[misc]
         kwargs = {ADDR_KW: unit} if unit is not None else {}
         if getattr(self, "_stopping", False):
             return None
-        hub = await self._check_connection()
+        async with self._lock:
+            hub = await self._check_connection()
         try:
             if not hub or getattr(hub, "_config_delay", False):
                 return None
@@ -2442,7 +2424,8 @@ class SolaXCoreModbusHub(SolaXModbusHub, CoreModbusHub):  # type: ignore[misc]
         kwargs = {ADDR_KW: unit} if unit is not None else {}
         if getattr(self, "_stopping", False):
             return None
-        hub = await self._check_connection()
+        async with self._lock:
+            hub = await self._check_connection()
         try:
             if not hub or getattr(hub, "_config_delay", False):
                 return None
@@ -2471,13 +2454,14 @@ class SolaXCoreModbusHub(SolaXModbusHub, CoreModbusHub):  # type: ignore[misc]
         else:
             regs = convert_to_registers(int(payload), DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
         kwargs: dict[str, int] = {ADDR_KW: unit} if unit is not None else {}
-        hub = await self._check_connection()
+        async with self._lock:
+            hub = await self._check_connection()
         try:
-            if not hub or hub._config_delay:
+            if hub._config_delay:
                 return None
             async with hub._lock:
                 try:
-                    resp = await self._track_task(hub._client.write_registers(address=address, values=regs, **kwargs))
+                    resp = await self._client.write_registers(address=address, values=regs, **kwargs)  # type: ignore[arg-type]
                 except (ConnectionException, ModbusIOException) as e:
                     original_message = str(e)
                     raise HomeAssistantError(f"Error writing single Modbus registers: {original_message}") from e
@@ -2536,13 +2520,14 @@ class SolaXCoreModbusHub(SolaXModbusHub, CoreModbusHub):  # type: ignore[misc]
                     _LOGGER.error(f"unsupported unit type: {typ} for {key}")
             # for easier debugging, make next line a _LOGGER.info line
             _LOGGER.debug(f"Ready to write multiple registers at 0x{address:02x}: {regs_out}")
-            hub = await self._check_connection()
+            async with self._lock:
+                hub = await self._check_connection()
             try:
-                if not hub or hub._config_delay:
+                if hub._config_delay:
                     return None
                 async with hub._lock:
                     try:
-                        resp = await self._track_task(hub._client.write_registers(address=address, values=regs_out, **kwargs))
+                        resp = await self._client.write_registers(address=address, values=regs_out, **kwargs)  # type: ignore[arg-type]
                     except (ConnectionException, ModbusIOException) as e:
                         original_message = str(e)
                         raise HomeAssistantError(f"Error writing multiple Modbus registers: {original_message}") from e

--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -141,12 +141,19 @@ class SolaXModbusNumber(NumberEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
+        if self._write_method == WRITE_DATA_LOCAL:
+            self.async_on_remove(self.hass.bus.async_listen("solax_modbus_local_data_loaded", self._handle_local_data_loaded))
+            self.async_write_ha_state()
+            return
+
         # Skip hub registration for computed/internal entities (those without modbus registers)
         if self.entity_description.register is None or self.entity_description.register < 0:
             return
         await self._hub.async_add_solax_modbus_sensor(self)
 
     async def async_will_remove_from_hass(self) -> None:
+        if self._write_method == WRITE_DATA_LOCAL or self.entity_description.register is None or self.entity_description.register < 0:
+            return
         await self._hub.async_remove_solax_modbus_sensor(self)
 
     """ remove duplicate declaration
@@ -156,6 +163,12 @@ class SolaXModbusNumber(NumberEntity):
 
     @callback
     def modbus_data_updated(self) -> None:
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_local_data_loaded(self, event: Any) -> None:
+        if (event.data or {}).get("hub_name") != self._hub._name:
+            return
         self.async_write_ha_state()
 
     @property

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -3749,7 +3749,7 @@ SELECT_TYPES: Sequence["SolaxModbusSelectEntityDescription"] = [
             2: "Inverter",
         },
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
-        modbus_min=101,
+        modbus_min=100,
         icon="mdi:dip-switch",
     ),
     SolaxModbusSelectEntityDescription(
@@ -4678,7 +4678,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
             2: "Inverter",
         },
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
-        modbus_min=101,
+        modbus_min=100,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(

--- a/custom_components/solax_modbus/select.py
+++ b/custom_components/solax_modbus/select.py
@@ -112,16 +112,29 @@ class SolaXModbusSelect(SelectEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
+        if self._write_method == WRITE_DATA_LOCAL:
+            self.async_on_remove(self.hass.bus.async_listen("solax_modbus_local_data_loaded", self._handle_local_data_loaded))
+            self.async_write_ha_state()
+            return
+
         # Skip hub registration for computed/internal entities (those without modbus registers)
         if self.entity_description.register is None or self.entity_description.register < 0:
             return
         await self._hub.async_add_solax_modbus_sensor(self)
 
     async def async_will_remove_from_hass(self) -> None:
+        if self._write_method == WRITE_DATA_LOCAL or self.entity_description.register is None or self.entity_description.register < 0:
+            return
         await self._hub.async_remove_solax_modbus_sensor(self)
 
     @callback
     def modbus_data_updated(self) -> None:
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_local_data_loaded(self, event: Any) -> None:
+        if (event.data or {}).get("hub_name") != self._hub._name:
+            return
         self.async_write_ha_state()
 
     @property

--- a/custom_components/solax_modbus/switch.py
+++ b/custom_components/solax_modbus/switch.py
@@ -6,7 +6,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -151,10 +151,11 @@ class SolaXModbusSwitch(SwitchEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        # Skip hub registration for computed/internal entities (those without modbus registers)
-        if self.entity_description.register is None or self.entity_description.register < 0:
-            return
         if self.entity_description.write_method != WRITE_DATA_LOCAL:
+            return
+        self.async_on_remove(self.hass.bus.async_listen("solax_modbus_local_data_loaded", self._handle_local_data_loaded))
+        if self._sensor_key is not None and self._sensor_key in self._hub.data:
+            self.async_write_ha_state()
             return
         last_state = await self.async_get_last_state()
         if not last_state or last_state.state in ("unknown", "unavailable"):
@@ -163,6 +164,12 @@ class SolaXModbusSwitch(SwitchEntity, RestoreEntity):
         self._attr_is_on = is_on
         if self._sensor_key is not None:
             self._hub.data[self._sensor_key] = 1 if is_on else 0
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_local_data_loaded(self, event: Any) -> None:
+        if (event.data or {}).get("hub_name") != self._hub._name:
+            return
         self.async_write_ha_state()
 
     async def _write_switch_to_modbus(self) -> None:

--- a/custom_components/solax_modbus/time.py
+++ b/custom_components/solax_modbus/time.py
@@ -79,14 +79,24 @@ class SolaXModbusTimeEntity(TimeEntity):
         self._option_dict = time_info.option_dict
         self.entity_description = time_info
         self._write_method = time_info.write_method
+        self._attr_native_value = None
         # wordcount for separate register format (e.g., hours and minutes in adjacent registers)
         self._wordcount = getattr(time_info, "wordcount", None) or 1
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
+        if self._write_method == WRITE_DATA_LOCAL:
+            self.async_on_remove(self.hass.bus.async_listen("solax_modbus_local_data_loaded", self._handle_local_data_loaded))
+            self.modbus_data_updated()
+            return
+
+        if self.entity_description.register is None or self.entity_description.register < 0:
+            return
         await self._hub.async_add_solax_modbus_sensor(self)
 
     async def async_will_remove_from_hass(self) -> None:
+        if self._write_method == WRITE_DATA_LOCAL or self.entity_description.register is None or self.entity_description.register < 0:
+            return
         await self._hub.async_remove_solax_modbus_sensor(self)
 
     @callback
@@ -95,6 +105,12 @@ class SolaXModbusTimeEntity(TimeEntity):
         # Clear the cached property by setting _attr_native_value
         self._attr_native_value = self._parse_time_value()
         self.async_write_ha_state()
+
+    @callback
+    def _handle_local_data_loaded(self, event: Any) -> None:
+        if (event.data or {}).get("hub_name") != self._hub._name:
+            return
+        self.modbus_data_updated()
 
     def _parse_time_value(self) -> datetime_time | None:
         """Parse the time value from hub.data and return a datetime.time object.

--- a/custom_components/solax_modbus/time.py
+++ b/custom_components/solax_modbus/time.py
@@ -18,6 +18,7 @@ from .const import (
     WRITE_DATA_LOCAL,
     WRITE_MULTISINGLE_MODBUS,
     WRITE_SINGLE_MODBUS,
+    BaseModbusTimeEntityDescription,
     matches_modbus_protocol,
 )
 
@@ -58,6 +59,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
 class SolaXModbusTimeEntity(TimeEntity):
     """Representation of an SolaX Modbus time entity."""
+
+    entity_description: BaseModbusTimeEntityDescription
 
     def __init__(
         self,


### PR DESCRIPTION
This fixes local WRITE_DATA_LOCAL entities staying unknown after Home Assistant restart.

The regression was introduced by my commit 4770711, which added should_poll = False to number entities. That change is correct for Modbus-backed entities because their state is pushed by the hub, but local entities such as remotecontrol_timeout have no Modbus register and are intentionally skipped from hub polling. As a result, their persisted values were loaded into hub.data but never pushed to Home Assistant.

This PR keeps should_poll = False and keeps local entities out of Modbus polling. Instead, local number/select/time/switch entities now refresh their HA state when local data has been loaded.

@wills106 please push another release with this fix.