### PR TITLE
Adjust Sofar feed-in power limit for parallel systems

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from typing import Any
 
@@ -4366,6 +4366,22 @@ class sofar_plugin(plugin_base):
 
     def getHardwareVersion(self, new_data: dict[str, Any]) -> str | None:
         return new_data.get("hardware_version", None)
+
+    def localDataCallback(self, hub: Any) -> bool:
+        parallel_setting = hub.data.get("parallel_masterslave", "Slave")
+        if parallel_setting == "Master":
+            system_limit_w = hub.inverterPowerKw * 1000
+            number_entity = hub.numberEntities.get("feedin_max_power")
+            if number_entity:
+                number_entity._attr_native_min_value = 0
+                number_entity._attr_native_max_value = system_limit_w
+                number_entity.entity_description = replace(
+                    number_entity.entity_description,
+                    native_min_value=0,
+                    native_max_value=system_limit_w,
+                )
+                _LOGGER.info(f"Parallel Master: Set feedin_max_power limit to 0-{system_limit_w}W (inverter_power_kw={hub.inverterPowerKw}kW)")
+        return True
 
 
 plugin_instance = sofar_plugin(

--- a/tests/unit/test_sofar_parallel_feedin_limit.py
+++ b/tests/unit/test_sofar_parallel_feedin_limit.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from custom_components.solax_modbus.plugin_sofar import plugin_instance
+
+
+@dataclass
+class MockEntityDescription:
+    native_min_value: int
+    native_max_value: int
+
+
+class MockNumberEntity:
+    def __init__(self) -> None:
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = 20000
+        self.entity_description = MockEntityDescription(
+            native_min_value=0,
+            native_max_value=20000,
+        )
+
+
+def make_hub(parallel_setting: str, inverter_power_kw: int) -> Any:
+    return SimpleNamespace(
+        data={"parallel_masterslave": parallel_setting},
+        inverterPowerKw=inverter_power_kw,
+        numberEntities={"feedin_max_power": MockNumberEntity()},
+    )
+
+
+def test_parallel_master_uses_total_system_power_for_feedin_limit() -> None:
+    hub = make_hub("Master", 40)
+
+    assert plugin_instance.localDataCallback(hub) is True
+
+    entity = hub.numberEntities["feedin_max_power"]
+    assert entity._attr_native_min_value == 0
+    assert entity._attr_native_max_value == 40000
+    assert entity.entity_description.native_min_value == 0
+    assert entity.entity_description.native_max_value == 40000
+
+
+def test_single_or_slave_inverter_keeps_existing_feedin_limit() -> None:
+    hub = make_hub("Slave", 100)
+
+    assert plugin_instance.localDataCallback(hub) is True
+
+    entity = hub.numberEntities["feedin_max_power"]
+    assert entity._attr_native_max_value == 20000
+    assert entity.entity_description.native_max_value == 20000


### PR DESCRIPTION
Sofar parallel systems currently use the fixed 20 kW limit for the maximum feed-in power.

For a parallel master, this change uses the configured total system capacity (`inverter_power_kw`) as the upper limit, following the existing SolaX implementation. Single inverters and slaves keep the existing 20 kW limit.

Added tests for both parallel master and single/slave configurations.

Fixes #2147