### PR TITLE
feat: display all number entities as input boxes by default

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -354,7 +354,7 @@ class BaseModbusNumberEntityDescription(NumberEntityDescription):
     # update only when read value changes
     sensor_key: str | None = None  # only specify this if corresponding sensor has a different key name
     depends_on: list[str] | None = None  # list of modbus register keys that must be read
-    display_as_box: bool = False  # if true, displays the entity as a box rather than a slider.
+    display_as_box: bool = True  # display numbers as an input box (default); set False for a slider.
     suggested_display_precision: int | None = None
 
 

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1919,7 +1919,6 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         entity_category=EntityCategory.CONFIG,
         initvalue=0,
         entity_registry_enabled_default=False,
-        display_as_box=True,
         write_method=WRITE_DATA_LOCAL,
     ),
     SolaxModbusNumberEntityDescription(
@@ -1933,7 +1932,6 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         entity_category=EntityCategory.CONFIG,
         initvalue=100,
         entity_registry_enabled_default=False,
-        display_as_box=True,
         write_method=WRITE_DATA_LOCAL,
     ),
     ###
@@ -2221,7 +2219,6 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         modbus_min=101,
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
-        display_as_box=True,
         icon="mdi:tune-variant",
     ),
     SolaxModbusNumberEntityDescription(
@@ -2574,7 +2571,6 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
-        display_as_box=True,
         icon="mdi:ev-station",
     ),
     SolaxModbusNumberEntityDescription(
@@ -2588,7 +2584,6 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_step=1,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | DCB,
         entity_category=EntityCategory.CONFIG,
-        display_as_box=True,
         icon="mdi:connection",
     ),
     SolaxModbusNumberEntityDescription(

--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -263,7 +263,6 @@ NUMBER_TYPES = [
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=NumberDeviceClass.VOLTAGE,
         entity_category=EntityCategory.CONFIG,
-        display_as_box=True,
     ),
     SolaXEVChargerModbusNumberEntityDescription(
         name="Undervoltage Limit",
@@ -276,7 +275,6 @@ NUMBER_TYPES = [
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=NumberDeviceClass.VOLTAGE,
         entity_category=EntityCategory.CONFIG,
-        display_as_box=True,
     ),
     SolaXEVChargerModbusNumberEntityDescription(
         name="Main Breaker Limit",
@@ -289,7 +287,6 @@ NUMBER_TYPES = [
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=NumberDeviceClass.CURRENT,
         entity_category=EntityCategory.CONFIG,
-        display_as_box=True,
     ),
     SolaXEVChargerModbusNumberEntityDescription(
         name="Datahub Charge Current",
@@ -338,7 +335,6 @@ NUMBER_TYPES = [
         native_step=1,
         icon="mdi:identifier",
         entity_category=EntityCategory.CONFIG,
-        display_as_box=True,
     ),
     SolaXEVChargerModbusNumberEntityDescription(
         name="Smart Boost Energy",
@@ -351,7 +347,6 @@ NUMBER_TYPES = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=NumberDeviceClass.ENERGY,
         entity_category=EntityCategory.CONFIG,
-        display_as_box=True,
     ),
     SolaXEVChargerModbusNumberEntityDescription(
         name="OCPP Charge Current",


### PR DESCRIPTION
## Problem

Number entities render as **sliders** by default, which is a poor fit for this integration: inverter and EV charger numbers are precise configuration values — charge current limits, SOC thresholds, export power limits — often with wide ranges (e.g. 0–30000 Wh, 0–6000 W). On a slider:

- exact values are hard to hit (try setting 4600 W on a 0–6000 W slider),
- a stray click/drag silently writes a wrong value to the inverter,
- mobile UX is worse still.

Box mode was already being adopted entity-by-entity — 10 scattered `display_as_box=True` overrides across `plugin_solax.py` and `plugin_solax_ev_charger.py` — while every other number stayed a slider. The result is inconsistent: `Adjust Current` renders as a box while `Export Control User Limit` next to it is a slider.

## Change

- `display_as_box` on `BaseModbusNumberEntityDescription` now defaults to **`True`** → every number entity in **all plugins** renders as an input box
- Removed all 10 per-entity `display_as_box=True` overrides — now redundant
- Verified no plugin forces a mode anywhere: no `display_as_box=False`, no direct `NumberMode` usage remains in any of the 17 plugin files

The escape hatch is preserved: an individual entity can still opt back into a slider with `display_as_box=False` (falls through to HA's default mode).

## Scope

| | Before | After |
|---|---|---|
| Default mode | slider | **input box** |
| Per-entity overrides | 10 × `display_as_box=True` | none |
| Opt-out | n/a | `display_as_box=False` |
| Affected plugins | — | all (mechanism lives in `const.py` + `number.py`) |

Diff is intentionally tiny: 1 line changed in `const.py`, 10 lines removed from plugins.
