### PR TITLE
Fix rounding when writing scaled number values

### DIFF
--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -27,6 +27,11 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _scale_native_value_to_register(value: float, scale: float, read_scale: float) -> int:
+    """Convert a native number value to its integer register representation."""
+    return int(round(value / (scale * read_scale)))
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> bool:
     if entry.data:  # old style - remove soon
         hub_name = entry.data[CONF_NAME]
@@ -229,10 +234,8 @@ class SolaXModbusNumber(NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Change the number value."""
         payload: int | float = value
-        if self._fmt == "i":
-            payload = int(value / (self._attr_scale * self.entity_description.read_scale))
-        elif self._fmt == "f":
-            payload = int(value / (self._attr_scale * self.entity_description.read_scale))
+        if self._fmt in ("i", "f"):
+            payload = _scale_native_value_to_register(value, self._attr_scale, self.entity_description.read_scale)
         if self._write_method == WRITE_MULTISINGLE_MODBUS:
             _LOGGER.info(
                 f"writing {self._platform_name} {self._key} number register {self._register} value {payload} after div by readscale {self.entity_description.read_scale} scale {self._attr_scale} with mode {self._write_method}"

--- a/tests/unit/test_number_payload_scaling.py
+++ b/tests/unit/test_number_payload_scaling.py
@@ -1,0 +1,35 @@
+"""Regression tests for scaled number writes."""
+
+import pytest
+
+from custom_components.solax_modbus.number import _scale_native_value_to_register
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (5.1, 51),
+        (5.8, 58),
+        (6.6, 66),
+        (8.2, 82),
+        (9.7, 97),
+    ],
+)
+def test_tenth_scale_does_not_truncate_float_rounding_error(value: float, expected: int) -> None:
+    """Values on a 0.1 step are written to the matching register value."""
+    assert _scale_native_value_to_register(value, 0.1, 1) == expected
+
+
+def test_hundredth_scale_does_not_truncate_float_rounding_error() -> None:
+    """The conversion also works for registers with a 0.01 scale."""
+    assert _scale_native_value_to_register(1.23, 0.01, 1) == 123
+
+
+def test_negative_scaled_value_rounds_to_nearest_register_step() -> None:
+    """Negative values are rounded instead of truncated toward zero."""
+    assert _scale_native_value_to_register(-5.1, 0.1, 1) == -51
+
+
+def test_read_scale_is_included_in_conversion() -> None:
+    """Per-inverter read scaling remains part of the register conversion."""
+    assert _scale_native_value_to_register(5.2, 0.1, 2) == 26


### PR DESCRIPTION
Scaled number values were converted with int(), which could truncate floating-point results and write a value one register step too low. This changes the conversion to round to the nearest register value and adds regression tests for the affected decimal scales.

Fixes [#2190](https://github.com/wills106/homeassistant-solax-modbus/issues/2190).