### PR TITLE
Fix Sofar Software Version wordcount to prevent string triplication

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -1195,7 +1195,7 @@ SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         key="software_version",
         register=0x44F,
         register_data_type=REGISTER_STR,
-        wordcount=12,
+        wordcount=4,
         entity_category=EntityCategory.DIAGNOSTIC,
         allowedtypes=HYBRID | PV,
     ),


### PR DESCRIPTION
### Description
On Sofar/ZCS HYD inverters (specifically tested on ZCS HYD 6000HP), the `software_version` sensor on register `0x44F` returns a triplicated string like `0V0700040V0700040V070004` instead of just `0V070004`. 

This happens because the current `wordcount` is set to `12` (requesting 24 characters). Since the actual software version string format is exactly 8 characters long, it only spans 4 registers. Reducing `wordcount` from `12` to `4` properly limits the read scope and fixes the sensor output.

### Inverter Model
ZCS Azzurro HYD 6000HP (Sofar Solar HYD series)
