### PR TITLE
fix(mega_forth): add MPPT6 flag to X3-MEGA 40kW G2 invertertype

### DIFF
--- a/custom_components/solax_modbus/plugin_solax_mega_forth.py
+++ b/custom_components/solax_modbus/plugin_solax_mega_forth.py
@@ -1033,7 +1033,7 @@ class solax_mega_forth_plugin(plugin_base):
 
         # derive invertertupe from seriiesnumber
         if seriesnumber.startswith("X3G04"):
-            invertertype = MAX | GEN2  # MAX G2
+            invertertype = MAX | GEN2 | MPPT6  # MAX G2
             self.inverter_model = "X3 - MEGA 40kW - G2"
         elif seriesnumber.startswith("X3G05"):
             invertertype = MAX | GEN2 | MPPT5  # MAX MEGA G2


### PR DESCRIPTION
## Description
This PR fixes the `invertertype` bitmask declaration for the Solax X3-MEGA 40kW G2 inverter in `plugin_solax_mega_forth.py`. 

The missing `MPPT6` bitwise flag prevented Home Assistant from properly identifying and reading data for all 6 MPPT trackers supported by this model.

## Changes Made
Updated the series number detection for `X3G04`:

**Before:**
```python
if seriesnumber.startswith("X3G04"):
    invertertype = MAX | GEN2   # MAX G2
    self.inverter_model = "X3 - MEGA 40kW - G2"


**After:*
if seriesnumber.startswith("X3G04"):
    invertertype = MAX | GEN2 | MPPT6    # MAX G2
    self.inverter_model = "X3 - MEGA 40kW - G2"
