### PR TITLE
Increase Gen6 X1-VAST battery max current from 30A to 50A

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1562,7 +1562,7 @@ MAX_CURRENTS: list[tuple[str, int | float]] = [
     ("H55", 50),  # Gen5 X1-IES
     ("H56", 50),  # Gen5 X1-IES
     ("H58", 50),  # Gen5 X1-IES
-    ("10M", 30),  # Gen6 X1-VAST
+    ("10M", 50),  # Gen6 X1-VAST
     ("F34", 30),  # Gen4 X3 RetroFit
     ("H31", 30),  # Gen4 X3 TIGO
     ("H34A", 30),  # Gen4 X3 A


### PR DESCRIPTION
I know it might be that this depends on the attached battery, but does it hurt if we just set the limit to 50A in general?

Other installations that can't do 50A won't allow it anyway.