### PR TITLE
Fix Growatt GEN4 EPS loading percentage

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -5846,6 +5846,8 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         register=3160,
         register_type=REG_INPUT,
+        scale=0.1,
+        rounding=1,
         allowedtypes=GEN4 | EPS,
     ),
     GrowattModbusSensorEntityDescription(

--- a/tests/unit/test_growatt_eps_loading_scale.py
+++ b/tests/unit/test_growatt_eps_loading_scale.py
@@ -1,0 +1,15 @@
+from custom_components.solax_modbus.plugin_growatt import SENSOR_TYPES
+
+
+def test_gen4_eps_loading_uses_tenths_percent_scale() -> None:
+    descriptions = [description for description in SENSOR_TYPES if description.key == "eps_loading" and description.register == 3160]
+
+    assert len(descriptions) == 1
+    description = descriptions[0]
+    scale = description.scale
+    rounding = description.rounding
+    assert isinstance(scale, (int, float))
+    assert isinstance(rounding, int)
+    assert scale == 0.1
+    assert rounding == 1
+    assert round(60 * scale, rounding) == 6.0


### PR DESCRIPTION
The Growatt GEN4 EPS loading sensor reads register 3160 without applying its documented scale.
Growatt defines this register in tenths of a percent, so values were displayed ten times too high. This adds `scale=0.1` and `rounding=1`, matching the existing GEN3 implementation. Fixes #2137