### PR TITLE
Add SoC entity to SolaX Energy Dashboard mapping

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -11804,6 +11804,14 @@ from .energy_dashboard import EnergyDashboardMapping, EnergyDashboardSensorMappi
 ENERGY_DASHBOARD_MAPPING = EnergyDashboardMapping(
     plugin_name="solax",
     mappings=[
+        # ===== SOC SENSOR =====
+        # Battery SoC %
+        EnergyDashboardSensorMapping(
+            source_key="battery_capacity",
+            target_key="battery_soc",
+            name="Battery SoC",
+            allowedtypes=GEN2 | GEN3 | GEN4 | GEN5 | GEN6,
+        ),
         # ===== POWER SENSORS =====
         # Grid Power
         EnergyDashboardSensorMapping(


### PR DESCRIPTION
The energy dashboard in home assistant now allows specifying a battery SoC sensor for a solar inverter.

To keep everything self-contained, add SoC mapping for the SolaX dashboard device which mirrors the battery capacity sensor.