### PR TITLE
Prevent duplicate hub names during setup

### DIFF
--- a/custom_components/solax_modbus/config_flow.py
+++ b/custom_components/solax_modbus/config_flow.py
@@ -90,6 +90,21 @@ def getPluginName(plugin_path: str) -> str:
     return plugin_path[len(PLUGIN_PATH) - 4 : -3]
 
 
+def _normalized_hub_name(name: str) -> str:
+    """Normalize a hub name for uniqueness checks."""
+    return name.strip().casefold()
+
+
+def _configured_hub_names(handler: SchemaCommonFlowHandler) -> set[str]:
+    """Return normalized hub names already configured for this integration."""
+    names: set[str] = set()
+    for entry in handler.parent_handler.hass.config_entries.async_entries(DOMAIN):
+        name = entry.options.get(CONF_NAME) or entry.data.get(CONF_NAME)
+        if isinstance(name, str):
+            names.add(_normalized_hub_name(name))
+    return names
+
+
 # ####################################################################################################
 
 BAUDRATES = [
@@ -219,6 +234,10 @@ async def _validate_base(handler: SchemaCommonFlowHandler, user_input: dict[str,
     if (name == DEFAULT_NAME) and (pluginconf_name != DEFAULT_PLUGIN):
         _LOGGER.warning(f"instance name {name} already defined or default name for non-default inverter")
         user_input[CONF_NAME] = user_input[CONF_PLUGIN]  # getPluginName(user_input[CONF_PLUGIN])
+        raise SchemaFlowError("name_already_used")
+
+    normalized_name = _normalized_hub_name(name)
+    if normalized_name in _configured_hub_names(handler):
         raise SchemaFlowError("name_already_used")
 
     return user_input

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -1,0 +1,77 @@
+"""Tests for the SolaX Modbus config flow."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.schema_config_entry_flow import SchemaCommonFlowHandler, SchemaFlowError
+
+from custom_components.solax_modbus.config_flow import _validate_base
+from custom_components.solax_modbus.const import CONF_INTERFACE, CONF_MODBUS_ADDR, CONF_PLUGIN, DEFAULT_PLUGIN, DOMAIN
+
+
+class _ConfigEntries:
+    def __init__(self, entries: list[Any]) -> None:
+        self._entries = entries
+
+    def async_entries(self, domain: str) -> list[Any]:
+        assert domain == DOMAIN
+        return self._entries
+
+
+def _handler_with_entries(entries: list[Any]) -> SchemaCommonFlowHandler:
+    hass = SimpleNamespace(config_entries=_ConfigEntries(entries))
+    return cast(SchemaCommonFlowHandler, SimpleNamespace(parent_handler=SimpleNamespace(hass=hass)))
+
+
+def _base_input(name: str) -> dict[str, Any]:
+    return {
+        CONF_NAME: name,
+        CONF_INTERFACE: "tcp",
+        CONF_MODBUS_ADDR: 1,
+        CONF_PLUGIN: DEFAULT_PLUGIN,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing_name", ["SolaX", " solax ", "SOLAX"])
+async def test_validate_base_rejects_duplicate_hub_name(existing_name: str) -> None:
+    """Reject names that identify an already configured hub."""
+    entry = SimpleNamespace(options={CONF_NAME: existing_name}, data={})
+
+    with pytest.raises(SchemaFlowError, match="name_already_used"):
+        await _validate_base(_handler_with_entries([entry]), _base_input("SolaX"))
+
+
+@pytest.mark.asyncio
+async def test_validate_base_checks_legacy_entry_data() -> None:
+    """Reject a duplicate name stored in legacy config entry data."""
+    entry = SimpleNamespace(options={}, data={CONF_NAME: "SolaX"})
+
+    with pytest.raises(SchemaFlowError, match="name_already_used"):
+        await _validate_base(_handler_with_entries([entry]), _base_input("SolaX"))
+
+
+@pytest.mark.asyncio
+async def test_validate_base_allows_unique_hub_name() -> None:
+    """Allow a hub name that is not already configured."""
+    entry = SimpleNamespace(options={CONF_NAME: "SolaX Garage"}, data={})
+    user_input = _base_input("SolaX Loft")
+
+    result = await _validate_base(_handler_with_entries([entry]), user_input)
+
+    assert result == user_input
+
+
+@pytest.mark.asyncio
+async def test_validate_base_preserves_default_name_handling_for_other_plugins() -> None:
+    """Keep suggesting the plugin name when a non-SolaX plugin uses the default."""
+    entry = SimpleNamespace(options={CONF_NAME: "SolaX"}, data={})
+    user_input = _base_input("SolaX")
+    user_input[CONF_PLUGIN] = "growatt"
+
+    with pytest.raises(SchemaFlowError, match="name_already_used"):
+        await _validate_base(_handler_with_entries([entry]), user_input)
+
+    assert user_input[CONF_NAME] == "growatt"


### PR DESCRIPTION
This prevents a second SolaX Modbus hub from being created with a name that is already in use.
Hub names are used internally as runtime keys and as part of entity unique IDs. Duplicate names can therefore cause hubs and entities to interfere with each other.
The comparison is case-insensitive and ignores surrounding whitespace. Existing configurations are not changed; the check only applies when adding a new hub.
Related to https://github.com/wills106/homeassistant-solax-modbus/issues/2103