### PR TITLE
Warn when the same inverter is configured more than once

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_PORT,
+    CONF_SCAN_INTERVAL,
     EVENT_HOMEASSISTANT_STOP,
     PERCENTAGE,
     Platform,
@@ -40,6 +41,12 @@ from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException, ModbusIOException
 from pymodbus.framer import FramerType
 
+from .connection import (
+    describe_modbus_connection,
+    format_config_entry_names,
+    matching_config_entries,
+    modbus_connection_identity,
+)
 from .const import (
     BUTTONREPEAT_FIRST as BUTTONREPEAT_FIRST,
 )
@@ -864,6 +871,29 @@ class SolaXModbusHub:
             _LOGGER.debug(f"{self._name}: returning scan_group interval {g} for {sensor.entity_description.key}")
         return int(g)
 
+    def _warn_duplicate_inverter_configuration(self, interval: int) -> None:
+        """Warn from one active duplicate configuration on every slow poll."""
+        slow_interval = int(self.config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+        if interval != slow_interval:
+            return
+
+        entries = matching_config_entries(self._hass, self.config, active_only=True)
+        if len(entries) < 2:
+            return
+
+        warning_owner = min(entries, key=lambda entry: str(entry.entry_id))
+        if warning_owner.entry_id != self.entry.entry_id:
+            return
+
+        identity = modbus_connection_identity(self.config)
+        if identity is None:
+            return
+        _LOGGER.warning(
+            "Duplicate inverter configuration detected: %s are enabled and poll the same Modbus device (%s).",
+            format_config_entry_names(entries),
+            describe_modbus_connection(identity),
+        )
+
     def device_group_key(self, device_info: DeviceInfo) -> str:
         """Extract device group key from device_info identifiers.
 
@@ -925,6 +955,7 @@ class SolaXModbusHub:
 
             async def _refresh(_now: Any = None) -> None:
                 secs = interval_group.interval
+                self._warn_duplicate_inverter_configuration(secs)
                 self.cyclecount += 1
                 cycle_id = self.cyclecount
                 _LOGGER.debug(f"{self._name}: [{secs}s] poll started – cycle #{cycle_id}")

--- a/custom_components/solax_modbus/config_flow.py
+++ b/custom_components/solax_modbus/config_flow.py
@@ -31,6 +31,9 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowMenuStep,
 )
 
+from .connection import (
+    matching_config_entries,
+)
 from .const import (
     CONF_BAUDRATE,
     CONF_CORE_HUB,
@@ -285,7 +288,31 @@ async def _next_step_battery(user_input: Any) -> str | None:
     _LOGGER.debug(f"_next_step_battery: returning data: {user_input}")
     if user_input.get("support-battery", False):
         return "battery"
-    return None
+    return "duplicate_inverter"
+
+
+def _current_config_entry_id(handler: SchemaCommonFlowHandler) -> str | None:
+    """Return the entry being edited by an options flow."""
+    try:
+        return cast(str, handler.parent_handler.config_entry.entry_id)
+    except (AttributeError, ValueError):
+        return None
+
+
+def _duplicate_inverter_entries(handler: SchemaCommonFlowHandler) -> list[Any]:
+    """Return other entries configured for the candidate connection."""
+    return matching_config_entries(
+        handler.parent_handler.hass,
+        handler.options,
+        exclude_entry_id=_current_config_entry_id(handler),
+    )
+
+
+async def _duplicate_inverter_schema(handler: SchemaCommonFlowHandler) -> vol.Schema | None:
+    """Only show the confirmation step when another config entry matches."""
+    if not _duplicate_inverter_entries(handler):
+        return None
+    return vol.Schema({})
 
 
 def _load_plugin(plugin_name: str) -> ModuleType:
@@ -303,14 +330,16 @@ if (MAJOR_VERSION >= 2023) or ((MAJOR_VERSION == 2022) and (MINOR_VERSION >= 12)
         "serial": SchemaFlowFormStep(SERIAL_SCHEMA, next_step=_next_step_battery),
         "tcp": SchemaFlowFormStep(TCP_SCHEMA, validate_user_input=_validate_host, next_step=_next_step_battery),
         "core": SchemaFlowFormStep(CORE_SCHEMA, validate_user_input=_validate_core_modbus_hub, next_step=_next_step_battery),
-        "battery": SchemaFlowFormStep(BATTERY_SCHEMA),
+        "battery": SchemaFlowFormStep(BATTERY_SCHEMA, next_step="duplicate_inverter"),
+        "duplicate_inverter": SchemaFlowFormStep(_duplicate_inverter_schema),
     }
     OPTIONS_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
         "init": SchemaFlowFormStep(OPTION_SCHEMA, next_step=_next_step_modbus),
         "serial": SchemaFlowFormStep(SERIAL_SCHEMA, next_step=_next_step_battery),
         "tcp": SchemaFlowFormStep(TCP_SCHEMA, validate_user_input=_validate_host, next_step=_next_step_battery),
         "core": SchemaFlowFormStep(CORE_SCHEMA, validate_user_input=_validate_core_modbus_hub, next_step=_next_step_battery),
-        "battery": SchemaFlowFormStep(BATTERY_SCHEMA),
+        "battery": SchemaFlowFormStep(BATTERY_SCHEMA, next_step="duplicate_inverter"),
+        "duplicate_inverter": SchemaFlowFormStep(_duplicate_inverter_schema),
     }
 
 else:  # for older versions - REMOVE SOON

--- a/custom_components/solax_modbus/config_flow.py
+++ b/custom_components/solax_modbus/config_flow.py
@@ -294,9 +294,12 @@ async def _next_step_battery(user_input: Any) -> str | None:
 def _current_config_entry_id(handler: SchemaCommonFlowHandler) -> str | None:
     """Return the entry being edited by an options flow."""
     try:
-        return cast(str, handler.parent_handler.config_entry.entry_id)
-    except (AttributeError, ValueError):
+        config_entry = getattr(handler.parent_handler, "config_entry", None)
+    except ValueError:
         return None
+    if config_entry is None:
+        return None
+    return str(config_entry.entry_id)
 
 
 def _duplicate_inverter_entries(handler: SchemaCommonFlowHandler) -> list[Any]:

--- a/custom_components/solax_modbus/connection.py
+++ b/custom_components/solax_modbus/connection.py
@@ -1,0 +1,139 @@
+"""Helpers for identifying configured Modbus connections."""
+
+import ipaddress
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+
+from .const import (
+    CONF_CORE_HUB,
+    CONF_INTERFACE,
+    CONF_MODBUS_ADDR,
+    CONF_SERIAL_PORT,
+    DEFAULT_MODBUS_ADDR,
+    DEFAULT_PORT,
+    DEFAULT_SERIAL_PORT,
+    DOMAIN,
+)
+
+
+@dataclass(frozen=True)
+class ModbusConnectionIdentity:
+    """The configured path to one Modbus device."""
+
+    interface: str
+    endpoint: str
+    modbus_addr: int
+    port: int | None = None
+
+
+def effective_entry_config(entry: Any) -> dict[str, Any]:
+    """Return config entry data with current options taking precedence."""
+    data = getattr(entry, "data", {}) or {}
+    options = getattr(entry, "options", {}) or {}
+    return {**dict(data), **dict(options)}
+
+
+def configured_entry_name(entry: Any) -> str:
+    """Return the user-visible name of a configured inverter."""
+    config = effective_entry_config(entry)
+    name = config.get(CONF_NAME) or getattr(entry, "title", None) or getattr(entry, "entry_id", "unknown")
+    return str(name)
+
+
+def _configured_interface(config: Mapping[str, Any]) -> str:
+    interface = config.get(CONF_INTERFACE)
+    if interface:
+        return str(interface)
+    return "serial" if config.get("read_serial", False) else "tcp"
+
+
+def _normalized_host(host: Any) -> str:
+    value = str(host).strip()
+    try:
+        return ipaddress.ip_address(value).compressed
+    except ValueError:
+        return value.rstrip(".").casefold()
+
+
+def modbus_connection_identity(config: Mapping[str, Any]) -> ModbusConnectionIdentity | None:
+    """Build a comparable identity for TCP, serial, or Core Modbus."""
+    interface = _configured_interface(config)
+    configured_addr = config.get(CONF_MODBUS_ADDR, DEFAULT_MODBUS_ADDR)
+    if configured_addr is None:
+        configured_addr = DEFAULT_MODBUS_ADDR
+    try:
+        modbus_addr = int(configured_addr)
+    except (TypeError, ValueError):
+        return None
+
+    if interface == "tcp":
+        host = config.get(CONF_HOST)
+        if not host:
+            return None
+        try:
+            port = int(config.get(CONF_PORT, DEFAULT_PORT))
+        except (TypeError, ValueError):
+            return None
+        return ModbusConnectionIdentity("tcp", _normalized_host(host), modbus_addr, port)
+
+    if interface == "serial":
+        serial_port = str(config.get(CONF_SERIAL_PORT, DEFAULT_SERIAL_PORT)).strip()
+        if not serial_port:
+            return None
+        return ModbusConnectionIdentity("serial", serial_port, modbus_addr)
+
+    if interface == "core":
+        core_hub = str(config.get(CONF_CORE_HUB, "")).strip()
+        if not core_hub:
+            return None
+        return ModbusConnectionIdentity("core", core_hub, modbus_addr)
+
+    return None
+
+
+def describe_modbus_connection(identity: ModbusConnectionIdentity) -> str:
+    """Return a user-facing description of a Modbus connection."""
+    if identity.interface == "tcp":
+        host = f"[{identity.endpoint}]" if ":" in identity.endpoint else identity.endpoint
+        return f"TCP {host}:{identity.port}, Modbus address {identity.modbus_addr}"
+    if identity.interface == "serial":
+        return f"serial {identity.endpoint}, Modbus address {identity.modbus_addr}"
+    return f'Core Modbus "{identity.endpoint}", Modbus address {identity.modbus_addr}'
+
+
+def matching_config_entries(
+    hass: Any,
+    config: Mapping[str, Any],
+    *,
+    exclude_entry_id: str | None = None,
+    active_only: bool = False,
+) -> list[Any]:
+    """Return integration entries configured for the same Modbus device."""
+    identity = modbus_connection_identity(config)
+    if identity is None:
+        return []
+
+    matches: list[Any] = []
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if getattr(entry, "entry_id", None) == exclude_entry_id:
+            continue
+        if active_only and (getattr(entry, "disabled_by", None) is not None or getattr(entry, "state", None) is not ConfigEntryState.LOADED):
+            continue
+        if modbus_connection_identity(effective_entry_config(entry)) == identity:
+            matches.append(entry)
+    return matches
+
+
+def format_config_entry_names(entries: list[Any]) -> str:
+    """Format inverter config entry names for warnings."""
+    names = sorted((configured_entry_name(entry) for entry in entries), key=str.casefold)
+    quoted = [f'"{name}"' for name in names]
+    if len(quoted) < 2:
+        return quoted[0] if quoted else ""
+    if len(quoted) == 2:
+        return " and ".join(quoted)
+    return f"{', '.join(quoted[:-1])}, and {quoted[-1]}"

--- a/custom_components/solax_modbus/strings.json
+++ b/custom_components/solax_modbus/strings.json
@@ -46,6 +46,10 @@
         "data": {
           "read_battery": "Enable readout"
         }
+      },
+      "duplicate_inverter": {
+        "title": "Duplicate inverter configuration",
+        "description": "Another inverter configuration already uses this Modbus connection and address. If both configurations are enabled, they will poll the same inverter and may cause communication problems. Submit to save anyway."
       }
     },
     "error": {
@@ -104,6 +108,10 @@
         "data": {
           "read_battery": "Enable readout"
         }
+      },
+      "duplicate_inverter": {
+        "title": "Duplicate inverter configuration",
+        "description": "Another inverter configuration already uses this Modbus connection and address. If both configurations are enabled, they will poll the same inverter and may cause communication problems. Submit to save anyway."
       }
     },
     "error": {

--- a/custom_components/solax_modbus/translations/en.json
+++ b/custom_components/solax_modbus/translations/en.json
@@ -46,6 +46,10 @@
         "data": {
           "read_core_hub": "The core Modbus hub used to connect to the inverter"
         }
+      },
+      "duplicate_inverter": {
+        "title": "Duplicate inverter configuration",
+        "description": "Another inverter configuration already uses this Modbus connection and address. If both configurations are enabled, they will poll the same inverter and may cause communication problems. Submit to save anyway."
       }
     },
     "error": {
@@ -104,6 +108,10 @@
         "data": {
           "read_core_hub": "The core Modbus hub used to connect to the inverter"
         }
+      },
+      "duplicate_inverter": {
+        "title": "Duplicate inverter configuration",
+        "description": "Another inverter configuration already uses this Modbus connection and address. If both configurations are enabled, they will poll the same inverter and may cause communication problems. Submit to save anyway."
       }
     },
     "error": {

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -180,7 +180,9 @@ async def test_duplicate_warning_step_allows_save_after_confirmation() -> None:
 
     assert warning["type"] == "form"
     assert warning["step_id"] == "duplicate_inverter"
-    assert warning["data_schema"].schema == {}
+    data_schema = warning["data_schema"]
+    assert data_schema is not None
+    assert data_schema.schema == {}
 
     result = await handler.async_step("duplicate_inverter", {})
 

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -7,8 +7,18 @@ import pytest
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.schema_config_entry_flow import SchemaCommonFlowHandler, SchemaFlowError
 
-from custom_components.solax_modbus.config_flow import _validate_base
-from custom_components.solax_modbus.const import CONF_INTERFACE, CONF_MODBUS_ADDR, CONF_PLUGIN, DEFAULT_PLUGIN, DOMAIN
+from custom_components.solax_modbus.config_flow import (
+    CONFIG_FLOW,
+    _duplicate_inverter_schema,
+    _validate_base,
+)
+from custom_components.solax_modbus.const import (
+    CONF_INTERFACE,
+    CONF_MODBUS_ADDR,
+    CONF_PLUGIN,
+    DEFAULT_PLUGIN,
+    DOMAIN,
+)
 
 
 class _ConfigEntries:
@@ -20,9 +30,31 @@ class _ConfigEntries:
         return self._entries
 
 
-def _handler_with_entries(entries: list[Any]) -> SchemaCommonFlowHandler:
+class _FlowParent:
+    def __init__(self, entries: list[Any]) -> None:
+        self.hass = SimpleNamespace(config_entries=_ConfigEntries(entries))
+
+    def async_show_form(self, **kwargs: Any) -> dict[str, Any]:
+        return {"type": "form", **kwargs}
+
+    def async_create_entry(self, *, data: dict[str, Any]) -> dict[str, Any]:
+        return {"type": "create_entry", "data": data}
+
+
+def _handler_with_entries(
+    entries: list[Any],
+    *,
+    options: dict[str, Any] | None = None,
+    current_entry: Any = None,
+) -> SchemaCommonFlowHandler:
     hass = SimpleNamespace(config_entries=_ConfigEntries(entries))
-    return cast(SchemaCommonFlowHandler, SimpleNamespace(parent_handler=SimpleNamespace(hass=hass)))
+    parent_handler = SimpleNamespace(hass=hass)
+    if current_entry is not None:
+        parent_handler.config_entry = current_entry
+    return cast(
+        SchemaCommonFlowHandler,
+        SimpleNamespace(parent_handler=parent_handler, options=options or {}),
+    )
 
 
 def _base_input(name: str) -> dict[str, Any]:
@@ -75,3 +107,97 @@ async def test_validate_base_preserves_default_name_handling_for_other_plugins()
         await _validate_base(_handler_with_entries([entry]), user_input)
 
     assert user_input[CONF_NAME] == "growatt"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_connection_shows_confirmation() -> None:
+    """Show the same non-blocking warning during initial setup."""
+    connection = {
+        CONF_NAME: "SolaX Test",
+        CONF_INTERFACE: "tcp",
+        "host": "192.0.2.10",
+        "port": 502,
+        CONF_MODBUS_ADDR: 1,
+    }
+    existing = SimpleNamespace(
+        entry_id="existing",
+        title="SolaX Existing",
+        options={**connection, CONF_NAME: "SolaX Existing"},
+        data={},
+    )
+    handler = _handler_with_entries([existing], options=connection)
+
+    schema = await _duplicate_inverter_schema(handler)
+
+    assert schema is not None
+    assert schema.schema == {}
+
+
+@pytest.mark.asyncio
+async def test_options_flow_excludes_only_the_entry_being_edited() -> None:
+    """Warn on save when another matching inverter config exists."""
+    connection = {
+        CONF_NAME: "SolaX Existing",
+        CONF_INTERFACE: "serial",
+        "read_serial_port": "/dev/ttyUSB0",
+        CONF_MODBUS_ADDR: 1,
+    }
+    current = SimpleNamespace(entry_id="current", title="SolaX Existing", options=connection, data={})
+    duplicate = SimpleNamespace(
+        entry_id="duplicate",
+        title="SolaX Test",
+        options={**connection, CONF_NAME: "SolaX Test"},
+        data={},
+    )
+
+    current_only = _handler_with_entries([current], options=connection, current_entry=current)
+    with_duplicate = _handler_with_entries([current, duplicate], options=connection, current_entry=current)
+
+    assert await _duplicate_inverter_schema(current_only) is None
+    assert await _duplicate_inverter_schema(with_duplicate) is not None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_warning_step_allows_save_after_confirmation() -> None:
+    """Show the warning once, then complete the flow after an empty submit."""
+    connection = {
+        CONF_NAME: "SolaX Test",
+        CONF_INTERFACE: "tcp",
+        "host": "192.0.2.10",
+        "port": 502,
+        CONF_MODBUS_ADDR: 1,
+    }
+    existing = SimpleNamespace(
+        entry_id="existing",
+        title="SolaX Existing",
+        options={**connection, CONF_NAME: "SolaX Existing"},
+        data={},
+    )
+    parent = _FlowParent([existing])
+    handler = SchemaCommonFlowHandler(cast(Any, parent), CONFIG_FLOW, connection)
+
+    warning = await handler.async_step("duplicate_inverter")
+
+    assert warning["type"] == "form"
+    assert warning["step_id"] == "duplicate_inverter"
+    assert warning["data_schema"].schema == {}
+
+    result = await handler.async_step("duplicate_inverter", {})
+
+    assert result == {"type": "create_entry", "data": connection}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_warning_step_is_skipped_for_unique_connection() -> None:
+    """Complete the flow immediately when no other inverter connection matches."""
+    connection = {
+        CONF_NAME: "SolaX",
+        CONF_INTERFACE: "core",
+        "read_core_hub": "inverter_bus",
+        CONF_MODBUS_ADDR: 1,
+    }
+    handler = SchemaCommonFlowHandler(cast(Any, _FlowParent([])), CONFIG_FLOW, connection)
+
+    result = await handler.async_step("duplicate_inverter")
+
+    assert result == {"type": "create_entry", "data": connection}

--- a/tests/unit/test_duplicate_inverter_connections.py
+++ b/tests/unit/test_duplicate_inverter_connections.py
@@ -1,0 +1,107 @@
+"""Tests for duplicate inverter connection identification."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+
+from custom_components.solax_modbus.connection import (
+    matching_config_entries,
+    modbus_connection_identity,
+)
+from custom_components.solax_modbus.const import (
+    CONF_BAUDRATE,
+    CONF_CORE_HUB,
+    CONF_INTERFACE,
+    CONF_MODBUS_ADDR,
+    CONF_SERIAL_PORT,
+    CONF_TCP_TYPE,
+    DOMAIN,
+)
+
+
+class _ConfigEntries:
+    def __init__(self, entries: list[Any]) -> None:
+        self._entries = entries
+
+    def async_entries(self, domain: str) -> list[Any]:
+        assert domain == DOMAIN
+        return self._entries
+
+
+def _entry(entry_id: str, name: str, config: dict[str, Any], *, active: bool = True) -> Any:
+    return SimpleNamespace(
+        entry_id=entry_id,
+        title=name,
+        data={},
+        options={CONF_NAME: name, **config},
+        disabled_by=None if active else "user",
+        state=ConfigEntryState.LOADED,
+    )
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        (
+            {CONF_INTERFACE: "tcp", CONF_HOST: "INVERTER.local.", CONF_PORT: 502, CONF_MODBUS_ADDR: 1, CONF_TCP_TYPE: "tcp"},
+            {CONF_INTERFACE: "tcp", CONF_HOST: "inverter.local", CONF_PORT: 502, CONF_MODBUS_ADDR: 1, CONF_TCP_TYPE: "rtu"},
+        ),
+        (
+            {CONF_INTERFACE: "serial", CONF_SERIAL_PORT: "/dev/ttyUSB0", CONF_MODBUS_ADDR: 2, CONF_BAUDRATE: "9600"},
+            {CONF_INTERFACE: "serial", CONF_SERIAL_PORT: "/dev/ttyUSB0", CONF_MODBUS_ADDR: 2, CONF_BAUDRATE: "19200"},
+        ),
+        (
+            {CONF_INTERFACE: "core", CONF_CORE_HUB: "inverter_bus", CONF_MODBUS_ADDR: 3},
+            {CONF_INTERFACE: "core", CONF_CORE_HUB: "inverter_bus", CONF_MODBUS_ADDR: 3},
+        ),
+    ],
+)
+def test_connection_identity_matches_same_modbus_device(first: dict[str, Any], second: dict[str, Any]) -> None:
+    """Treat connection settings that target the same device as duplicates."""
+    assert modbus_connection_identity(first) == modbus_connection_identity(second)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {CONF_INTERFACE: "tcp", CONF_HOST: "192.0.2.10", CONF_PORT: 502, CONF_MODBUS_ADDR: 1},
+        {CONF_INTERFACE: "serial", CONF_SERIAL_PORT: "/dev/ttyUSB0", CONF_MODBUS_ADDR: 1},
+        {CONF_INTERFACE: "core", CONF_CORE_HUB: "inverter_bus", CONF_MODBUS_ADDR: 1},
+    ],
+)
+def test_connection_identity_distinguishes_modbus_addresses(config: dict[str, Any]) -> None:
+    """Allow multiple inverters behind one TCP, serial, or Core Modbus connection."""
+    other = {**config, CONF_MODBUS_ADDR: 2}
+
+    assert modbus_connection_identity(config) != modbus_connection_identity(other)
+
+
+def test_legacy_none_modbus_address_uses_default() -> None:
+    """Match legacy entries that the runtime treats as Modbus address 1."""
+    legacy = {CONF_INTERFACE: "tcp", CONF_HOST: "192.0.2.10", CONF_PORT: 502, CONF_MODBUS_ADDR: None}
+    current = {CONF_INTERFACE: "tcp", CONF_HOST: "192.0.2.10", CONF_PORT: 502, CONF_MODBUS_ADDR: 1}
+
+    assert modbus_connection_identity(legacy) == modbus_connection_identity(current)
+
+
+def test_matching_entries_can_include_disabled_entries_for_setup_warning() -> None:
+    """Warn in setup even when the existing duplicate is currently disabled."""
+    config = {CONF_INTERFACE: "tcp", CONF_HOST: "192.0.2.10", CONF_PORT: 502, CONF_MODBUS_ADDR: 1}
+    disabled = _entry("existing", "Existing inverter", config, active=False)
+    hass = SimpleNamespace(config_entries=_ConfigEntries([disabled]))
+
+    assert matching_config_entries(hass, config) == [disabled]
+    assert matching_config_entries(hass, config, active_only=True) == []
+
+
+def test_matching_entries_excludes_entry_being_edited() -> None:
+    """Do not treat an options flow entry as its own duplicate."""
+    config = {CONF_INTERFACE: "serial", CONF_SERIAL_PORT: "/dev/ttyUSB0", CONF_MODBUS_ADDR: 1}
+    current = _entry("current", "Current inverter", config)
+    duplicate = _entry("duplicate", "Duplicate inverter", config)
+    hass = SimpleNamespace(config_entries=_ConfigEntries([current, duplicate]))
+
+    assert matching_config_entries(hass, config, exclude_entry_id="current") == [duplicate]

