### PR TITLE
Add provisional support for Solinteg M2HT model inverters

### DIFF
--- a/custom_components/solax_modbus/plugin_solinteg.py
+++ b/custom_components/solax_modbus/plugin_solinteg.py
@@ -1624,6 +1624,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        allowedtypes=HYBRID | ALL_EPS_GROUP,
         icon="mdi:home",
     ),
     # internal sensors are only used for polling values for selects, etc

--- a/custom_components/solax_modbus/plugin_solinteg.py
+++ b/custom_components/solax_modbus/plugin_solinteg.py
@@ -2029,10 +2029,14 @@ ENERGY_DASHBOARD_MAPPING = EnergyDashboardMapping(
             name="Grid Export Energy",
         ),
         # Home Consumption Energy
+        # The 'house_energy_today' sensor does not provide valid information
+        # on some inverters, so use riemann sum of house load power.
         EnergyDashboardSensorMapping(
-            source_key="house_energy_today",
+            source_key="house_load_total",
             target_key="home_consumption_energy",
             name="Home Consumption Energy",
+            use_riemann_sum=True,
+            filter_function=lambda v: max(0, v),
         ),
         # Battery Charge Energy
         EnergyDashboardSensorMapping(

--- a/custom_components/solax_modbus/plugin_solinteg.py
+++ b/custom_components/solax_modbus/plugin_solinteg.py
@@ -1959,20 +1959,105 @@ from .energy_dashboard import EnergyDashboardMapping, EnergyDashboardSensorMappi
 ENERGY_DASHBOARD_MAPPING = EnergyDashboardMapping(
     plugin_name="solinteg",
     mappings=[
+        # ===== SOC SENSOR =====
+        # Battery SoC %
+        EnergyDashboardSensorMapping(
+            source_key="battery_soc",
+            target_key="battery_soc",
+            name="Battery SoC",
+        ),
+        # ===== POWER SENSORS =====
+        # Grid Power
         EnergyDashboardSensorMapping(
             source_key="measured_power",
-            source_key_pm=None,  # measured_power is system-wide
             target_key="grid_power",
             name="Grid Power",
             invert=True,
             icon="mdi:transmission-tower",
         ),
+        # Solar Power
         EnergyDashboardSensorMapping(
-            source_key="battery_power",  # Note: plugin_solinteg uses battery_power (not battery_power_charge)
-            source_key_pm=None,  # No parallel mode support in this plugin
+            source_key="pv_power_total",
+            target_key="solar_power",
+            name="Solar Power",
+        ),
+        # PV Variant Power
+        EnergyDashboardSensorMapping(
+            source_key="pv_power_{n}",
+            target_key="pv_power_{n}",
+            name="PV Power {n}",
+        ),
+        # Battery Power
+        EnergyDashboardSensorMapping(
+            source_key="battery_power",
             target_key="battery_power",
             name="Battery Power",
-            invert=True,
+        ),
+        # Home Consumption Power
+        EnergyDashboardSensorMapping(
+            source_key="house_total_load",
+            target_key="home_consumption_power",
+            name="Home Consumption Power",
+        ),
+        # Grid to Battery Power (TODO)
+        # EnergyDashboardSensorMapping(
+        #     source_key="inverter_power",
+        #     target_key="grid_to_battery_power",
+        #     name="Grid to Battery Power",
+        #     filter_function=lambda v: max(0 - v, 0),
+        #     icon="mdi:transmission-tower-export",
+        # ),
+        # ===== ENERGY SENSORS =====
+        # PV Variant Energy (per string).
+        EnergyDashboardSensorMapping(
+            source_key="pv_power_{n}",
+            target_key="pv_energy_{n}",
+            name="PV Energy {n}",
+            use_riemann_sum=True,
+            filter_function=lambda v: max(0, v),
+        ),
+        # Grid Import Energy
+        EnergyDashboardSensorMapping(
+            source_key="grid_import_today",
+            target_key="grid_energy_import",
+            name="Grid Import Energy",
+        ),
+        # Grid Export Energy
+        EnergyDashboardSensorMapping(
+            source_key="grid_export_today",
+            target_key="grid_energy_export",
+            name="Grid Export Energy",
+        ),
+        # Home Consumption Energy
+        EnergyDashboardSensorMapping(
+            source_key="house_energy_today",
+            target_key="home_consumption_energy",
+            name="Home Consumption Energy",
+        ),
+        # Battery Charge Energy
+        EnergyDashboardSensorMapping(
+            source_key="battery_charge_today",
+            target_key="battery_energy_charge",
+            name="Battery Charge Energy",
+        ),
+        # Battery Discharge Energy
+        EnergyDashboardSensorMapping(
+            source_key="battery_discharge_today",
+            target_key="battery_energy_discharge",
+            name="Battery Discharge Energy",
+        ),
+        # Grid to Battery Energy (TODO)
+        # EnergyDashboardSensorMapping(
+        #     source_key="e_charge_today",
+        #     target_key="grid_to_battery_energy",
+        #     name="Grid to Battery Energy",
+        #     icon="mdi:transmission-tower-export",
+        # ),
+        # Solar Production Energy
+        EnergyDashboardSensorMapping(
+            source_key="energy_generation_today",
+            target_key="solar_energy_production",
+            name="Solar Production Energy",
         ),
     ],
     parallel_mode_supported=False,  # Plugin doesn't support parallel mode

--- a/custom_components/solax_modbus/plugin_solinteg.py
+++ b/custom_components/solax_modbus/plugin_solinteg.py
@@ -63,7 +63,7 @@ GEN = 0x0001  # base generation for MIC, PV, AC
 GEN2 = 0x0002
 ALL_GEN_GROUP = GEN2
 
-X1 = 0x0100  # not needed
+X1 = 0x0100
 X3 = 0x0200
 ALL_X_GROUP = X1 | X3
 
@@ -85,9 +85,9 @@ ALL_PM_GROUP = PM
 
 # 1 is minimum
 MPPT2 = 0x40000
-MPPT4 = MPPT2 * 2
-MPPT_MIN2 = MPPT2 | MPPT4
-ALL_MPPT = MPPT2 | MPPT4
+MPPT4 = 0x80000
+MPPT6 = 0x100000
+ALL_MPPT = MPPT2 | MPPT4 | MPPT6
 
 # ALLDEFAULT = 0 # should be equivalent to HYBRID | AC | GEN2 | GEN3 | GEN4 | X1 | X3
 ALLDEFAULT = 0  # HYBRID | AC | ALL_X_GROUP
@@ -142,7 +142,7 @@ def _bytes_str(b_array: list[int]) -> str:
 
 
 def _model_str(val: int) -> str:
-    # there are models 40,41,42, docu not found
+    # Mapping based on Solinteg documentation in issue #2158
     d = {
         30: [
             "MHT-4K-25",
@@ -174,6 +174,29 @@ def _model_str(val: int) -> str:
             "MHT-36K-100",
             "MHT-40K-100",
             "MHT-50K-100",
+        ],
+        40: [
+            "M2HT-3K-30",
+            "M2HT-3.6K-30",
+            "M2HT-4.2K-30",
+            "M2HT-4.6K-30",
+            "M2HT-5K-30",
+            "M2HT-6K-30",
+        ],
+        41: [
+            "M2HT-25K-150",
+            "M2HT-29.9K-150",
+            "M2HT-30K-150",
+            "M2HT-40K-150",
+            "M2HT-50K-150",
+        ],
+        43: [
+            "M2HT-75K-300",
+            "M2HT-80K-300",
+            "M2HT-99K-300",
+            "M2HT-100K-300",
+            "M2HT-110K-300",
+            "M2HT-125K-300",
         ],
     }
     try:
@@ -968,7 +991,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         key="pv_voltage_2",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
-        allowedtypes=MPPT_MIN2,
+        allowedtypes=MPPT2 | MPPT4 | MPPT6,
         register=11040,
         scale=0.1,
         scan_group=SCAN_GROUP_MPPT,
@@ -979,7 +1002,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         key="pv_current_2",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
-        allowedtypes=MPPT_MIN2,
+        allowedtypes=MPPT2 | MPPT4 | MPPT6,
         register=11041,
         scale=0.1,
         scan_group=SCAN_GROUP_MPPT,
@@ -991,7 +1014,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        allowedtypes=MPPT_MIN2,
+        allowedtypes=MPPT2 | MPPT4 | MPPT6,
         register=11064,
         register_data_type=REGISTER_U32,
         scan_group=SCAN_GROUP_MPPT,
@@ -1002,7 +1025,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         key="pv_voltage_3",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
-        allowedtypes=MPPT4,
+        allowedtypes=MPPT4 | MPPT6,
         register=11042,
         scale=0.1,
         scan_group=SCAN_GROUP_MPPT,
@@ -1013,7 +1036,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         key="pv_current_3",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
-        allowedtypes=MPPT4,
+        allowedtypes=MPPT4 | MPPT6,
         register=11043,
         scale=0.1,
         scan_group=SCAN_GROUP_MPPT,
@@ -1025,7 +1048,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        allowedtypes=MPPT4,
+        allowedtypes=MPPT4 | MPPT6,
         register=11066,
         register_data_type=REGISTER_U32,
         scan_group=SCAN_GROUP_MPPT,
@@ -1036,7 +1059,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         key="pv_voltage_4",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
-        allowedtypes=MPPT4,
+        allowedtypes=MPPT4 | MPPT6,
         register=11044,
         scale=0.1,
         scan_group=SCAN_GROUP_MPPT,
@@ -1047,7 +1070,7 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         key="pv_current_4",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
-        allowedtypes=MPPT4,
+        allowedtypes=MPPT4 | MPPT6,
         register=11045,
         scale=0.1,
         scan_group=SCAN_GROUP_MPPT,
@@ -1059,8 +1082,76 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        allowedtypes=MPPT4,
+        allowedtypes=MPPT4 | MPPT6,
         register=11068,
+        register_data_type=REGISTER_U32,
+        scan_group=SCAN_GROUP_MPPT,
+        icon="mdi:solar-power-variant",
+    ),
+    SolintegModbusSensorEntityDescription(
+        name="PV Voltage 5",
+        key="pv_voltage_5",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        allowedtypes=MPPT6,
+        register=11046,
+        scale=0.1,
+        scan_group=SCAN_GROUP_MPPT,
+        icon="mdi:current-dc",
+    ),
+    SolintegModbusSensorEntityDescription(
+        name="PV Current 5",
+        key="pv_current_5",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        allowedtypes=MPPT6,
+        register=11047,
+        scale=0.1,
+        scan_group=SCAN_GROUP_MPPT,
+        icon="mdi:current-dc",
+    ),
+    SolintegModbusSensorEntityDescription(
+        name="PV Power 5",
+        key="pv_power_5",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        allowedtypes=MPPT6,
+        register=11070,
+        register_data_type=REGISTER_U32,
+        scan_group=SCAN_GROUP_MPPT,
+        icon="mdi:solar-power-variant",
+    ),
+    SolintegModbusSensorEntityDescription(
+        name="PV Voltage 6",
+        key="pv_voltage_6",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        allowedtypes=MPPT6,
+        register=11048,
+        scale=0.1,
+        scan_group=SCAN_GROUP_MPPT,
+        icon="mdi:current-dc",
+    ),
+    SolintegModbusSensorEntityDescription(
+        name="PV Current 6",
+        key="pv_current_6",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        allowedtypes=MPPT6,
+        register=11049,
+        scale=0.1,
+        scan_group=SCAN_GROUP_MPPT,
+        icon="mdi:current-dc",
+    ),
+    SolintegModbusSensorEntityDescription(
+        name="PV Power 6",
+        key="pv_power_6",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        allowedtypes=MPPT6,
+        register=11072,
         register_data_type=REGISTER_U32,
         scan_group=SCAN_GROUP_MPPT,
         icon="mdi:solar-power-variant",
@@ -1791,18 +1882,23 @@ class solinteg_plugin(plugin_base):
 
         bh, bl = model // 256, model % 256
         invertertype = 0
-        if bh in [30, 31, 32]:
+        if bh in [30, 31, 32, 40, 41, 43]:
             invertertype = invertertype | HYBRID
 
-        if bh in [30, 32, 40, 42]:
+        if bh in [30, 32, 41, 43]:
             invertertype = invertertype | X3
+        else:
+            invertertype = invertertype | X1
 
-        if bh == 30 and bl in [0, 1]:
+        if (bh == 31 and bl in [8, 9]) or (bh == 40 and bl == 0):
             mppt = 1
-        elif bh == 32:
+        elif bh == 43:
+            mppt = 6
+            invertertype = invertertype | MPPT6
+        elif bh in [32, 41]:
             mppt = 4
             invertertype = invertertype | MPPT4
-        else:  # bh == 31, other 30...
+        else:
             mppt = 2
             invertertype = invertertype | MPPT2
 


### PR DESCRIPTION
These should share the same register map as the existing inverters. Simply add model ID decoding for them to ensure the correct HYBRID/MPPT/X3 flags are set.

This also corrects the MPPT decoding for inverters in the 30/31 high byte ID group.

Fixes #2158.

---

Furthermore this include a more complete population of the energy dashboard mappings.

The dashboard mappings have been in a draft PR for a while. They've been added into this PR to allow testing alongside the new models and get them merged in.