### PR TITLE
Fix Growatt SPA3000 inverter detection

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -115,13 +115,11 @@ async def async_read_serialnr(hub: Any, address: int) -> str | None:
             for register in inverter_data.registers[0:5]:
                 raw_bytes.extend(int(register).to_bytes(2, byteorder="big", signed=False))
             res = raw_bytes.decode("ascii", errors="ignore").rstrip("\x00").strip() or None
-            if res:
-                hub.seriesnumber = res
     except Exception:
-        _LOGGER.warning(f"{hub.name}: attempt to read firmware failed at 0x{address:x}", exc_info=True)
+        _LOGGER.warning(f"{hub.name}: attempt to read inverter identifier failed at 0x{address:x}", exc_info=True)
     if not res:
-        _LOGGER.warning(f"{hub.name}: reading firmware number from address 0x{address:x} failed; other address may succeed")
-    _LOGGER.info(f"Read {hub.name} 0x{address:x} firmware number before potential swap: {res}")
+        _LOGGER.warning(f"{hub.name}: reading inverter identifier from address 0x{address:x} failed; other address may succeed")
+    _LOGGER.info(f"Read {hub.name} 0x{address:x} inverter identifier before potential swap: {res}")
     return res
 
 
@@ -9655,255 +9653,150 @@ TIME_TYPES = [
 # ============================ plugin declaration =================================================
 
 
+SERIAL_NUMBER_REGISTERS = (3001, 209, 23)
+
+# Serial-number prefixes from the supported Growatt model families.
+SERIAL_PREFIX_TYPES = {
+    # MIN hybrid
+    "ABJ": HYBRID | GEN4 | X1,
+    "SKL": HYBRID | GEN4 | X1,
+    "XVM": HYBRID | GEN4 | X1,
+    "SMN": HYBRID | GEN4 | X1 | MPPT4,
+    "JGQ": HYBRID | GEN4 | X1 | MPPT3,
+    "HJU": HYBRID | GEN4 | X1,
+    # MOD hybrid
+    "XHL": HYBRID | GEN4 | X1,
+    "DPS": HYBRID | GEN4 | X3,
+    "DMS": HYBRID | GEN4 | X3 | MPPT3,
+    "DKS": HYBRID | GEN4 | X3 | MPPT3,
+    "DO1": HYBRID | GEN4 | X3 | MPPT3,
+    "TTS": HYBRID | GEN4 | X3 | MPPT3,
+    "TSS": HYBRID | GEN4 | X3 | MPPT3,
+    "PYL": HYBRID | GEN4 | X3,
+    "JCM": HYBRID | GEN4 | X3,
+    "MEK": HYBRID | GEN4 | X3,
+    "MFK": HYBRID | GEN4 | X1,
+    "DFK": HYBRID | GEN4 | X3,
+    "EGR": HYBRID | GEN4 | X3 | MPPT3,
+    # MID hybrid
+    "KLN": HYBRID | GEN4 | X3,
+    "KMN": HYBRID | GEN4 | X3,
+    "KNN": HYBRID | GEN4 | X3 | MPPT3,
+    "RKM": HYBRID | GEN4 | X3 | MPPT3,
+    # MOD BP hybrid
+    "FMP": HYBRID | GEN4 | X3,
+    "FPP": HYBRID | GEN4 | X3,
+    "FQP": HYBRID | GEN4 | X3,
+    "CZM": HYBRID | GEN4 | X3,
+    # SPH, SPE and SPA storage
+    "YRP": HYBRID | GEN3 | X1,
+    "NFR": HYBRID | SPF | X1,
+    "WPD": AC | GEN3 | X1,
+    # SPF
+    "YRE": HYBRID | SPF | X1,
+    "TTJ": HYBRID | SPF | X1,
+    "BNJ": HYBRID | SPF | X1,
+    "KAM": HYBRID | SPF | X1,
+    "NUK": HYBRID | SPF | X1,
+    # WIT
+    "0PE": HYBRID | GEN4 | X3,
+    "0PC": HYBRID | GEN4 | X3,
+    "0PH": HYBRID | GEN4 | X3 | MPPT10,
+    "0HU": HYBRID | GEN4 | X3,
+    # MIC and MIN PV
+    "FPH": PV | GEN4 | X1,
+    "FWJ": PV | GEN4 | X1,
+    "QYL": PV | GEN4 | X1,
+    "XTD": PV | GEN4 | X1,
+    "BDK": PV | GEN4 | X1,
+    "WVN": PV | GEN4 | X1 | MPPT3,
+    # MOD, MID and MAX PV
+    "RDH": PV | GEN2 | X3,
+    "QEH": PV | GEN2 | X3,
+    "RPH": PV | GEN2 | X3,
+    "GXF": PV | GEN4 | X3,
+    "NAH": PV | GEN4 | X3 | MPPT6,
+    # SPH PV
+    "DIE": PV | GEN3 | X1,
+    "PYH": PV | GEN3 | X1,
+    "NLC": PV | GEN3 | X1,
+    "NRC": PV | GEN3 | X1,
+    # NEO and older PV models
+    "BZP": PV | GEN | X1,
+    "QNB": PV | GEN | X1,
+    "QMB": PV | GEN | X1,
+    "JLE": PV | GEN | X1,
+    "MVC": PV | GEN | X3,
+    "4FZ": PV | GEN | X1,
+    "BY3": PV | GEN | X1,
+}
+
+# Firmware/build prefixes used when no supported serial-number prefix is available.
+FIRMWARE_PREFIX_TYPES = {
+    "dha": PV | GEN | X3,
+    "DL1": PV | GEN2 | X3,
+    "DM1": PV | GEN2 | X3 | MPPT4,
+    "AH1": PV | GEN3 | X1,
+    "AJ1": PV | GEN4 | X1,
+    "GH1": PV | GEN4 | X1,
+    "AK1": PV | GEN4 | X1,
+    "AM1": PV | GEN4 | X1 | MPPT3,
+    "RAA": HYBRID | GEN3 | X1,
+    "RA1": HYBRID | GEN3 | X1,
+    "SPH": HYBRID | GEN3 | X3,
+    "YA1": HYBRID | GEN3 | X3,
+    "RH1": AC | GEN3 | X1,
+    "AL1": HYBRID | GEN4 | X1,
+    "DN1": HYBRID | GEN4 | X3,
+    "V": HYBRID | GEN4 | X3,
+    "067": HYBRID | SPF | X1,
+    "113": HYBRID | SPF | X1,
+    "500": HYBRID | SPF | X1,
+}
+
+
+def _inverter_type_from_prefix(identifier: str | None, prefix_types: dict[str, int]) -> int:
+    if not identifier:
+        return 0
+    for prefix, invertertype in prefix_types.items():
+        if identifier.startswith(prefix):
+            return invertertype
+    return 0
+
+
 @dataclass(kw_only=True)
 class growatt_plugin(plugin_base):
     async def async_determineInverterType(self, hub: Any, configdict: dict[str, Any]) -> int:
         _LOGGER.info(f"{hub.name}: trying to determine inverter type")
-        seriesnumber = await async_read_serialnr(hub, 3001)
-        if not seriesnumber:
-            _LOGGER.info(f"{hub.name}: trying alternative location")
-            seriesnumber = await async_read_serialnr(hub, 209)
-        if not seriesnumber:
-            _LOGGER.info(f"{hub.name}: trying alternative location")
-            seriesnumber = await async_read_serialnr(hub, 9)
-        if not seriesnumber:
-            _LOGGER.error(f"{hub.name}: cannot find firmware version, even not for other Inverter")
-            seriesnumber = "unknown"
+        invertertype = 0
+        identifier: str | None = None
 
-        ### Current mapping assumptions for Growatt
-        # TL3-SL = GEN
-        # TL3-X (MAX, MID, MAC & MOD) = GEN2
-        # Storage (MIX, SPA, SPH) = GEN3
-        # TL-X, TL-XH, TL-XHUS (MIN) = GEN4
-        # TL3-XH (MOD) = GEN4
-        # TL3-XH (MID) = GEN4
-        # SPF = SPF
+        for address in SERIAL_NUMBER_REGISTERS:
+            candidate = await async_read_serialnr(hub, address)
+            candidate_type = _inverter_type_from_prefix(candidate, SERIAL_PREFIX_TYPES)
+            if candidate_type:
+                identifier = candidate
+                invertertype = candidate_type
+                break
+            if candidate:
+                _LOGGER.info(f"{hub.name}: unrecognized serial number at 0x{address:x}: {candidate}")
+            _LOGGER.info(f"{hub.name}: trying alternative serial number location")
 
-        # new seriesnumber detection
-
-        # PV and Battery
-
-        # MIN type:GEN4
-        if seriesnumber.startswith("ABJ"):
-            invertertype = HYBRID | GEN4 | X1  # MIN 2500 TL-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("SKL"):
-            invertertype = HYBRID | GEN4 | X1  # MIN 3600 TL-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("XVM"):
-            invertertype = HYBRID | GEN4 | X1  # MIN 5000 TL-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("SMN"):
-            invertertype = HYBRID | GEN4 | X1 | MPPT4  # MIN TL-XH-US Hybrid, 4 MPPT
-        elif seriesnumber.startswith("JGQ"):
-            invertertype = HYBRID | GEN4 | X1 | MPPT3  # MIN 7600 TL-XH-US Hybrid, 3 MPPT
-        elif seriesnumber.startswith("HJU"):
-            invertertype = HYBRID | GEN4 | X1  # MIN 4200TL-XH2 Hybrid, 2 MPPT
-
-        # MOD type:GEN4
-        # elif seriesnumber.startswith('???'):  invertertype = HYBRID | GEN4 | X1         # MOD 3000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("XHL"):
-            invertertype = HYBRID | GEN4 | X1  # MOD 4000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("DPS"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 5000 TL3-HU Hybrid, 2 MPPT
-        elif seriesnumber.startswith("DMS"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT3  # MOD 8000 TL3-HU Hybrid, 3 MPPT
-        elif seriesnumber.startswith("DKS"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT3  # MOD 10000 TL3-HU Hybrid, 3 MPPT
-        elif seriesnumber.startswith("DO1"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT3  # MOD 12000 TL3-HU Hybrid, 3 MPPT
-        elif seriesnumber.startswith("TTS"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT3  # Hybrid KTL3-HU 12kW
-        elif seriesnumber.startswith("TSS"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT3  # Hybrid KTL3-HU 12kW
-        elif seriesnumber.startswith("PYL"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 5000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("JCM"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 6000 TL3-XH Hybrid, 2 MPPT
-        # elif seriesnumber.startswith('???'):  invertertype = HYBRID | GEN4 | X1         # MOD 6000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("MEK"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 7000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("MFK"):
-            invertertype = HYBRID | GEN4 | X1  # MOD 8000 TL3-XH Hybrid, 2 MPPT
-        # elif seriesnumber.startswith('???'):  invertertype = HYBRID | GEN4 | X1         # MOD 9000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("DFK"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 100000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("EGR"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT3  # MOD 150000 TL3-HU Hybrid, 3 MPPT
-
-        # MID type:GEN4
-        elif seriesnumber.startswith("KLN"):
-            invertertype = HYBRID | GEN4 | X3  # MID 15000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("KMN"):
-            invertertype = HYBRID | GEN4 | X3  # MID 17000 TL3-XH Hybrid, 2 MPPT
-        elif seriesnumber.startswith("KNN"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT3  # MID 25000 TL3-XH Hybrid, 3 MPPT
-        elif seriesnumber.startswith("RKM"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT3  # MID 30000 TL3-XH Hybrid, 3 MPPT
-
-        # MOD BP type:GEN4
-        elif seriesnumber.startswith("FMP"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 5000 TL3-XH (BP) Hybrid, 2 MPPT
-        elif seriesnumber.startswith("FPP"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 7000 TL3-XH (BP) Hybrid, 2 MPPT
-        elif seriesnumber.startswith("FQP"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 8000 TL3-XH (BP) Hybrid, 2 MPPT
-        elif seriesnumber.startswith("CZM"):
-            invertertype = HYBRID | GEN4 | X3  # MOD 10000 TL3-XH (BP) Hybrid, 2 MPPT
-
-        # SPH type:GEN3
-        elif seriesnumber.startswith("YRP"):
-            invertertype = HYBRID | GEN3 | X1  # SPH 5000 TL-HUB Hybrid, 2 MPPT
-
-        # SPE type:?
-        elif seriesnumber.startswith("NFR"):
-            invertertype = HYBRID | SPF | X1  # SPE 8000 ES, 2 MPPT
-
-        # SPA type:GEN3 (AC-coupled)
-        elif seriesnumber.startswith("RH1"):
-            invertertype = AC | GEN3 | X1  # SPA 3000TL BL AC, no PV MPPT
-
-        # SPF type:SPF
-        elif seriesnumber.startswith("YRE"):
-            invertertype = HYBRID | SPF | X1  # SPF 5000 ES, 1 MPPT
-        elif seriesnumber.startswith("TTJ"):
-            invertertype = HYBRID | SPF | X1  # SPF 5000 ES, 1 MPPT
-        elif seriesnumber.startswith("BNJ"):
-            invertertype = HYBRID | SPF | X1  # SPF 3000 TL LVM 24P, 1 MPPT
-        elif seriesnumber.startswith("KAM"):
-            invertertype = HYBRID | SPF | X1  # SPF 5000 ES observed live, 1 MPPT
-        elif seriesnumber.startswith("NUK"):
-            invertertype = HYBRID | SPF | X1  # SPF 12000T DVM-US MPV, 2 MPPT
-
-        # WIT type:GEN4
-        elif seriesnumber.startswith("0PE"):
-            invertertype = HYBRID | GEN4 | X3  # WIT 8000-HU, 2 MPPT
-        elif seriesnumber.startswith("0PC"):
-            invertertype = HYBRID | GEN4 | X3  # WIT 12000-HU, 2 MPPT
-        elif seriesnumber.startswith("0PH"):
-            invertertype = HYBRID | GEN4 | X3 | MPPT10  # WIT 100000-HU, 10 MPPT
-        elif seriesnumber.startswith("0HU"):
-            invertertype = HYBRID | GEN4 | X3  # WIT 15K-HU, 2 MPPT
-
-        # PV only
-
-        # MIC type:GEN4
-        elif seriesnumber.startswith("FPH"):
-            invertertype = PV | GEN4 | X1  # MIC 2000 TL-X, 1 MPPT
-        elif seriesnumber.startswith("FWJ"):
-            invertertype = PV | GEN4 | X1  # MIC 3300 TL-X, 1 MPPT
-
-        # MIN type:GEN4
-        elif seriesnumber.startswith("QYL"):
-            invertertype = PV | GEN4 | X1  # MIN 2500 TL-X, 2 MPPT
-        elif seriesnumber.startswith("XTD"):
-            invertertype = PV | GEN4 | X1  # MIN 5000 TL-X, 2 MPPT
-        elif seriesnumber.startswith("BDK"):
-            invertertype = PV | GEN4 | X1  # MIN 4200 TL-XE, 2 MPPT
-        elif seriesnumber.startswith("WVN"):
-            invertertype = PV | GEN4 | X1 | MPPT3  # MIN 8000 TL-X2, 3 MPPT
-        # elif seriesnumber.startswith('???'):  invertertype = PV | GEN4 | X1 | MPPT3     # MIN 10000 TL-X2, 3 MPPT
-
-        # MOD type:GEN2
-        elif seriesnumber.startswith("RDH"):
-            invertertype = PV | GEN2 | X3  # MOD 4000 TL3-X, 2 MPPT
-        elif seriesnumber.startswith("QEH"):
-            invertertype = PV | GEN2 | X3  # MOD 8000 TL3-X, 2 MPPT
-        elif seriesnumber.startswith("RPH"):
-            invertertype = PV | GEN2 | X3  # MOD 15000 TL3-X, 2 MPPT
-
-        # MID type:GEN4
-        elif seriesnumber.startswith("GXF"):
-            invertertype = PV | GEN4 | X3  # MID 12000 TL3-XL, 2 MPPT
-
-        # MAX type:GEN4
-        elif seriesnumber.startswith("NAH"):
-            invertertype = PV | GEN4 | X3 | MPPT6  # MAX 60000 TL3 LV, 6 MPPT
-
-        # SPH type:GEN3
-        elif seriesnumber.startswith("DIE"):
-            invertertype = PV | GEN3 | X1  # SPH 1000-S, 1 MPPT
-        elif seriesnumber.startswith("PYH"):
-            invertertype = PV | GEN3 | X1  # SPH 1500 TL-X, 1 MPPT
-        elif seriesnumber.startswith("NLC"):
-            invertertype = PV | GEN3 | X1  # SPH 3000 BP, 1 MPPT
-        elif seriesnumber.startswith("NRC"):
-            invertertype = PV | GEN3 | X1  # SPH 5000, 1 MPPT
-
-        # NEO type:GEN
-        elif seriesnumber.startswith("BZP"):
-            invertertype = PV | GEN | X1  # Neo 800M-X, 2 MPPT
-
-        # ? type:GEN
-        elif seriesnumber.startswith("QNB"):
-            invertertype = PV | GEN | X1  # 1000-S, 1 MPPT
-        elif seriesnumber.startswith("QMB"):
-            invertertype = PV | GEN | X1  # 1500-S, 1 MPPT
-        elif seriesnumber.startswith("JLE"):
-            invertertype = PV | GEN | X1  # 5000 TL3-S, x MPPT
-        elif seriesnumber.startswith("MVC"):
-            invertertype = PV | GEN | X3  # 12000 TL3-S, ? MPPT
-
-        # ? type:GEN
-        elif seriesnumber.startswith("4FZ"):
-            invertertype = PV | GEN | X1  # 5000 MTL-S, 2 MPPT
-        elif seriesnumber.startswith("BY3"):
-            invertertype = PV | GEN | X1  # 5000, ? MPPT
-
-        else:
-            _LOGGER.info(f"{hub.name}: trying alternative location")
-            seriesnumber = await async_read_serialnr(hub, 9)
-            if not seriesnumber:
-                _LOGGER.error(f"{hub.name}: cannot find firmware version, even not for other Inverter")
-                seriesnumber = "unknown"
-            ### Current mapping assumptions for Growatt
-            # TL3-SL = GEN
-            # TL3-X (MAX, MID, MAC & MOD) = GEN2
-            # Storage (MIX, SPA, SPH) = GEN3
-            # TL-X, TL-XH, TL-XHUS (MIN) = GEN4
-            # TL3-XH (MOD) = GEN4
-            # TL3-XH (MID) = GEN4
-            # SPF = SPF
-
-            # derive invertertype from seriesnumber
-            if seriesnumber.startswith("dha"):
-                invertertype = PV | GEN | X3  # PV TL3-SL 10-22kW #1067
-            # elif seriesnumber.startswith('xyz'):  invertertype = PV | GEN | X1 # Possible Single Phase version of above
-            # elif seriesnumber.startswith('xyz'):  invertertype = PV | GEN | X3 | MPPT3 # Possible 3xMMPT version of above
-            elif seriesnumber.startswith("DL1"):
-                invertertype = PV | GEN2 | X3  # PV TL3-X 15kW 3Phase (MOD)
-            elif seriesnumber.startswith("DM1"):
-                invertertype = PV | GEN2 | X3 | MPPT4  # PV TL3-X 35kW 3Phase (MID)
-            elif seriesnumber.startswith("AH1"):
-                invertertype = PV | GEN3 | X1  # Hybrid SPH 4kW - 10kW
-            elif seriesnumber.startswith("AJ1"):
-                invertertype = PV | GEN4 | X1  # PV TL-X 2.5kW - 6kW (MIN)
-            elif seriesnumber.startswith("GH1"):
-                invertertype = PV | GEN4 | X1  # PV TL-X 2.5kW - 6kW (MIN)
-            elif seriesnumber.startswith("AK1"):
-                invertertype = PV | GEN4 | X1  # MIN 3600TL-X2, 2 MPPT #2027
-            elif seriesnumber.startswith("AM1"):
-                invertertype = PV | GEN4 | X1 | MPPT3  # PV TL-X2 7kW - 120kW (MIN)
-            # elif seriesnumber.startswith('MID'):  invertertype = PV | GEN4 | X3 | MPPT3 # PV X3 2MPPT 15-25kW, 3/4 MPPT 25-40kW & 30-50kW
-            # elif seriesnumber.startswith('MAC'):  invertertype = PV | GEN4 | X3 # PV X3 3MPPT 50-70kW
-            # elif seriesnumber.startswith('MAX'):  invertertype = PV | GEN4 | X3 # PV X3 6/7MPPT 50-80kW, 8 MPPT 100-150kW & 10 MPPT 100-150kW
-            elif seriesnumber.startswith("RAA"):
-                invertertype = HYBRID | GEN3 | X1  # Hybrid SPH 3kW - 6kW
-            elif seriesnumber.startswith("RA1"):
-                invertertype = HYBRID | GEN3 | X1  # Hybrid SPH 3kW - 6kW
-            elif seriesnumber.startswith("SPH"):
-                invertertype = HYBRID | GEN3 | X3  # Hybrid SPH 4kW - 10kW
-            elif seriesnumber.startswith("YA1"):
-                invertertype = HYBRID | GEN3 | X3  # Hybrid SPH 4kW - 10kW 3P TL UP
-            elif seriesnumber.startswith("AL1"):
-                invertertype = HYBRID | GEN4 | X1  # Hybrid TL-XH 2.5kW - 6kW (MIN)
-            elif seriesnumber.startswith("DN1"):
-                invertertype = HYBRID | GEN4 | X3  # Hybrid TL3-XH (BP) 3kW - 10kW (MOD), 11kW - 30kW (MID)
-            elif seriesnumber.startswith("V"):
-                invertertype = HYBRID | GEN4 | X3  # Hybrid TL3-XH 3kW - 10kW (MOD)
-            # Include additional SPF5000ES firmware branches only as fallback when the real serial prefix is unavailable.
-            elif seriesnumber.startswith(("067", "113", "500")):
-                invertertype = HYBRID | SPF | X1  # Hybrid SPF 5kW / SPF5000ES branch, treated as 1 MPPT
+        if not invertertype:
+            firmware = await async_read_serialnr(hub, 9)
+            invertertype = _inverter_type_from_prefix(firmware, FIRMWARE_PREFIX_TYPES)
+            if not invertertype:
+                # Some older models expose a serial-style model prefix only at register 9.
+                invertertype = _inverter_type_from_prefix(firmware, SERIAL_PREFIX_TYPES)
+            if invertertype:
+                identifier = firmware
             else:
-                invertertype = 0
-                _LOGGER.error(f"unrecognized {hub.name} inverter type - firmware version : {seriesnumber}")
+                displayed_firmware = firmware or "unknown"
+                _LOGGER.error(f"unrecognized {hub.name} inverter type - firmware version : {displayed_firmware}")
+                identifier = firmware
+
+        if identifier:
+            hub.seriesnumber = identifier
 
         if invertertype > 0:
             read_eps = configdict.get(CONF_READ_EPS, DEFAULT_READ_EPS)

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -9658,100 +9658,100 @@ SERIAL_NUMBER_REGISTERS = (3001, 209, 23)
 # Serial-number prefixes from the supported Growatt model families.
 SERIAL_PREFIX_TYPES = {
     # MIN hybrid
-    "ABJ": HYBRID | GEN4 | X1,
-    "SKL": HYBRID | GEN4 | X1,
-    "XVM": HYBRID | GEN4 | X1,
-    "SMN": HYBRID | GEN4 | X1 | MPPT4,
-    "JGQ": HYBRID | GEN4 | X1 | MPPT3,
-    "HJU": HYBRID | GEN4 | X1,
+    "ABJ": HYBRID | GEN4 | X1,  # MIN 2500 TL-XH Hybrid, 2 MPPT
+    "SKL": HYBRID | GEN4 | X1,  # MIN 3600 TL-XH Hybrid, 2 MPPT
+    "XVM": HYBRID | GEN4 | X1,  # MIN 5000 TL-XH Hybrid, 2 MPPT
+    "SMN": HYBRID | GEN4 | X1 | MPPT4,  # MIN TL-XH-US Hybrid, 4 MPPT
+    "JGQ": HYBRID | GEN4 | X1 | MPPT3,  # MIN 7600 TL-XH-US Hybrid, 3 MPPT
+    "HJU": HYBRID | GEN4 | X1,  # MIN 4200TL-XH2 Hybrid, 2 MPPT
     # MOD hybrid
-    "XHL": HYBRID | GEN4 | X1,
-    "DPS": HYBRID | GEN4 | X3,
-    "DMS": HYBRID | GEN4 | X3 | MPPT3,
-    "DKS": HYBRID | GEN4 | X3 | MPPT3,
-    "DO1": HYBRID | GEN4 | X3 | MPPT3,
-    "TTS": HYBRID | GEN4 | X3 | MPPT3,
-    "TSS": HYBRID | GEN4 | X3 | MPPT3,
-    "PYL": HYBRID | GEN4 | X3,
-    "JCM": HYBRID | GEN4 | X3,
-    "MEK": HYBRID | GEN4 | X3,
-    "MFK": HYBRID | GEN4 | X1,
-    "DFK": HYBRID | GEN4 | X3,
-    "EGR": HYBRID | GEN4 | X3 | MPPT3,
+    "XHL": HYBRID | GEN4 | X1,  # MOD 4000 TL3-XH Hybrid, 2 MPPT
+    "DPS": HYBRID | GEN4 | X3,  # MOD 5000 TL3-HU Hybrid, 2 MPPT
+    "DMS": HYBRID | GEN4 | X3 | MPPT3,  # MOD 8000 TL3-HU Hybrid, 3 MPPT
+    "DKS": HYBRID | GEN4 | X3 | MPPT3,  # MOD 10000 TL3-HU Hybrid, 3 MPPT
+    "DO1": HYBRID | GEN4 | X3 | MPPT3,  # MOD 12000 TL3-HU Hybrid, 3 MPPT
+    "TTS": HYBRID | GEN4 | X3 | MPPT3,  # Hybrid KTL3-HU 12kW
+    "TSS": HYBRID | GEN4 | X3 | MPPT3,  # Hybrid KTL3-HU 12kW
+    "PYL": HYBRID | GEN4 | X3,  # MOD 5000 TL3-XH Hybrid, 2 MPPT
+    "JCM": HYBRID | GEN4 | X3,  # MOD 6000 TL3-XH Hybrid, 2 MPPT
+    "MEK": HYBRID | GEN4 | X3,  # MOD 7000 TL3-XH Hybrid, 2 MPPT
+    "MFK": HYBRID | GEN4 | X1,  # MOD 8000 TL3-XH Hybrid, 2 MPPT
+    "DFK": HYBRID | GEN4 | X3,  # MOD 100000 TL3-XH Hybrid, 2 MPPT
+    "EGR": HYBRID | GEN4 | X3 | MPPT3,  # MOD 150000 TL3-HU Hybrid, 3 MPPT
     # MID hybrid
-    "KLN": HYBRID | GEN4 | X3,
-    "KMN": HYBRID | GEN4 | X3,
-    "KNN": HYBRID | GEN4 | X3 | MPPT3,
-    "RKM": HYBRID | GEN4 | X3 | MPPT3,
+    "KLN": HYBRID | GEN4 | X3,  # MID 15000 TL3-XH Hybrid, 2 MPPT
+    "KMN": HYBRID | GEN4 | X3,  # MID 17000 TL3-XH Hybrid, 2 MPPT
+    "KNN": HYBRID | GEN4 | X3 | MPPT3,  # MID 25000 TL3-XH Hybrid, 3 MPPT
+    "RKM": HYBRID | GEN4 | X3 | MPPT3,  # MID 30000 TL3-XH Hybrid, 3 MPPT
     # MOD BP hybrid
-    "FMP": HYBRID | GEN4 | X3,
-    "FPP": HYBRID | GEN4 | X3,
-    "FQP": HYBRID | GEN4 | X3,
-    "CZM": HYBRID | GEN4 | X3,
+    "FMP": HYBRID | GEN4 | X3,  # MOD 5000 TL3-XH (BP) Hybrid, 2 MPPT
+    "FPP": HYBRID | GEN4 | X3,  # MOD 7000 TL3-XH (BP) Hybrid, 2 MPPT
+    "FQP": HYBRID | GEN4 | X3,  # MOD 8000 TL3-XH (BP) Hybrid, 2 MPPT
+    "CZM": HYBRID | GEN4 | X3,  # MOD 10000 TL3-XH (BP) Hybrid, 2 MPPT
     # SPH, SPE and SPA storage
-    "YRP": HYBRID | GEN3 | X1,
-    "NFR": HYBRID | SPF | X1,
-    "WPD": AC | GEN3 | X1,
+    "YRP": HYBRID | GEN3 | X1,  # SPH 5000 TL-HUB Hybrid, 2 MPPT
+    "NFR": HYBRID | SPF | X1,  # SPE 8000 ES, 2 MPPT
+    "WPD": AC | GEN3 | X1,  # SPA 3000TL BL AC, no PV MPPT
     # SPF
-    "YRE": HYBRID | SPF | X1,
-    "TTJ": HYBRID | SPF | X1,
-    "BNJ": HYBRID | SPF | X1,
-    "KAM": HYBRID | SPF | X1,
-    "NUK": HYBRID | SPF | X1,
+    "YRE": HYBRID | SPF | X1,  # SPF 5000 ES, 1 MPPT
+    "TTJ": HYBRID | SPF | X1,  # SPF 5000 ES, 1 MPPT
+    "BNJ": HYBRID | SPF | X1,  # SPF 3000 TL LVM 24P, 1 MPPT
+    "KAM": HYBRID | SPF | X1,  # SPF 5000 ES observed live, 1 MPPT
+    "NUK": HYBRID | SPF | X1,  # SPF 12000T DVM-US MPV, 2 MPPT
     # WIT
-    "0PE": HYBRID | GEN4 | X3,
-    "0PC": HYBRID | GEN4 | X3,
-    "0PH": HYBRID | GEN4 | X3 | MPPT10,
-    "0HU": HYBRID | GEN4 | X3,
+    "0PE": HYBRID | GEN4 | X3,  # WIT 8000-HU, 2 MPPT
+    "0PC": HYBRID | GEN4 | X3,  # WIT 12000-HU, 2 MPPT
+    "0PH": HYBRID | GEN4 | X3 | MPPT10,  # WIT 100000-HU, 10 MPPT
+    "0HU": HYBRID | GEN4 | X3,  # WIT 15K-HU, 2 MPPT
     # MIC and MIN PV
-    "FPH": PV | GEN4 | X1,
-    "FWJ": PV | GEN4 | X1,
-    "QYL": PV | GEN4 | X1,
-    "XTD": PV | GEN4 | X1,
-    "BDK": PV | GEN4 | X1,
-    "WVN": PV | GEN4 | X1 | MPPT3,
+    "FPH": PV | GEN4 | X1,  # MIC 2000 TL-X, 1 MPPT
+    "FWJ": PV | GEN4 | X1,  # MIC 3300 TL-X, 1 MPPT
+    "QYL": PV | GEN4 | X1,  # MIN 2500 TL-X, 2 MPPT
+    "XTD": PV | GEN4 | X1,  # MIN 5000 TL-X, 2 MPPT
+    "BDK": PV | GEN4 | X1,  # MIN 4200 TL-XE, 2 MPPT
+    "WVN": PV | GEN4 | X1 | MPPT3,  # MIN 8000 TL-X2, 3 MPPT
     # MOD, MID and MAX PV
-    "RDH": PV | GEN2 | X3,
-    "QEH": PV | GEN2 | X3,
-    "RPH": PV | GEN2 | X3,
-    "GXF": PV | GEN4 | X3,
-    "NAH": PV | GEN4 | X3 | MPPT6,
+    "RDH": PV | GEN2 | X3,  # MOD 4000 TL3-X, 2 MPPT
+    "QEH": PV | GEN2 | X3,  # MOD 8000 TL3-X, 2 MPPT
+    "RPH": PV | GEN2 | X3,  # MOD 15000 TL3-X, 2 MPPT
+    "GXF": PV | GEN4 | X3,  # MID 12000 TL3-XL, 2 MPPT
+    "NAH": PV | GEN4 | X3 | MPPT6,  # MAX 60000 TL3 LV, 6 MPPT
     # SPH PV
-    "DIE": PV | GEN3 | X1,
-    "PYH": PV | GEN3 | X1,
-    "NLC": PV | GEN3 | X1,
-    "NRC": PV | GEN3 | X1,
+    "DIE": PV | GEN3 | X1,  # SPH 1000-S, 1 MPPT
+    "PYH": PV | GEN3 | X1,  # SPH 1500 TL-X, 1 MPPT
+    "NLC": PV | GEN3 | X1,  # SPH 3000 BP, 1 MPPT
+    "NRC": PV | GEN3 | X1,  # SPH 5000, 1 MPPT
     # NEO and older PV models
-    "BZP": PV | GEN | X1,
-    "QNB": PV | GEN | X1,
-    "QMB": PV | GEN | X1,
-    "JLE": PV | GEN | X1,
-    "MVC": PV | GEN | X3,
-    "4FZ": PV | GEN | X1,
-    "BY3": PV | GEN | X1,
+    "BZP": PV | GEN | X1,  # Neo 800M-X, 2 MPPT
+    "QNB": PV | GEN | X1,  # 1000-S, 1 MPPT
+    "QMB": PV | GEN | X1,  # 1500-S, 1 MPPT
+    "JLE": PV | GEN | X1,  # 5000 TL3-S, x MPPT
+    "MVC": PV | GEN | X3,  # 12000 TL3-S, ? MPPT
+    "4FZ": PV | GEN | X1,  # 5000 MTL-S, 2 MPPT
+    "BY3": PV | GEN | X1,  # 5000, ? MPPT
 }
 
 # Firmware/build prefixes used when no supported serial-number prefix is available.
 FIRMWARE_PREFIX_TYPES = {
-    "dha": PV | GEN | X3,
-    "DL1": PV | GEN2 | X3,
-    "DM1": PV | GEN2 | X3 | MPPT4,
-    "AH1": PV | GEN3 | X1,
-    "AJ1": PV | GEN4 | X1,
-    "GH1": PV | GEN4 | X1,
-    "AK1": PV | GEN4 | X1,
-    "AM1": PV | GEN4 | X1 | MPPT3,
-    "RAA": HYBRID | GEN3 | X1,
-    "RA1": HYBRID | GEN3 | X1,
-    "SPH": HYBRID | GEN3 | X3,
-    "YA1": HYBRID | GEN3 | X3,
-    "RH1": AC | GEN3 | X1,
-    "AL1": HYBRID | GEN4 | X1,
-    "DN1": HYBRID | GEN4 | X3,
-    "V": HYBRID | GEN4 | X3,
-    "067": HYBRID | SPF | X1,
-    "113": HYBRID | SPF | X1,
-    "500": HYBRID | SPF | X1,
+    "dha": PV | GEN | X3,  # PV TL3-SL 10-22kW #1067
+    "DL1": PV | GEN2 | X3,  # PV TL3-X 15kW 3Phase (MOD)
+    "DM1": PV | GEN2 | X3 | MPPT4,  # PV TL3-X 35kW 3Phase (MID)
+    "AH1": PV | GEN3 | X1,  # Hybrid SPH 4kW - 10kW
+    "AJ1": PV | GEN4 | X1,  # PV TL-X 2.5kW - 6kW (MIN)
+    "GH1": PV | GEN4 | X1,  # PV TL-X 2.5kW - 6kW (MIN)
+    "AK1": PV | GEN4 | X1,  # MIN 3600TL-X2, 2 MPPT #2027
+    "AM1": PV | GEN4 | X1 | MPPT3,  # PV TL-X2 7kW - 120kW (MIN)
+    "RAA": HYBRID | GEN3 | X1,  # Hybrid SPH 3kW - 6kW
+    "RA1": HYBRID | GEN3 | X1,  # Hybrid SPH 3kW - 6kW
+    "SPH": HYBRID | GEN3 | X3,  # Hybrid SPH 4kW - 10kW
+    "YA1": HYBRID | GEN3 | X3,  # Hybrid SPH 4kW - 10kW 3P TL UP
+    "RH1": AC | GEN3 | X1,  # SPA 3000TL BL AC, no PV MPPT
+    "AL1": HYBRID | GEN4 | X1,  # Hybrid TL-XH 2.5kW - 6kW (MIN)
+    "DN1": HYBRID | GEN4 | X3,  # Hybrid TL3-XH (BP) 3kW - 10kW (MOD), 11kW - 30kW (MID)
+    "V": HYBRID | GEN4 | X3,  # Hybrid TL3-XH 3kW - 10kW (MOD)
+    "067": HYBRID | SPF | X1,  # Hybrid SPF 5kW / SPF5000ES branch, treated as 1 MPPT
+    "113": HYBRID | SPF | X1,  # Hybrid SPF 5kW / SPF5000ES branch, treated as 1 MPPT
+    "500": HYBRID | SPF | X1,  # Hybrid SPF 5kW / SPF5000ES branch, treated as 1 MPPT
 }
 
 

--- a/tests/unit/test_growatt_inverter_detection.py
+++ b/tests/unit/test_growatt_inverter_detection.py
@@ -1,0 +1,118 @@
+from typing import Any
+
+import pytest
+
+from custom_components.solax_modbus.plugin_growatt import AC, GEN3, GEN4, HYBRID, PV, X1
+from custom_components.solax_modbus.plugin_growatt import plugin_instance as growatt_plugin
+
+
+class GrowattResponse:
+    def __init__(self, value: str | None) -> None:
+        encoded = (value or "").encode("ascii").ljust(10, b"\x00")
+        self.registers = [int.from_bytes(encoded[offset : offset + 2], byteorder="big") for offset in range(0, 10, 2)]
+
+    def isError(self) -> bool:
+        return False
+
+
+class GrowattHub:
+    def __init__(self, responses: dict[int, str | None]) -> None:
+        self.name = "Growatt"
+        self._modbus_addr = 1
+        self.seriesnumber: str | None = None
+        self.responses = responses
+        self.read_addresses: list[int] = []
+
+    async def async_read_holding_registers(self, unit: int, address: int, count: int) -> GrowattResponse:
+        assert unit == self._modbus_addr
+        assert count == 5
+        self.read_addresses.append(address)
+        return GrowattResponse(self.responses.get(address))
+
+
+CONFIG: dict[str, Any] = {"read_eps": False, "read_dcb": False}
+
+
+@pytest.mark.asyncio
+async def test_spa_serial_register_is_checked_after_unknown_identifiers() -> None:
+    hub = GrowattHub(
+        {
+            3001: "NOTAMODEL1",
+            209: "ALSOUNKNWN",
+            23: "WPDBN4200S",
+            9: "RH1.0 ZCAA",
+        }
+    )
+
+    invertertype = await growatt_plugin.async_determineInverterType(hub, CONFIG)
+
+    assert invertertype == AC | GEN3 | X1
+    assert hub.seriesnumber == "WPDBN4200S"
+    assert hub.read_addresses == [3001, 209, 23]
+
+
+@pytest.mark.asyncio
+async def test_spa_firmware_is_used_when_serial_is_unavailable() -> None:
+    hub = GrowattHub(
+        {
+            3001: "NOTAMODEL1",
+            209: None,
+            23: None,
+            9: "RH1.0 ZCAA",
+        }
+    )
+
+    invertertype = await growatt_plugin.async_determineInverterType(hub, CONFIG)
+
+    assert invertertype == AC | GEN3 | X1
+    assert hub.seriesnumber == "RH1.0 ZCAA"
+    assert hub.read_addresses == [3001, 209, 23, 9]
+
+
+@pytest.mark.asyncio
+async def test_known_serial_still_stops_detection_at_first_register() -> None:
+    hub = GrowattHub(
+        {
+            3001: "XTD1234567",
+            209: "NOTREAD001",
+            23: "NOTREAD002",
+            9: "NOTREAD003",
+        }
+    )
+
+    invertertype = await growatt_plugin.async_determineInverterType(hub, CONFIG)
+
+    assert invertertype == PV | GEN4 | X1
+    assert hub.seriesnumber == "XTD1234567"
+    assert hub.read_addresses == [3001]
+
+
+@pytest.mark.asyncio
+async def test_known_secondary_serial_is_not_blocked_by_unknown_primary_value() -> None:
+    hub = GrowattHub(
+        {
+            3001: "NOTAMODEL1",
+            209: "HJU1234567",
+        }
+    )
+
+    invertertype = await growatt_plugin.async_determineInverterType(hub, CONFIG)
+
+    assert invertertype == HYBRID | GEN4 | X1
+    assert hub.seriesnumber == "HJU1234567"
+    assert hub.read_addresses == [3001, 209]
+
+
+@pytest.mark.asyncio
+async def test_existing_firmware_fallback_is_preserved() -> None:
+    hub = GrowattHub(
+        {
+            9: "GH1.0 ZAAa",
+        }
+    )
+
+    invertertype = await growatt_plugin.async_determineInverterType(hub, CONFIG)
+
+    assert invertertype == PV | GEN4 | X1
+    assert hub.seriesnumber == "GH1.0 ZAAa"
+    assert hub.read_addresses == [3001, 209, 23, 9]


### PR DESCRIPTION
The Growatt SPA3000 exposes its serial number in holding registers 23-27, while register 9 contains the RH1 firmware identifier. Detection could stop after an unknown but non-empty value from an earlier register, so the valid SPA identifiers were not always reached.
This change continues checking identifier locations until a known prefix is found, adds the WPD serial prefix for AC | GEN3 | X1, and keeps RH1 as a firmware fallback. Existing Growatt mappings and the fast path for already recognized inverters remain unchanged.
Fixes #2134