--- a/tests/unit/test_duplicate_inverter_poll_warning.py
+++ b/tests/unit/test_duplicate_inverter_poll_warning.py
@@ -2,7 +2,7 @@
 
 import logging
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import Mock, call
 
 import pytest
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SCAN_INTER
 import custom_components.solax_modbus as solax_modbus
 from custom_components.solax_modbus import SolaXModbusHub
 from custom_components.solax_modbus.const import CONF_INTERFACE, CONF_MODBUS_ADDR, DOMAIN
+from custom_components.solax_modbus.sensor import SolaXModbusSensor
 
 
 class _ConfigEntries:
@@ -36,7 +37,7 @@ def _entry(entry_id: str, name: str, config: dict[str, Any], *, active: bool = T
 
 def _hub(entries: list[Any], current: Any, config: dict[str, Any]) -> SolaXModbusHub:
     hub = object.__new__(SolaXModbusHub)
-    hub._hass = SimpleNamespace(config_entries=_ConfigEntries(entries))
+    object.__setattr__(hub, "_hass", SimpleNamespace(config_entries=_ConfigEntries(entries)))
     hub.config = config
     hub.entry = current
     return hub
@@ -116,30 +117,34 @@ async def test_scheduled_poll_checks_warning_on_every_cycle(monkeypatch: Any) ->
     monkeypatch.setattr(solax_modbus, "async_track_time_interval", _track_interval)
 
     hub = object.__new__(SolaXModbusHub)
-    hub._hass = SimpleNamespace()
+    object.__setattr__(hub, "_hass", SimpleNamespace())
     hub._name = "SolaX"
     hub.groups = {}
     hub.cyclecount = 0
     hub.slowdown = 1
     hub.blocks_changed = False
-    hub.scan_group = Mock(return_value=15)
-    hub.device_group_key = Mock(return_value="inverter")
-    hub._warn_duplicate_inverter_configuration = Mock()
-    hub._record_poll_cycle = Mock()
+    monkeypatch.setattr(hub, "scan_group", Mock(return_value=15))
+    monkeypatch.setattr(hub, "device_group_key", Mock(return_value="inverter"))
+    warn_duplicate = Mock()
+    monkeypatch.setattr(hub, "_warn_duplicate_inverter_configuration", warn_duplicate)
+    monkeypatch.setattr(hub, "_record_poll_cycle", Mock())
 
     async def _refresh_data(_interval_group: Any, _now: Any, *, cycle_id: int) -> tuple[bool, int]:
         assert cycle_id > 0
         return True, 0
 
-    hub.async_refresh_modbus_data = _refresh_data
-    sensor = SimpleNamespace(
-        entity_description=SimpleNamespace(key="test_sensor"),
-        device_info={},
-        _attr_available=True,
+    monkeypatch.setattr(hub, "async_refresh_modbus_data", _refresh_data)
+    sensor = cast(
+        SolaXModbusSensor,
+        SimpleNamespace(
+            entity_description=SimpleNamespace(key="test_sensor"),
+            device_info={},
+            _attr_available=True,
+        ),
     )
 
     await hub.async_add_solax_modbus_sensor(sensor)
     await scheduled["callback"]()
     await scheduled["callback"]()
 
-    assert hub._warn_duplicate_inverter_configuration.call_args_list == [call(15), call(15)]
+    assert warn_duplicate.call_args_list == [call(15), call(15)]

--- a/tests/unit/test_duplicate_inverter_poll_warning.py
+++ b/tests/unit/test_duplicate_inverter_poll_warning.py
@@ -1,0 +1,145 @@
+"""Tests for duplicate inverter warnings during polling."""
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, call
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL
+
+import custom_components.solax_modbus as solax_modbus
+from custom_components.solax_modbus import SolaXModbusHub
+from custom_components.solax_modbus.const import CONF_INTERFACE, CONF_MODBUS_ADDR, DOMAIN
+
+
+class _ConfigEntries:
+    def __init__(self, entries: list[Any]) -> None:
+        self._entries = entries
+
+    def async_entries(self, domain: str) -> list[Any]:
+        assert domain == DOMAIN
+        return self._entries
+
+
+def _entry(entry_id: str, name: str, config: dict[str, Any], *, active: bool = True) -> Any:
+    return SimpleNamespace(
+        entry_id=entry_id,
+        title=name,
+        data={},
+        options={CONF_NAME: name, **config},
+        disabled_by=None if active else "user",
+        state=ConfigEntryState.LOADED,
+    )
+
+
+def _hub(entries: list[Any], current: Any, config: dict[str, Any]) -> SolaXModbusHub:
+    hub = object.__new__(SolaXModbusHub)
+    hub._hass = SimpleNamespace(config_entries=_ConfigEntries(entries))
+    hub.config = config
+    hub.entry = current
+    return hub
+
+
+def test_warning_is_logged_on_every_slow_poll(caplog: Any) -> None:
+    """Keep warning while two active configurations poll the same inverter."""
+    config = {
+        CONF_INTERFACE: "tcp",
+        CONF_HOST: "192.0.2.10",
+        CONF_PORT: 502,
+        CONF_MODBUS_ADDR: 1,
+        CONF_SCAN_INTERVAL: 15,
+    }
+    first = _entry("01", "Primary inverter", config)
+    second = _entry("02", "Test inverter", config)
+    hub = _hub([first, second], first, config)
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.solax_modbus"):
+        hub._warn_duplicate_inverter_configuration(15)
+        hub._warn_duplicate_inverter_configuration(15)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 2
+    assert all('"Primary inverter" and "Test inverter"' in message for message in messages)
+    assert all("TCP 192.0.2.10:502, Modbus address 1" in message for message in messages)
+
+
+def test_only_one_duplicate_configuration_logs(caplog: Any) -> None:
+    """Avoid duplicate warnings from both active inverter configurations."""
+    config = {
+        CONF_INTERFACE: "tcp",
+        CONF_HOST: "192.0.2.10",
+        CONF_PORT: 502,
+        CONF_MODBUS_ADDR: 1,
+        CONF_SCAN_INTERVAL: 15,
+    }
+    first = _entry("01", "Primary inverter", config)
+    second = _entry("02", "Test inverter", config)
+    hub = _hub([first, second], second, config)
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.solax_modbus"):
+        hub._warn_duplicate_inverter_configuration(15)
+
+    assert caplog.records == []
+
+
+def test_fast_poll_and_inactive_duplicate_do_not_log(caplog: Any) -> None:
+    """Only warn on slow polls when both inverter configurations are active."""
+    config = {
+        CONF_INTERFACE: "tcp",
+        CONF_HOST: "192.0.2.10",
+        CONF_PORT: 502,
+        CONF_MODBUS_ADDR: 1,
+        CONF_SCAN_INTERVAL: 15,
+    }
+    first = _entry("01", "Primary inverter", config)
+    inactive = _entry("02", "Inactive inverter", config, active=False)
+    hub = _hub([first, inactive], first, config)
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.solax_modbus"):
+        hub._warn_duplicate_inverter_configuration(5)
+        hub._warn_duplicate_inverter_configuration(15)
+
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_scheduled_poll_checks_warning_on_every_cycle(monkeypatch: Any) -> None:
+    """Call duplicate detection for each invocation of the slow poll callback."""
+    scheduled: dict[str, Any] = {}
+
+    def _track_interval(_hass: Any, callback: Any, _interval: Any) -> Any:
+        scheduled["callback"] = callback
+        return Mock()
+
+    monkeypatch.setattr(solax_modbus, "async_track_time_interval", _track_interval)
+
+    hub = object.__new__(SolaXModbusHub)
+    hub._hass = SimpleNamespace()
+    hub._name = "SolaX"
+    hub.groups = {}
+    hub.cyclecount = 0
+    hub.slowdown = 1
+    hub.blocks_changed = False
+    hub.scan_group = Mock(return_value=15)
+    hub.device_group_key = Mock(return_value="inverter")
+    hub._warn_duplicate_inverter_configuration = Mock()
+    hub._record_poll_cycle = Mock()
+
+    async def _refresh_data(_interval_group: Any, _now: Any, *, cycle_id: int) -> tuple[bool, int]:
+        assert cycle_id > 0
+        return True, 0
+
+    hub.async_refresh_modbus_data = _refresh_data
+    sensor = SimpleNamespace(
+        entity_description=SimpleNamespace(key="test_sensor"),
+        device_info={},
+        _attr_available=True,
+    )
+
+    await hub.async_add_solax_modbus_sensor(sensor)
+    await scheduled["callback"]()
+    await scheduled["callback"]()
+
+    assert hub._warn_duplicate_inverter_configuration.call_args_list == [call(15), call(15)]


### PR DESCRIPTION
This adds a non-blocking warning when a new or existing configuration uses the same Modbus connection and address as another inverter configuration.

It covers TCP, serial, and Core Modbus connections while still allowing multiple devices with different Modbus addresses on the same bus or gateway. The duplicate configuration can still be saved for testing purposes.

When duplicate configurations are both enabled, one of them also logs a warning on every slow poll with the affected inverter names and connection details.