### PR TITLE
fix: standardize entity and device naming across all platforms

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -675,14 +675,16 @@ class SolaXModbusHub:
             return
 
         # Prepare device_info (inverter detected during initial window)
-        plugin_name = self.plugin.plugin_name
+        # Device name = hub name + optional suffix (e.g. "EV" + "Charger" -> "EV Charger").
+        # Unique per config entry; entity names never repeat it, HA composes the friendly name.
+        device_name = self._name
         if self.inverterNameSuffix is not None and self.inverterNameSuffix != "":
-            plugin_name = plugin_name + " " + self.inverterNameSuffix
+            device_name = device_name + " " + self.inverterNameSuffix
         self.device_info = DeviceInfo(
             identifiers=cast(set[tuple[str, str]], {(DOMAIN, self._name, INVERTER_IDENT)}),
             manufacturer=self.plugin.plugin_manufacturer,
             model=self._get_inverter_model(),
-            name=plugin_name,
+            name=device_name,
             serial_number=self.seriesnumber,
             sw_version=self.plugin.getSoftwareVersion(self.data),
             hw_version=self.plugin.getHardwareVersion(self.data),
@@ -732,14 +734,14 @@ class SolaXModbusHub:
                     self._invertertype = inv
                     _LOGGER.debug(f"{self._name}: inverter detected during deferred setup (type={inv}) – forwarding platforms")
                     # Prepare/refresh device_info in case it wasn't set
-                    plugin_name = self.plugin.plugin_name
+                    device_name = self._name
                     if self.inverterNameSuffix:
-                        plugin_name = plugin_name + " " + self.inverterNameSuffix
+                        device_name = device_name + " " + self.inverterNameSuffix
                     self.device_info = DeviceInfo(
                         identifiers=cast(set[tuple[str, str]], {(DOMAIN, self._name, INVERTER_IDENT)}),
                         manufacturer=self.plugin.plugin_manufacturer,
                         model=self._get_inverter_model(),
-                        name=plugin_name,
+                        name=device_name,
                         serial_number=self.seriesnumber,
                         sw_version=self.plugin.getSoftwareVersion(self.data),
                         hw_version=self.plugin.getHardwareVersion(self.data),

--- a/custom_components/solax_modbus/button.py
+++ b/custom_components/solax_modbus/button.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import replace
 from time import time
 from typing import Any
 
@@ -36,17 +35,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     hub = hass.data[DOMAIN][hub_name]["hub"]
 
     plugin = hub.plugin
-    inverter_name_suffix = ""
-    if hub.inverterNameSuffix is not None and hub.inverterNameSuffix != "":
-        inverter_name_suffix = hub.inverterNameSuffix + " "
-
     entities = []
     for button_info in plugin.BUTTON_TYPES:
         if plugin.matchInverterWithMask(
             hub._invertertype, button_info.allowedtypes, hub.seriesnumber, button_info.blacklist
         ) and matches_modbus_protocol(hub, button_info):
-            if not (button_info.name.startswith(inverter_name_suffix)):
-                button_info = replace(button_info, name=inverter_name_suffix + button_info.name)
             button = SolaXModbusButton(hub_name, hub, modbus_addr, hub.device_info, button_info)
             entities.append(button)
             if button_info.key == plugin.wakeupButton():
@@ -80,6 +73,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class SolaXModbusButton(ButtonEntity):
     """Representation of an SolaX Modbus button."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         platform_name: str,
@@ -105,8 +100,8 @@ class SolaXModbusButton(ButtonEntity):
 
     @property
     def name(self) -> str:
-        """Return the name."""
-        return f"{self._platform_name} {self._name}"
+        """Return the entity name (description name only — the device name provides context)."""
+        return str(self._name or self._key)
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -37,10 +37,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     hub = hass.data[DOMAIN][hub_name]["hub"]
 
     plugin = hub.plugin  # getPlugin(hub_name)
-    inverter_name_suffix = ""
-    if hub.inverterNameSuffix is not None and hub.inverterNameSuffix != "":
-        inverter_name_suffix = hub.inverterNameSuffix + " "
-
     entities = []
     for number_info in plugin.NUMBER_TYPES:
         newdescr = number_info
@@ -54,9 +50,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         if plugin.matchInverterWithMask(hub._invertertype, newdescr.allowedtypes, hub.seriesnumber, newdescr.blacklist) and matches_modbus_protocol(
             hub, newdescr
         ):
-            if not (newdescr.name.startswith(inverter_name_suffix)):
-                newdescr = replace(newdescr, name=inverter_name_suffix + newdescr.name)
-
             number = SolaXModbusNumber(hub_name, hub, modbus_addr, hub.device_info, newdescr)
             if newdescr.write_method == WRITE_DATA_LOCAL:
                 hub.writeLocals[newdescr.key] = newdescr
@@ -90,6 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class SolaXModbusNumber(NumberEntity):
     """Representation of an SolaX Modbus number."""
 
+    _attr_has_entity_name = True
     entity_description: BaseModbusNumberEntityDescription
 
     def __init__(
@@ -178,8 +172,8 @@ class SolaXModbusNumber(NumberEntity):
 
     @property
     def name(self) -> str:
-        """Return the name."""
-        return f"{self._platform_name} {self._name}"
+        """Return the entity name (description name only — the device name provides context)."""
+        return str(self._name or self._key)
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/solax_modbus/select.py
+++ b/custom_components/solax_modbus/select.py
@@ -36,18 +36,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     hub = hass.data[DOMAIN][hub_name]["hub"]
 
     plugin = hub.plugin  # getPlugin(hub_name)
-    inverter_name_suffix = ""
-    if hub.inverterNameSuffix is not None and hub.inverterNameSuffix != "":
-        inverter_name_suffix = hub.inverterNameSuffix + " "
-
     entities = []
     for select_info in plugin.SELECT_TYPES:
         if plugin.matchInverterWithMask(
             hub._invertertype, select_info.allowedtypes, hub.seriesnumber, select_info.blacklist
         ) and matches_modbus_protocol(hub, select_info):
             select_info = replace(select_info, reverse_option_dict={v: k for k, v in select_info.option_dict.items()})
-            if not (select_info.name.startswith(inverter_name_suffix)):
-                select_info = replace(select_info, name=inverter_name_suffix + select_info.name)
             select = SolaXModbusSelect(hub_name, hub, modbus_addr, hub.device_info, select_info)
             if select_info.write_method == WRITE_DATA_LOCAL:
                 if select_info.initvalue is not None:
@@ -86,6 +80,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class SolaXModbusSelect(SelectEntity):
     """Representation of an SolaX Modbus select."""
 
+    _attr_has_entity_name = True
     entity_description: BaseModbusSelectEntityDescription
 
     def __init__(
@@ -170,8 +165,8 @@ class SolaXModbusSelect(SelectEntity):
 
     @property
     def name(self) -> str:
-        """Return the name."""
-        return f"{self._platform_name} {self._name}"
+        """Return the entity name (description name only — the device name provides context)."""
+        return str(self._name or self._key)
 
     @property
     def should_poll(self) -> bool:

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -159,10 +159,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 dev_registry.async_update_device(device.id, sw_version=sw_version, hw_version=hw_version)
         return True
 
+    # Entity names never carry the inverter suffix — the device name provides that context.
     inverter_name_suffix = ""
-    # Test: Comment out to prevent adding inverter suffix to Energy Dashboard sensors
-    # if hub.inverterNameSuffix is not None and hub.inverterNameSuffix != "":
-    #     inverter_name_suffix = hub.inverterNameSuffix + " "
 
     # Check if hub initialization is complete
     if hub.device_info is None:
@@ -228,17 +226,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     if batt_pack_serial is None:
                         continue
 
+                # Battery pack device name = hub name + pack identity (unique per config entry);
+                # entity names never repeat it, HA composes the friendly name.
                 device_info_battery = DeviceInfo(
                     identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, batt_pack_id)}),
-                    name=hub.plugin.plugin_name + f" Battery {batt_nr + 1}/{batt_pack_nr + 1}",
+                    name=f"{hub_name} Battery {batt_nr + 1}/{batt_pack_nr + 1}",
                     manufacturer=hub.plugin.plugin_manufacturer,
                     serial_number=batt_pack_serial,
                     via_device=cast(tuple[str, str], (DOMAIN, hub_name, INVERTER_IDENT)),
                 )
 
-                name_prefix = battery_config.battery_sensor_name_prefix.replace("{batt-nr}", str(batt_nr + 1)).replace(
-                    "{pack-nr}", str(batt_pack_nr + 1)
-                )
                 key_prefix = battery_config.battery_sensor_key_prefix.replace("{batt-nr}", str(batt_nr + 1)).replace(
                     "{pack-nr}", str(batt_pack_nr + 1)
                 )
@@ -275,7 +272,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     computedRegs,
                     device_info_battery,
                     battery_config.battery_sensor_type,
-                    name_prefix,
+                    "",  # entity names never carry the pack prefix — the battery device name provides it
                     key_prefix,
                     readPreparation,
                     readFollowUpBattery,
@@ -553,6 +550,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class SolaXModbusSensor(SensorEntity):
     """Representation of an SolaX Modbus sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         platform_name: str,
@@ -617,10 +616,8 @@ class SolaXModbusSensor(SensorEntity):
 
     @property
     def name(self) -> str:
-        """Return the name."""
-        if self.entity_description.key in COMMUNICATION_SENSOR_KEYS:
-            return str(self.entity_description.name or self.entity_description.key)
-        return f"{self._platform_name} {self.entity_description.name}"
+        """Return the entity name (description name only — the device name provides context)."""
+        return str(self.entity_description.name or self.entity_description.key)
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/solax_modbus/switch.py
+++ b/custom_components/solax_modbus/switch.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
@@ -34,18 +33,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     hub = hass.data[DOMAIN][hub_name]["hub"]
 
     plugin = hub.plugin  # getPlugin(hub_name)
-    inverter_name_suffix = ""
-    if hub.inverterNameSuffix is not None and hub.inverterNameSuffix != "":
-        inverter_name_suffix = hub.inverterNameSuffix + " "
-
     entities = []
 
     for switch_info in plugin.SWITCH_TYPES:
         if plugin.matchInverterWithMask(
             hub._invertertype, switch_info.allowedtypes, hub.seriesnumber, switch_info.blacklist
         ) and matches_modbus_protocol(hub, switch_info):
-            if not (switch_info.name.startswith(inverter_name_suffix)):
-                switch_info = replace(switch_info, name=inverter_name_suffix + switch_info.name)
             switch = SolaXModbusSwitch(hub_name, hub, modbus_addr, hub.device_info, switch_info)
             if switch_info.value_function:
                 hub.computedSwitches[switch_info.key] = switch_info
@@ -108,6 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class SolaXModbusSwitch(SwitchEntity, RestoreEntity):
     """Representation of an SolaX Modbus switch."""
 
+    _attr_has_entity_name = True
     entity_description: BaseModbusSwitchEntityDescription
 
     def __init__(
@@ -223,6 +217,11 @@ class SolaXModbusSwitch(SwitchEntity, RestoreEntity):
             return bool(sensor_value & (1 << self._bit))
 
         return self._attr_is_on
+
+    @property
+    def name(self) -> str:
+        """Return the entity name (description name only — the device name provides context)."""
+        return str(self._name or self._key)
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/solax_modbus/time.py
+++ b/custom_components/solax_modbus/time.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import replace
 from datetime import datetime
 from datetime import time as datetime_time
 from typing import Any
@@ -35,17 +34,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     hub = hass.data[DOMAIN][hub_name]["hub"]
 
     plugin = hub.plugin  # getPlugin(hub_name)
-    inverter_name_suffix = ""
-    if hub.inverterNameSuffix is not None and hub.inverterNameSuffix != "":
-        inverter_name_suffix = hub.inverterNameSuffix + " "
-
     entities = []
     for time_info in plugin.TIME_TYPES:
         if plugin.matchInverterWithMask(hub._invertertype, time_info.allowedtypes, hub.seriesnumber, time_info.blacklist) and matches_modbus_protocol(
             hub, time_info
         ):
-            if not (time_info.name.startswith(inverter_name_suffix)):
-                time_info = replace(time_info, name=inverter_name_suffix + time_info.name)
             time_entity = SolaXModbusTimeEntity(hub_name, hub, modbus_addr, hub.device_info, time_info)
             if time_info.write_method == WRITE_DATA_LOCAL:
                 if time_info.initvalue is not None:
@@ -60,6 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class SolaXModbusTimeEntity(TimeEntity):
     """Representation of an SolaX Modbus time entity."""
 
+    _attr_has_entity_name = True
     entity_description: BaseModbusTimeEntityDescription
 
     def __init__(
@@ -180,14 +174,14 @@ class SolaXModbusTimeEntity(TimeEntity):
         return self._attr_native_value
 
     @property
-    def name(self) -> str:
-        """Return the name."""
-        return f"{self._platform_name} {self._name}"
-
-    @property
     def should_poll(self) -> bool:
         """Data is delivered by by the hub"""
         return False
+
+    @property
+    def name(self) -> str:
+        """Return the entity name (description name only — the device name provides context)."""
+        return str(self._name or self._key)
 
     @property
     def unique_id(self) -> str | None:

--- a/tests/unit/test_device_info_regressions.py
+++ b/tests/unit/test_device_info_regressions.py
@@ -228,11 +228,11 @@ class TestDeviceInfoInitializationPattern:
 
         # Find both device_info initialization patterns
         # Pattern 1: Initial setup (in async_init_hub around line 640)
-        initial_pattern = r"plugin_name = self\.plugin\.plugin_name\s+if self\.inverterNameSuffix.*?self\.device_info = DeviceInfo\("
+        initial_pattern = r"device_name = self\._name\s+if self\.inverterNameSuffix.*?self\.device_info = DeviceInfo\("
         initial_match = re.search(initial_pattern, content, re.DOTALL)
 
         # Pattern 2: Deferred setup (in _deferred_setup_loop around line 687)
-        deferred_pattern = r"plugin_name = self\.plugin\.plugin_name\s+if self\.inverterNameSuffix.*?self\.device_info = DeviceInfo\("
+        deferred_pattern = r"device_name = self\._name\s+if self\.inverterNameSuffix.*?self\.device_info = DeviceInfo\("
         deferred_matches = list(re.finditer(deferred_pattern, content, re.DOTALL))
 
         assert len(deferred_matches) >= 1, "Could not find device_info initialization patterns"


### PR DESCRIPTION
## Problem

Entity naming is built three different ways depending on the platform, so the same integration produces inconsistent friendly names and entity_ids — and with an inverter name suffix configured, doubled words:

| Platform | Current convention | `has_entity_name` |
|---|---|---|
| sensor | `"{hub_name} {description name}"` (legacy composition, no suffix) | ❌ |
| select, number, button, time | `"{hub_name} {suffix} {description name}"` | ❌ |
| switch | `"{suffix} {description name}"` — hub missing entirely | ❌ |
| device name | `plugin_name + suffix` | — |

### Real-world example (hub name `EV`, suffix `Charger`, X3 EVC device)

| Layer | Current | Problem |
|---|---|---|
| Device name | `SolaX EV Charger Charger` | plugin_name already ends with "Charger", suffix appends it again |
| Switch friendly name | `Charger Electronic Lock` | hub name missing — and its entity_id (`switch.charger_electronic_lock`) is not even scoped to the hub |
| Number friendly name | `EV Charger Overload Limit` | looks right **only by accident** — "EV" + "Charger" happens to spell the device name; any other hub-name/suffix combination renders doubled or mismatched |
| Two hubs, same plugin | `SolaX Inverter` + `SolaX Inverter` | device names collide, users must rename manually |

## Change

One convention, applied identically to all six platforms:

```
device name   = hub name + " " + suffix        →  "EV Charger"
entity name   = description name               →  "Electronic Lock"
                (fallback: entity key, on all six platforms)
friendly name = composed by HA (has_entity_name=True)
              →  "EV Charger Electronic Lock"
```

- `_attr_has_entity_name = True` on sensor, select, switch, number, button, time
- every platform exposes the **same** `name` property: `str(description name or key)` — no hub-name composition, no setup-time suffix injection (`replace(descr, name=suffix + name)` removed everywhere)
- device name = `hub_name + suffix` instead of `plugin_name + suffix` — the suffix now exists in exactly **one** place, and device names are unique per config entry
- **battery pack sub-devices follow the same rule**: device = `"{hub} Battery {n}/{m}"`, entity names no longer carry the pack prefix (keys keep it — identity unchanged). Previously the pack identity lived in both the device name and the entity name, which would have doubled under `has_entity_name`. `battery_sensor_name_prefix` stays in `base_battery_config` for API compatibility but is no longer applied to names.

### Before/after (hub `EV`, suffix `Charger`)

| | Before | After |
|---|---|---|
| Device | SolaX EV Charger **Charger** | EV Charger |
| Switch | Charger Electronic Lock (no hub) | EV Charger Electronic Lock |
| Sensor | EV Firmware Version (no suffix) | EV Charger Firmware Version |
| Select | EV Charger ECO Gear | EV Charger ECO Gear (unchanged) |

## Compatibility

- **`unique_id` untouched** (`{hub_name}_{key}`, byte-identical on all six platforms before and after) — no entity identity changes, nothing breaks
- Existing **entity_ids and history are preserved**: HA resolves stored entity_ids by unique_id before ever invoking its generator, so the new naming applies to friendly names immediately and to entity_ids only for newly created entities (or via HA's "Recreate entity IDs" dialog, opt-in)
- Entities group properly under their device in the UI (standard `has_entity_name` behaviour per HA developer docs)
- Applies uniformly to all 17 brand plugins — naming lives entirely in the platform files
- None-name handling strictly improves: previously a nameless description rendered the literal string `"None"` inside composed names; now it falls back to the entity key (generalizing the pattern upstream already used for its communication sensors). A repo-wide scan confirms zero non-internal descriptions currently lack a name, so this is defensive only.

## Testing

- Verified live on three hubs (X3-Hybrid-G4 15kW, X3-MIC/PRO-G2, X3 EVC 11kW): friendly names consistent across all six platforms, no doubled words, device names unique
- Adversarial review pass performed; both findings (battery pack doubling, None-name fallback) fixed — see review comment below
- Automated uniformity check: `has_entity_name`, name rule, unique_id rule, no suffix injection, no manual entity_id — identical across all six platform files
- `test_device_info_regressions.py` updated for the renamed device-name variable (same structural guarantee, both init paths verified identical)

## Entity IDs & areas (clarification)

This PR never sets `entity_id` — HA core generates it. The PR only supplies the two clean inputs (device name, entity name); HA composes:

```
entity_id (first registration) = slug(device name) + "_" + slug(entity name)
                               = switch.ev_charger_electronic_lock
```

- **No area is involved** in normal registration — a device's area assignment does **not** change entity IDs (verified: assigning an area leaves every existing ID untouched).
- The area only ever enters an entity_id if a user explicitly clicks HA's **"Recreate entity IDs"** dialog while the device is in an area — that is HA core behaviour and is outside this integration's control.
- Because `unique_id` is unchanged, existing installs keep their current entity IDs regardless; only the friendly names update on upgrade.
