### PR TITLE
Secure inverter_model from being overwritten.

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_PORT,
-    EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
     PERCENTAGE,
     Platform,
@@ -414,19 +413,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "hub": hub,
     }
 
-    # Tests on some systems have shown that establishing the Modbus connection
-    # can occasionally lead to errors if Home Assistant is not fully loaded.
-    if hass.is_running:
-        # Start init in background so it can be cancelled on unload
-        hub._init_task = hass.loop.create_task(hub.async_init())
-    else:
-        # Defer until HA is started, but still capture the task handle for cancellation
-        async def _deferred_init(event: Any) -> None:
-            if getattr(hub, "_stopping", False):
-                return
-            hub._init_task = hass.loop.create_task(hub.async_init())
-
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _deferred_init)
+    await hub.async_init()
 
     entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
     return True
@@ -590,6 +577,8 @@ class SolaXModbusHub:
         self.config: Any = config  # MappingProxyType from entry.options
         self.entry: ConfigEntry = entry
         self.device_info: DeviceInfo | None = None
+        self.inverter_model: str | None = None
+        self._has_local_inverter_model: bool = False
         self.blocks_changed: bool = False
         self.initial_groups: dict[Any, Any] = {}  # as returned by the sensor setup - holdingRegs and inputRegs should not change
 
@@ -691,7 +680,7 @@ class SolaXModbusHub:
         self.device_info = DeviceInfo(
             identifiers=cast(set[tuple[str, str]], {(DOMAIN, self._name, INVERTER_IDENT)}),
             manufacturer=self.plugin.plugin_manufacturer,
-            model=getattr(self.plugin, "inverter_model", None),
+            model=self._get_inverter_model(),
             name=plugin_name,
             serial_number=self.seriesnumber,
             sw_version=self.plugin.getSoftwareVersion(self.data),
@@ -722,6 +711,11 @@ class SolaXModbusHub:
 
         self._init_task = None
 
+    def _get_inverter_model(self) -> str | None:
+        if self._has_local_inverter_model:
+            return self.inverter_model
+        return getattr(self.plugin, "inverter_model", None)
+
     async def _deferred_setup_loop(self, interval: int = 30) -> None:
         """Keep trying to detect inverter type and forward platforms once online."""
         import asyncio
@@ -743,7 +737,7 @@ class SolaXModbusHub:
                     self.device_info = DeviceInfo(
                         identifiers=cast(set[tuple[str, str]], {(DOMAIN, self._name, INVERTER_IDENT)}),
                         manufacturer=self.plugin.plugin_manufacturer,
-                        model=getattr(self.plugin, "inverter_model", None),
+                        model=self._get_inverter_model(),
                         name=plugin_name,
                         serial_number=self.seriesnumber,
                         sw_version=self.plugin.getSoftwareVersion(self.data),

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -11300,6 +11300,7 @@ class solax_plugin(plugin_base):
     async def async_determineInverterType(self, hub: Any, configdict: dict[str, Any]) -> int:
         # global SENSOR_TYPES
         _LOGGER.info(f"{hub.name}: trying to determine inverter type")
+        self.inverter_model = None
         seriesnumber = await async_read_serialnr(hub, 0x0)
         if not seriesnumber:
             seriesnumber = await async_read_serialnr(hub, 0x300)  # bug in Endian.LITTLE decoding?
@@ -11684,6 +11685,9 @@ class solax_plugin(plugin_base):
         else:
             invertertype = 0
             _LOGGER.error(f"unrecognized inverter type - serial number : {seriesnumber}")
+
+        hub.inverter_model = self.inverter_model if invertertype > 0 else None
+        hub._has_local_inverter_model = True
 
         if invertertype > 0:
             # Firmware metadata is needed before the first poll so the device registry and


### PR DESCRIPTION
In cases of more than one inverter recent changes made the inverter_model being prone to be overwritten. This should fix that wrong inverters are initialized in parallel setups.