### PR TITLE
Enable main breaker for modbus version 1.00

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -2187,7 +2187,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=NumberDeviceClass.CURRENT,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
-        modbus_min=102,
+        modbus_min=100,
     ),
     SolaxModbusNumberEntityDescription(
         name="Bias Power",
@@ -4829,7 +4829,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         key="main_breaker_current_limit",
         register=0xD7,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
-        modbus_min=102,
+        modbus_min=100,
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(


### PR DESCRIPTION
It worked for me previously so I think we can change its modbus min version from 1.02 to 1.00.
