### PR TITLE
Growatt: recognize TTS serial prefixes in inverter type detection

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -9677,6 +9677,8 @@ class growatt_plugin(plugin_base):
             invertertype = HYBRID | GEN4 | X3 | MPPT3  # MOD 10000 TL3-HU Hybrid, 3 MPPT
         elif seriesnumber.startswith("DO1"):
             invertertype = HYBRID | GEN4 | X3 | MPPT3  # MOD 12000 TL3-HU Hybrid, 3 MPPT
+        elif seriesnumber.startswith("TTS"):
+            invertertype = HYBRID | GEN4 | X3 | MPPT3  # Hybrid KTL3-HU 12kW
         elif seriesnumber.startswith("TSS"):
             invertertype = HYBRID | GEN4 | X3 | MPPT3  # Hybrid KTL3-HU 12kW
         elif seriesnumber.startswith("PYL"):


### PR DESCRIPTION
This PR adds Growatt inverter type detection for serial numbers starting with `TTS`.

Tested with:
- Model: Growatt MOD 13KTL3-HU
- Observed serial prefix: `TTS
- Firmware: `DO1.0ZBDC`
- Logger: ShineWiLan-X2
- Connection: Modbus TCP, port 502, slave ID 1