### PR TITLE
Add missing MPPT3 flag to EGR and JQG prefix inverters

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -9663,7 +9663,7 @@ class growatt_plugin(plugin_base):
         elif seriesnumber.startswith("SMN"):
             invertertype = HYBRID | GEN4 | X1 | MPPT4  # MIN TL-XH-US Hybrid, 4 MPPT
         elif seriesnumber.startswith("JGQ"):
-            invertertype = HYBRID | GEN4 | X1  # MIN 7600 TL-XH-US Hybrid, 3 MPPT
+            invertertype = HYBRID | GEN4 | X1 | MPPT3  # MIN 7600 TL-XH-US Hybrid, 3 MPPT
         elif seriesnumber.startswith("HJU"):
             invertertype = HYBRID | GEN4 | X1  # MIN 4200TL-XH2 Hybrid, 2 MPPT
 
@@ -9692,7 +9692,7 @@ class growatt_plugin(plugin_base):
         elif seriesnumber.startswith("DFK"):
             invertertype = HYBRID | GEN4 | X3  # MOD 100000 TL3-XH Hybrid, 2 MPPT
         elif seriesnumber.startswith("EGR"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 150000 TL3-HU Hybrid, 3 MPPT
+            invertertype = HYBRID | GEN4 | X3 | MPPT3  # MOD 150000 TL3-HU Hybrid, 3 MPPT
 
         # MID type:GEN4
         elif seriesnumber.startswith("KLN"):


### PR DESCRIPTION
They are labelled in the comments as 3x MPPT, however were missing the flag to actually enable sensors for the 3rd solar input.

Fixes #2165.