### PR TITLE
feat(evcharger): convert binary SELECT entities to SWITCH

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -483,6 +483,11 @@ def value_function_disabled_enabled(initval: Any, descr: Any, datadict: dict[str
     return scale.get(initval, str(initval) + " Unknown Status")
 
 
+def value_function_enable_disable(bit: int | None, state: bool | None, sensor_key: str | None, datadict: dict[str, Any]) -> int:
+    """Switch value function: write 1 for on, 0 for off (whole-register enable/disable)."""
+    return 1 if state else 0
+
+
 def value_function_gain_offset(initval: Any, descr: Any, datadict: dict[str, Any]) -> float:
     """Apply gain and offset calibration to power measurement."""
     # Simple offset (unit) and gain (%) calibration of the measured power

--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -32,8 +32,10 @@ from custom_components.solax_modbus.const import (
     BaseModbusNumberEntityDescription,
     BaseModbusSelectEntityDescription,
     BaseModbusSensorEntityDescription,
+    BaseModbusSwitchEntityDescription,
     BaseModbusTimeEntityDescription,
     plugin_base,
+    value_function_enable_disable,
     value_function_firmware_decimal_hundredths,
     value_function_separate_registers_time,
 )
@@ -223,6 +225,11 @@ def value_function_sync_rtc_evc(initval: Any, descr: Any, datadict: dict[str, An
         (REGISTER_U16, utc_now.month),  # 0x622: month    (UTC)
         (REGISTER_U16, utc_now.year % 100),  # 0x623: year     (UTC)
     ]
+
+
+def value_function_disable_enable(bit: int | None, state: bool | None, sensor_key: str | None, datadict: dict[str, Any]) -> int:
+    """Write 0 for on, 1 for off (inverted polarity: 0=Closed/Active, 1=Open/Inactive)."""
+    return 0 if state else 1
 
 
 # ================================= Button Declarations ============================================================
@@ -467,28 +474,6 @@ SELECT_TYPES = [
         icon="mdi:dip-switch",
     ),
     SolaXEVChargerModbusSelectEntityDescription(
-        name="Device Lock",
-        key="device_lock",
-        register=0x615,
-        option_dict={
-            0: "Unlock",
-            1: "Lock",
-        },
-        entity_category=EntityCategory.CONFIG,
-        icon="mdi:lock",
-    ),
-    SolaXEVChargerModbusSelectEntityDescription(
-        name="RFID Card Activation",
-        key="rfid_program",
-        register=0x616,
-        option_dict={
-            0: "Disabled",
-            1: "Enabled",
-        },
-        entity_category=EntityCategory.CONFIG,
-        icon="mdi:card-account-details",
-    ),
-    SolaXEVChargerModbusSelectEntityDescription(
         name="Charging Mode",
         key="evse_scene",
         register=0x61C,
@@ -675,17 +660,17 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         internal=True,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
-        name="Device Lock",
-        key="device_lock",
+        name="Electronic Lock",
+        key="electronic_lock",
         register=0x615,
-        scale={0: "Unlock", 1: "Lock"},
+        scale={0: 0, 1: 1},
         internal=True,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
         name="RFID Card Activation",
-        key="rfid_program",
+        key="rfid_card_activation",
         register=0x616,
-        scale={0: "Disabled", 1: "Enabled"},
+        scale={0: 0, 1: 1},
         internal=True,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
@@ -770,6 +755,15 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
         register=0x668,
         scale=0.01,
         rounding=1,
+        internal=True,
+    ),
+    SolaXEVChargerModbusSensorEntityDescription(
+        name="Main Breaker Limit Switch",
+        key="main_breaker_limit_switch",
+        register=0x664,
+        # Inverted scale: device 0=Closed/Active -> 1 (on), device 1=Open/Inactive -> 0 (off)
+        scale={0: 1, 1: 0},
+        allowedtypes=GEN2,
         internal=True,
     ),
     SolaXEVChargerModbusSensorEntityDescription(
@@ -1756,7 +1750,38 @@ plugin_instance = solax_ev_charger_plugin(
     NUMBER_TYPES=NUMBER_TYPES,
     BUTTON_TYPES=BUTTON_TYPES,
     SELECT_TYPES=SELECT_TYPES,
-    SWITCH_TYPES=[],
+    SWITCH_TYPES=[
+        BaseModbusSwitchEntityDescription(
+            name="Electronic Lock",
+            key="electronic_lock",
+            register=0x615,
+            sensor_key="electronic_lock",
+            value_function=value_function_enable_disable,
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:lock",
+        ),
+        BaseModbusSwitchEntityDescription(
+            name="RFID Card Activation",
+            key="rfid_card_activation",
+            register=0x616,
+            sensor_key="rfid_card_activation",
+            value_function=value_function_enable_disable,
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:card-account-details",
+        ),
+        BaseModbusSwitchEntityDescription(
+            name="Main Breaker Limit Switch",
+            key="main_breaker_limit_switch",
+            register=0x664,
+            allowedtypes=GEN2,
+            sensor_key="main_breaker_limit_switch",
+            # Register polarity: 0=Closed/Active, 1=Open/Inactive
+            # Switch ON writes 0 (limit active), OFF writes 1 (limit inactive)
+            value_function=value_function_disable_enable,
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:electric-switch",
+        ),
+    ],
     TIME_TYPES=TIME_TYPES,
     block_size=32,
     # order16=Endian.BIG,


### PR DESCRIPTION
## Problem

The EV charger exposes boolean device states as 2-option **select dropdowns**:

- `Device Lock` (0x615): *Unlock / Lock*
- `RFID Card Activation` (0x616): *Disabled / Enabled*

A dropdown is the wrong entity type for a boolean. Compared to a switch it:

- **takes two interactions** (open dropdown, pick option) instead of one tap,
- **wastes UI space** — a select renders as a full-width dropdown row, a switch is a compact toggle,
- **reads worse at a glance** — a toggle's on/off position is instantly visible; a dropdown shows a word you have to parse,
- **integrates worse with HA** — switches work directly with `switch.turn_on/off` services, Google/Alexa exposure, dashboards' toggle cards and quick-action buttons; selects need `select.select_option` with a magic string,
- **is harder in automations** — `state: 'on'` vs matching the exact option string ("Enabled"? "Enable"? "On"?), which differs per entity.

## Change

| Before | After |
|---|---|
| `select.device_lock` — Unlock / Lock | `switch.electronic_lock` — toggle |
| `select.rfid_program` — Disabled / Enabled | `switch.rfid_card_activation` — toggle |
| — (not exposed) | `switch.main_breaker_limit_switch` — **new**, GEN2, register 0x664 |

- Uses the existing `BaseModbusSwitchEntityDescription` infrastructure (register + `sensor_key` + `value_function`) — no platform changes needed
- Adds a generic `value_function_enable_disable` helper to `const.py` (write 1/0), reusable by any plugin that wants the same conversion
- `Main Breaker Limit Switch` (0x664) has inverted register polarity (0 = Closed/Active, 1 = Open/Inactive); a local inverted value function + inverted sensor scale make the switch read naturally: **on = limit active**
- Backing internal sensors deliver 0/1 ints so switch state tracks the actual register on every poll — external changes (via the charger's app/display) are reflected in HA

## Naming

Keys renamed to match switch semantics (`device_lock` → `electronic_lock` per SolaX's own terminology, `rfid_program` → `rfid_card_activation`). The entities change domain anyway (`select.*` → `switch.*`), so there is no unique_id continuity to preserve.

## Testing

Verified on a real **X3 EVC 11kW (GEN2)**: all three switches track register state correctly (including changes made from the charger side) and writes take effect. This pattern could later be applied to the ~20 binary Enabled/Disabled selects in `plugin_solax.py` (MPPT, Battery Heating, HotStandBy, …) — kept out of scope here to keep the change reviewable and because inverter users' automations reference the existing select entities.
