### PR TITLE
fix: switch writes honor write_method; unreadable readbacks no longer spam errors

### DIFF
--- a/custom_components/solax_modbus/switch.py
+++ b/custom_components/solax_modbus/switch.py
@@ -16,6 +16,7 @@ from .const import (
     DEFAULT_MODBUS_ADDR,
     DOMAIN,
     WRITE_DATA_LOCAL,
+    WRITE_MULTISINGLE_MODBUS,
     BaseModbusSwitchEntityDescription,
     matches_modbus_protocol,
 )
@@ -190,13 +191,21 @@ class SolaXModbusSwitch(SwitchEntity, RestoreEntity):
             return
 
         payload: int = self._value_function(self._bit, is_on, self._sensor_key, self._hub.data)
-        _LOGGER.debug(f"Writing {self._platform_name} {self._key} to register {self._register} with value {payload}")
-        await self._hub.async_write_registers_single(
-            unit=self._modbus_addr,
-            address=self._register,
-            payload=payload,
-            register_data_type=getattr(self.entity_description, "register_data_type", None),
-        )
+        _LOGGER.debug(f"Writing {self._platform_name} {self._key} to register {self._register} with value {payload} method {self._write_method}")
+        if self._write_method == WRITE_MULTISINGLE_MODBUS:
+            await self._hub.async_write_registers_single(
+                unit=self._modbus_addr,
+                address=self._register,
+                payload=payload,
+                register_data_type=getattr(self.entity_description, "register_data_type", None),
+            )
+        else:
+            await self._hub.async_write_register(
+                unit=self._modbus_addr,
+                address=self._register,
+                payload=payload,
+                register_data_type=getattr(self.entity_description, "register_data_type", None),
+            )
 
     @property
     def is_on(self) -> bool | None:
@@ -208,13 +217,18 @@ class SolaXModbusSwitch(SwitchEntity, RestoreEntity):
         # Otherwise, return the sensor state
         if self._sensor_key and (self._sensor_key in self._hub.data):
             sensvalue = self._hub.data.get(self._sensor_key, None)
-            if sensvalue is not None:
+            if sensvalue is None:
+                # Readback register temporarily unreadable (failed or quarantined read);
+                # report unknown instead of a fabricated off state, like selects do.
+                _LOGGER.debug(f"{self._hub.name}: Sensor {self._sensor_key} for switch {self._key} has no value yet, state unknown")
+                return None
+            try:
                 sensor_value = int(sensvalue)
-            else:
-                _LOGGER.error(
-                    f"{self._hub.name}: Sensor {self._sensor_key} corresponding to switch {self._key} bit {self._bit} has no integer value {sensvalue}"
+            except (TypeError, ValueError):
+                _LOGGER.debug(
+                    f"{self._hub.name}: Sensor {self._sensor_key} for switch {self._key} has non-integer value {sensvalue!r}, state unknown"
                 )
-                sensor_value = 0  # probably completely wrong, but at least we can continue with other entities
+                return None
             return bool(sensor_value & (1 << self._bit))
 
         return self._attr_is_on


### PR DESCRIPTION
Fixes both regressions reported in #2177 (by @rosenrot00 and @wills106) after 2026.07.2.

## 1. Writes ignored `write_method` — the FC16 rejections

`_write_switch_to_modbus` always called `async_write_registers_single`, which despite its name issues a **function 0x10** (write multiple) request. Every converted select had used the default `WRITE_SINGLE_MODBUS` (**function 0x06**), and some inverters reject 0x10 on those registers — exactly the reported error:

```
multi-function single-register write was rejected by device 1 at register 0x9e: ExceptionResponse(..., function_code=144, exception_code=3)
```

Switches now dispatch on `write_method` the same way `select.py` does: `WRITE_SINGLE_MODBUS` → `async_write_register` (0x06), `WRITE_MULTISINGLE_MODBUS` → `async_write_registers_single` (0x10). Verified against the pre-#2177 tree: none of the converted selects declared a non-default write method, so restoring the dispatch restores the exact function codes used before the conversion. No entity declarations change.

## 2. Unreadable readbacks — the ERROR spam

When a readback register cannot be read (device does not answer that address, or the register was quarantined after failed retries), the hub deliberately stores `None` for the key. The select platform has always degraded silently to *unknown* in that case; the switch platform logged an **ERROR every poll cycle** and substituted `0` — actively showing the switch as off regardless of the real device state.

| Readback condition | Before | After |
|---|---|---|
| reads normally | on/off | on/off (unchanged) |
| unreadable (`None`) | ERROR every poll + shows **off** | **unknown**, debug log, auto-recovers |
| non-integer value | unhandled `ValueError` | **unknown**, debug log |

One file (`switch.py`), single commit.
