### PR TITLE
Use a shared Modbus transport for native and Core hubs

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass, replace
 from datetime import timedelta
 from types import ModuleType, SimpleNamespace
 from typing import Any, cast
-from weakref import ref as WeakRef
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -118,7 +117,8 @@ from .const import (
 from .const import (
     WRITE_MULTISINGLE_MODBUS as WRITE_MULTISINGLE_MODBUS,
 )
-from .pymodbus_compat import ADDR_KW, DataType, convert_from_registers, convert_to_registers, pymodbus_version_info
+from .modbus_transport import CoreModbusTransport, ModbusTransport, NativeModbusTransport, UnavailableModbusTransport
+from .pymodbus_compat import DataType, convert_from_registers, convert_to_registers, pymodbus_version_info
 from .sensor import SolaXModbusSensor
 
 RETRIES = 1  # was 6 then 0, which worked also, but 1 is probably the safe choice
@@ -129,18 +129,6 @@ COMM_BLOCK_FAILURE_THRESHOLD = 3
 COMM_BLOCK_FAILURE_WINDOW = 600
 COMM_RECOVERY_INTERVAL = 300
 INFLIGHT_CANCEL_TIMEOUT = 2.0
-
-
-try:
-    from homeassistant.components.modbus import ModbusHub as CoreModbusHub  # type: ignore[attr-defined]
-    from homeassistant.components.modbus import get_hub as get_core_hub
-except ImportError:
-
-    def get_core_hub(hass: HomeAssistant, name: str) -> None:  # type: ignore[misc]
-        return None
-
-    class CoreModbusHub:  # type: ignore[no-redef]  # placeholder dummy
-        pass
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -519,30 +507,35 @@ class SolaXModbusHub:
         self._hass = hass
         # explicit init for stop flag
         self._stopping = False
-        self._client: AsyncModbusSerialClient | AsyncModbusTcpClient | SimpleNamespace
+        self._transport: ModbusTransport
         if interface == "serial":
-            self._client = AsyncModbusSerialClient(
-                port=serial_port,
-                baudrate=baudrate,
-                parity="N",
-                stopbits=1,
-                bytesize=8,
-                timeout=time_out,
-                retries=RETRIES,
+            self._transport = NativeModbusTransport(
+                AsyncModbusSerialClient(
+                    port=serial_port,
+                    baudrate=baudrate,
+                    parity="N",
+                    stopbits=1,
+                    bytesize=8,
+                    timeout=time_out,
+                    retries=RETRIES,
+                )
             )
         elif interface == "tcp":
             if tcp_type == "rtu":
-                self._client = AsyncModbusTcpClient(host=host, port=port, timeout=time_out, framer=FramerType.RTU, retries=RETRIES)
+                client = AsyncModbusTcpClient(host=host, port=port, timeout=time_out, framer=FramerType.RTU, retries=RETRIES)
             elif tcp_type == "ascii":
-                self._client = AsyncModbusTcpClient(host=host, port=port, timeout=time_out, framer=FramerType.ASCII, retries=RETRIES)
+                client = AsyncModbusTcpClient(host=host, port=port, timeout=time_out, framer=FramerType.ASCII, retries=RETRIES)
             else:
-                self._client = AsyncModbusTcpClient(host=host, port=port, timeout=time_out, retries=RETRIES)
+                client = AsyncModbusTcpClient(host=host, port=port, timeout=time_out, retries=RETRIES)
+            self._transport = NativeModbusTransport(client)
         elif interface == "core":
-            # Core-hub variant uses Home Assistant's Modbus hub; use harmless dummy client
-            self._client = SimpleNamespace(connected=False, comm_params=SimpleNamespace(host="", port=""))
+            self._transport = CoreModbusTransport(
+                hass,
+                config.get(CONF_CORE_HUB, ""),
+                name,
+            )
         else:
-            # Fallback dummy client for unrecognized interface types
-            self._client = SimpleNamespace(connected=False, comm_params=SimpleNamespace(host="", port=""))
+            self._transport = UnavailableModbusTransport(interface)
         self._lock = asyncio.Lock()
         self._poll_data_lock = asyncio.Lock()
         self._name: str = name
@@ -1158,8 +1151,7 @@ class SolaXModbusHub:
 
     async def async_close(self) -> None:
         """Disconnect client."""
-        if self._client.connected:
-            self._client.close()
+        await self._transport.close()
 
     async def async_stop(self) -> None:
         """Stop polling/timers and close transport deterministically."""
@@ -1224,8 +1216,7 @@ class SolaXModbusHub:
             pass
         # 4) close transport
         try:
-            if self._client and self._client.connected:
-                self._client.close()
+            await self.async_close()
         except Exception:
             pass
 
@@ -1261,77 +1252,45 @@ class SolaXModbusHub:
             return False
         return isinstance(ex, ModbusIOException) and "Request cancelled outside pymodbus" in str(ex)
 
-    # async def async_connect(self):
-    #    """Connect client."""
-    #    _LOGGER.debug("connect modbus")
-    #    if not self._client.connected:
-    #        async with self._lock:
-    #            await self._client.connect()
-
     async def _check_connection(self) -> bool:
         if getattr(self, "_stopping", False):
             return False
-        if not self._client.connected:
+        if not self._transport.is_connected():
             _LOGGER.debug(f"{self._name}: Inverter is not connected, trying to connect")
             await self.async_connect()
-            await asyncio.sleep(1)
-        return self._client.connected
+        return self._transport.is_connected()
 
     async def is_online(self) -> bool:
-        return self._client.connected and (self.slowdown == 1)
+        return self._transport.is_connected() and (self.slowdown == 1)
 
-    async def async_connect(self) -> None:
+    async def async_connect(self) -> bool:
         if getattr(self, "_stopping", False):
-            return
-        if self._client.connected:
+            return False
+        if self._transport.is_connected():
             _LOGGER.debug(f"{self._name}: async_connect skipped - already connected")
-            return
-        _LOGGER.debug(
-            f"{self._name}: Trying to connect to Inverter at {self._client.comm_params.host}:{self._client.comm_params.port} connected: {self._client.connected} ",
-        )
-        await self._client.connect()
+            return True
+        _LOGGER.debug(f"{self._name}: trying to connect to inverter through {self._transport.endpoint}")
+        return await self._transport.connect()
 
     async def async_read_holding_registers(self, unit: int, address: int, count: int) -> Any:
-        """Read holding registers using high-level pymodbus API."""
-        async with self._lock:
-            if getattr(self, "_stopping", False):
-                return None
-            await self._check_connection()
-            if not self._client.connected:
-                return None
-            try:
-                # Use high-level API; unit key is provided via ADDR_KW for compatibility
-                kwargs = {ADDR_KW: unit} if unit is not None else {}
-                _LOGGER.debug(f"{self._name}: READ HOLDING {ADDR_KW}={unit} addr=0x{address:x} cnt={count}")
-                resp = await self._track_task(self._client.read_holding_registers(address=address, count=count, **kwargs))  # type: ignore[arg-type]
-            except ModbusException as exception_error:
-                error = f"Error: device: {unit} address: 0x{address:x} -> {exception_error!s}"
-                if self._is_expected_shutdown_modbus_error(exception_error):
-                    _LOGGER.debug(f"{self._name}: ignoring Modbus read cancellation during shutdown: {error}")
-                    return None
-                _LOGGER.error(error)
-                if getattr(self, "_stopping", False):
-                    _LOGGER.debug(f"{self._name}: ModbusException during shutdown - skipping reconnect")
-                    return None
-                _LOGGER.debug(f"{self._name}: ModbusException – closing transport and deferring reconnect")
-                self._client.close()
-                return None
-        return resp
+        """Read holding registers."""
+        return await self._async_read_registers("holding", unit, address, count)
 
     async def async_read_input_registers(self, unit: int, address: int, count: int) -> Any:
-        """Read input registers using high-level pymodbus API."""
+        """Read input registers."""
+        return await self._async_read_registers("input", unit, address, count)
+
+    async def _async_read_registers(self, register_type: str, unit: int, address: int, count: int) -> Any:
+        """Read registers through the configured transport."""
         async with self._lock:
             if getattr(self, "_stopping", False):
                 return None
-            await self._check_connection()
-            if not self._client.connected:
+            if not await self._check_connection():
                 return None
             try:
-                # Use high-level API; unit key is provided via ADDR_KW for compatibility
-                kwargs = {ADDR_KW: unit} if unit is not None else {}
-                _LOGGER.debug(f"{self._name}: READ INPUT  {ADDR_KW}={unit} addr=0x{address:x} cnt={count}")
-                resp = await self._track_task(self._client.read_input_registers(address=address, count=count, **kwargs))  # type: ignore[arg-type]
-            except ModbusException as exception_error:
+                _LOGGER.debug(f"{self._name}: READ {register_type.upper()} device={unit} addr=0x{address:x} cnt={count}")
+                response = await self._track_task(self._transport.read(register_type, unit, address, count))
+            except (ModbusException, AttributeError, TypeError) as exception_error:
                 error = f"Error: device: {unit} address: 0x{address:x} -> {exception_error!s}"
                 if self._is_expected_shutdown_modbus_error(exception_error):
                     _LOGGER.debug(f"{self._name}: ignoring Modbus read cancellation during shutdown: {error}")
@@ -1341,9 +1300,9 @@ class SolaXModbusHub:
                     _LOGGER.debug(f"{self._name}: ModbusException during shutdown - skipping reconnect")
                     return None
                 _LOGGER.debug(f"{self._name}: ModbusException – closing transport and deferring reconnect")
-                self._client.close()
+                await self._transport.close()
                 return None
-        return resp
+        return response
 
     def _validate_write_response(self, response: Any, *, unit: int, address: int, operation: str) -> Any:
         """Raise when pymodbus did not confirm a write operation."""
@@ -1404,33 +1363,53 @@ class SolaXModbusHub:
 
         return registers
 
+    async def _async_transport_write(
+        self,
+        unit: int,
+        address: int,
+        values: list[int],
+        *,
+        multiple: bool,
+        operation: str,
+    ) -> Any:
+        """Write encoded registers through the configured transport."""
+        if getattr(self, "_stopping", False):
+            raise HomeAssistantError(f"{self._name}: integration is stopping")
+        async with self._lock:
+            if not await self._check_connection():
+                raise HomeAssistantError(f"{self._name}: inverter is not connected")
+            try:
+                response = await self._track_task(self._transport.write(unit, address, values, multiple=multiple))
+            except (ModbusException, AttributeError, TypeError) as ex:
+                raise HomeAssistantError(f"{self._name}: {operation} failed: {ex}") from ex
+        return self._validate_write_response(
+            response,
+            unit=unit,
+            address=address,
+            operation=operation,
+        )
+
     async def async_lowlevel_write_register(self, unit: int, address: int, payload: int, register_data_type: str | None = None) -> Any:
-        kwargs: dict[str, int] = {ADDR_KW: unit} if unit is not None else {}
         if register_data_type == REGISTER_U16:
             regs = convert_to_registers(int(payload), DataType.UINT16, self.plugin.order32)  # type: ignore[attr-defined]
         else:
             regs = convert_to_registers(int(payload), DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
         try:
-            async with self._lock:
-                if not await self._check_connection():
-                    raise HomeAssistantError(f"{self._name}: inverter is not connected")
-                resp = await self._track_task(self._client.write_register(address=address, value=regs[0], **kwargs))  # type: ignore[arg-type]
-            resp = self._validate_write_response(
-                resp,
+            response = await self._async_transport_write(
                 unit=unit,
                 address=address,
+                values=regs,
+                multiple=False,
                 operation="single-register write",
             )
-        except (ModbusException, HomeAssistantError) as ex:
+        except HomeAssistantError as ex:
             if hasattr(self.plugin, "log_register_write"):
                 self.plugin.log_register_write(self, address, unit, payload, error=(type(ex).__name__, str(ex)))
-            if isinstance(ex, HomeAssistantError):
-                raise
-            raise HomeAssistantError(f"Error writing single Modbus register: {ex}") from ex
+            raise
 
         if hasattr(self.plugin, "log_register_write"):
-            self.plugin.log_register_write(self, address, unit, payload, result=resp)
-        return resp
+            self.plugin.log_register_write(self, address, unit, payload, result=response)
+        return response
 
     async def async_write_register(self, unit: int, address: int, payload: int, register_data_type: str | None = None) -> Any:
         """Write register."""
@@ -1492,18 +1471,11 @@ class SolaXModbusHub:
             regs = convert_to_registers(int(payload), DataType.UINT16, self.plugin.order32)  # type: ignore[attr-defined]
         else:
             regs = convert_to_registers(int(payload), DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
-        kwargs = {ADDR_KW: unit} if unit is not None else {}
-        async with self._lock:
-            if not await self._check_connection():
-                raise HomeAssistantError(f"{self._name}: inverter is not connected")
-            try:
-                resp = await self._track_task(self._client.write_registers(address=address, values=regs, **kwargs))  # type: ignore[arg-type]
-            except ModbusException as ex:
-                raise HomeAssistantError(f"Error writing single Modbus registers: {ex}") from ex
-        return self._validate_write_response(
-            resp,
+        return await self._async_transport_write(
             unit=unit,
             address=address,
+            values=regs,
+            multiple=True,
             operation="multi-function single-register write",
         )
 
@@ -1519,20 +1491,13 @@ class SolaXModbusHub:
         All register descriptions referenced in the payload must be consecutive (without leaving holes)
         32bit integers will be converted to 2 modbus register values according to the endian strategy of the plugin
         """
-        kwargs: dict[str, int] = {ADDR_KW: unit} if unit is not None else {}
         regs_out = self._encode_multi_write_payload(payload)
         _LOGGER.debug(f"Ready to write multiple registers at 0x{address:02x}: {regs_out}")
-        async with self._lock:
-            if not await self._check_connection():
-                raise HomeAssistantError(f"{self._name}: inverter is not connected")
-            try:
-                resp = await self._track_task(self._client.write_registers(address=address, values=regs_out, **kwargs))  # type: ignore[arg-type]
-            except ModbusException as ex:
-                raise HomeAssistantError(f"Error writing multiple Modbus registers: {ex}") from ex
-        return self._validate_write_response(
-            resp,
+        return await self._async_transport_write(
             unit=unit,
             address=address,
+            values=regs_out,
+            multiple=True,
             operation="multi-register write",
         )
 
@@ -2153,7 +2118,7 @@ class SolaXModbusHub:
         task.add_done_callback(_remove_runtime_bisect_task)
 
     async def _runtime_bisect_block(self, block_obj: Any, typ: str, key: str) -> None:
-        if not getattr(self._client, "connected", False):
+        if not self._transport.is_connected():
             return
         candidates: set[int] = set()
         _LOGGER.warning(f"{self._name}: repeated failures for {key}; probing block to isolate bad registers")
@@ -2184,7 +2149,7 @@ class SolaXModbusHub:
             return
         if await self._probe_block(block_obj, typ):
             return
-        if not getattr(self._client, "connected", False):
+        if not self._transport.is_connected():
             return
 
         regs = list(block_obj.regs or [])
@@ -2202,7 +2167,7 @@ class SolaXModbusHub:
         single = self._single_register_block(typ, addr)
         failures = 0
         for _ in range(2):
-            if not getattr(self._client, "connected", False):
+            if not self._transport.is_connected():
                 return False
             if await self._probe_block(single, typ):
                 return False
@@ -2246,7 +2211,7 @@ class SolaXModbusHub:
             _LOGGER.debug(f"{self._name}: quarantine recheck loop failed: {ex}")
 
     async def _recheck_quarantined_register(self, typ: str, addr: int) -> None:
-        if not getattr(self._client, "connected", False):
+        if not self._transport.is_connected():
             return
         single = self._single_register_block(typ, addr)
         if not await self._probe_block(single, typ, timeout=self._quarantine_recheck_timeout()):
@@ -2390,259 +2355,5 @@ class SolaXModbusHub:
             return False
 
 
-# --- SolaXCoreModbusHub class ---
-
-
-class SolaXCoreModbusHub(SolaXModbusHub, CoreModbusHub):  # type: ignore[misc]
-    """Thread safe wrapper class for pymodbus."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        plugin: ModuleType,
-        entry: ConfigEntry,
-    ) -> None:
-        SolaXModbusHub.__init__(self, hass, plugin, entry)
-        config = entry.options
-        core_hub_name = config.get(CONF_CORE_HUB, "")
-        self._core_hub = core_hub_name
-        self._hub: Any = None
-        _LOGGER.debug(f"solax via core modbus hub '{core_hub_name}")
-
-        _LOGGER.debug("setup solax core modbus hub done %s", self.__dict__)
-
-    async def async_close(self) -> None:
-        """Disconnect client."""
-        async with self._lock:
-            if self._hub:
-                self._hub = None
-
-    # async def async_connect(self):
-    #    """Connect client."""
-    #    _LOGGER.debug("connect modbus")
-    #    if not self._client.connected:
-    #        async with self._lock:
-    #            await self._client.connect()
-
-    async def _check_connection(self) -> Any:
-        # get hold of temporary strong reference to CoreModbusHub object
-        # and pass it on success to caller if available
-        if self._hub is None or (hub := self._hub()) is None:
-            return await self.async_connect()
-        async with hub._lock:
-            try:
-                if hub._client.connected:
-                    return hub
-            except (TypeError, AttributeError):
-                pass
-        _LOGGER.debug(f"{self._name}: Inverter is not connected, trying to connect")
-        return await self.async_connect(hub)
-
-    async def is_online(self) -> bool:
-        """Reflect online state using the Core Modbus hub client."""
-        try:
-            hub = self._hub() if self._hub is not None else None
-        except Exception:
-            hub = None
-        try:
-            return bool(hub and getattr(hub, "_client", None) and hub._client.connected and (self.slowdown == 1))
-        except Exception:
-            return False
-
-    def _hub_closed_now(self, ref_obj: Any) -> None:
-        # Called from WeakRef finalizer (synchronous context)
-        # Cannot use asyncio.Lock here - just clear the reference
-        if ref_obj is self._hub:
-            self._hub = None
-
-    async def async_connect(self, hub: Any = None) -> Any:
-        delay = True
-        while True:
-            # check if strong reference to
-            # get one.
-            if hub is not None or (self._hub is not None and (hub := self._hub()) is not None):
-                port = hub._pb_params.get("port", 0)
-                host = hub._pb_params.get("host", port)
-                # TODO just wait some time and recheck again if client connected before
-                # giving up
-                await hub._lock.acquire()
-                try:
-                    if hub._client and hub._client.connected:
-                        hub._lock.release()
-                        _LOGGER.debug(
-                            "Inverter connected at %s:%s",
-                            host,
-                            port,
-                        )
-                        return hub
-                except (TypeError, AttributeError):
-                    pass
-                hub._lock.release()
-                if not delay:
-                    reason = " core modbus hub '{self._core_hub}' not ready" if hub._config_delay else ""
-                    _LOGGER.warning(f"Unable to connect to Inverter at {host}:{port}.{reason}")
-                    return None
-            else:
-                # get hold of current CoreModbusHub object with
-                # provided entity name
-                try:
-                    hub = get_core_hub(self._hass, self._core_hub)
-                except KeyError:
-                    _LOGGER.warning(
-                        f"CoreModbusHub '{self._core_hub}' not available",
-                    )
-                    return None
-                else:
-                    if hub:
-                        # update weak reference handle to refer to
-                        # the actual CoreModbusHub object
-                        self._hub = WeakRef(hub, self._hub_closed_now)
-                        continue
-                if not delay:
-                    _LOGGER.warning(
-                        "Unable to join core modbus %s",
-                        self._core_hub,
-                    )
-                    return None
-            # wait some time (TODO make configurable) before
-            # rechecking if CoreModbusHub object has been created and
-            # connected
-            delay = False
-            await asyncio.sleep(10)
-
-    async def async_read_holding_registers(self, unit: int, address: int, count: int) -> Any:
-        """Read holding registers."""
-        kwargs = {ADDR_KW: unit} if unit is not None else {}
-        if getattr(self, "_stopping", False):
-            return None
-        async with self._lock:
-            hub = await self._check_connection()
-        try:
-            if not hub or getattr(hub, "_config_delay", False):
-                return None
-            async with hub._lock:
-                try:
-                    resp = await self._track_task(hub._client.read_holding_registers(address=address, count=count, **kwargs))
-                except (ConnectionException, ModbusIOException) as e:
-                    if self._is_expected_shutdown_modbus_error(e):
-                        _LOGGER.debug(f"{self._name}: ignoring core Modbus read cancellation during shutdown: {e}")
-                        return None
-                    original_message = str(e)
-                    raise HomeAssistantError(f"Error reading Modbus holding registers: {original_message}") from e
-            return resp
-        except (TypeError, AttributeError) as e:
-            raise HomeAssistantError("Error reading Modbus holding registers: core modbus access failed") from e
-
-    async def async_read_input_registers(self, unit: int, address: int, count: int) -> Any:
-        """Read input registers."""
-        kwargs = {ADDR_KW: unit} if unit is not None else {}
-        if getattr(self, "_stopping", False):
-            return None
-        async with self._lock:
-            hub = await self._check_connection()
-        try:
-            if not hub or getattr(hub, "_config_delay", False):
-                return None
-            async with hub._lock:
-                try:
-                    resp = await self._track_task(hub._client.read_input_registers(address=address, count=count, **kwargs))
-                except (ConnectionException, ModbusIOException) as e:
-                    if self._is_expected_shutdown_modbus_error(e):
-                        _LOGGER.debug(f"{self._name}: ignoring core Modbus read cancellation during shutdown: {e}")
-                        return None
-                    original_message = str(e)
-                    raise HomeAssistantError(f"Error reading Modbus input registers: {original_message}") from e
-            return resp
-        except (TypeError, AttributeError) as e:
-            raise HomeAssistantError("Error reading Modbus input registers: core modbus access failed") from e
-
-    async def async_lowlevel_write_register(self, unit: int, address: int, payload: int, register_data_type: str | None = None) -> Any:
-        """
-        Write a single register using the Core hub's client.
-        """
-        if register_data_type == REGISTER_U16:
-            regs = convert_to_registers(int(payload), DataType.UINT16, self.plugin.order32)  # type: ignore[attr-defined]
-        else:
-            regs = convert_to_registers(int(payload), DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
-        kwargs = {ADDR_KW: unit} if unit is not None else {}
-        if getattr(self, "_stopping", False):
-            raise HomeAssistantError(f"{self._name}: integration is stopping")
-        async with self._lock:
-            hub = await self._check_connection()
-        try:
-            if not hub or getattr(hub, "_config_delay", False):
-                raise HomeAssistantError(f"{self._name}: core Modbus hub is not ready")
-            async with hub._lock:
-                resp = await self._track_task(hub._client.write_register(address=address, value=regs[0], **kwargs))
-            resp = self._validate_write_response(
-                resp,
-                unit=unit,
-                address=address,
-                operation="core single-register write",
-            )
-        except (ModbusException, HomeAssistantError, TypeError, AttributeError) as ex:
-            if hasattr(self.plugin, "log_register_write"):
-                self.plugin.log_register_write(self, address, unit, payload, error=(type(ex).__name__, str(ex)))
-            if isinstance(ex, HomeAssistantError):
-                raise
-            raise HomeAssistantError(f"Error writing single register through core Modbus: {ex}") from ex
-
-        if hasattr(self.plugin, "log_register_write"):
-            self.plugin.log_register_write(self, address, unit, payload, result=resp)
-        return resp
-
-    async def async_write_registers_single(
-        self, unit: int, address: int, payload: int, register_data_type: str | None = None
-    ) -> Any:  # Needs adapting for register queue
-        """Write registers multi, but write only one register of type 16bit"""
-        if register_data_type == REGISTER_U16:
-            regs = convert_to_registers(int(payload), DataType.UINT16, self.plugin.order32)  # type: ignore[attr-defined]
-        else:
-            regs = convert_to_registers(int(payload), DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
-        kwargs: dict[str, int] = {ADDR_KW: unit} if unit is not None else {}
-        async with self._lock:
-            hub = await self._check_connection()
-        try:
-            if not hub or getattr(hub, "_config_delay", False):
-                raise HomeAssistantError(f"{self._name}: core Modbus hub is not ready")
-            async with hub._lock:
-                resp = await self._track_task(hub._client.write_registers(address=address, values=regs, **kwargs))
-        except (ModbusException, TypeError, AttributeError) as ex:
-            raise HomeAssistantError(f"Error writing single register through core Modbus: {ex}") from ex
-        return self._validate_write_response(
-            resp,
-            unit=unit,
-            address=address,
-            operation="core multi-function single-register write",
-        )
-
-    async def async_write_registers_multi(self, unit: int, address: int, payload: list[tuple[Any, Any]]) -> Any:  # Needs adapting for register queue
-        """Write registers multi.
-        unit is the modbus address of the device that will be written to
-        address us the start register address
-        payload is a list of tuples containing
-            - a select or number entity keys names or alternatively REGISTER_xx type declarations
-            - the values are the values that will be encoded according to the spec of that entity
-        The list of tuples will be converted to a modbus payload with the proper encoding and written
-        to modbus device with address=unit
-        All register descriptions referenced in the payload must be consecutive (without leaving holes)
-        32bit integers will be converted to 2 modbus register values according to the endian strategy of the plugin
-        """
-        kwargs: dict[str, int] = {ADDR_KW: unit} if unit is not None else {}
-        regs_out = self._encode_multi_write_payload(payload)
-        _LOGGER.debug(f"Ready to write multiple registers at 0x{address:02x}: {regs_out}")
-        async with self._lock:
-            hub = await self._check_connection()
-        try:
-            if not hub or getattr(hub, "_config_delay", False):
-                raise HomeAssistantError(f"{self._name}: core Modbus hub is not ready")
-            async with hub._lock:
-                resp = await self._track_task(hub._client.write_registers(address=address, values=regs_out, **kwargs))
-        except (ModbusException, TypeError, AttributeError) as ex:
-            raise HomeAssistantError(f"Error writing multiple registers through core Modbus: {ex}") from ex
-        return self._validate_write_response(
-            resp,
-            unit=unit,
-            address=address,
-            operation="core multi-register write",
-        )
+class SolaXCoreModbusHub(SolaXModbusHub):
+    """Compatibility type using the Core transport configured by the base hub."""

--- a/custom_components/solax_modbus/modbus_transport.py
+++ b/custom_components/solax_modbus/modbus_transport.py
@@ -1,0 +1,226 @@
+"""Transport adapters for native and Home Assistant Core Modbus access."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections.abc import Callable
+from typing import Any, Protocol
+from weakref import ReferenceType, ref
+
+from homeassistant.core import HomeAssistant
+
+from .pymodbus_compat import ADDR_KW
+
+_LOGGER = logging.getLogger(__name__)
+
+CORE_CALL_TYPE_REGISTER_HOLDING = "holding"
+CORE_CALL_TYPE_REGISTER_INPUT = "input"
+CORE_CALL_TYPE_WRITE_REGISTER = "write_register"
+CORE_CALL_TYPE_WRITE_REGISTERS = "write_registers"
+
+
+def _get_core_hub(hass: HomeAssistant, name: str) -> Any | None:
+    """Resolve the optional Core Modbus hub without coupling native startup to it."""
+    try:
+        from homeassistant.components.modbus import get_hub
+    except ImportError:
+        return None
+    try:
+        return get_hub(hass, name)
+    except KeyError:
+        return None
+
+
+class ModbusTransport(Protocol):
+    """Common interface used by polling, writes and register quarantine."""
+
+    @property
+    def endpoint(self) -> str:
+        """Return a human-readable transport endpoint."""
+
+    def is_connected(self) -> bool:
+        """Return whether the underlying transport is ready."""
+
+    async def connect(self) -> bool:
+        """Connect or attach to the underlying transport."""
+
+    async def close(self) -> None:
+        """Release the underlying transport."""
+
+    async def read(self, register_type: str, unit: int, address: int, count: int) -> Any:
+        """Read holding or input registers."""
+
+    async def write(self, unit: int, address: int, values: list[int], *, multiple: bool) -> Any:
+        """Write one or more registers."""
+
+
+class NativeModbusTransport:
+    """Transport backed by a pymodbus client owned by this integration."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    @property
+    def endpoint(self) -> str:
+        params = getattr(self._client, "comm_params", None)
+        host = getattr(params, "host", "")
+        port = getattr(params, "port", "")
+        return f"{host}:{port}" if host or port else "native Modbus"
+
+    def is_connected(self) -> bool:
+        return bool(getattr(self._client, "connected", False))
+
+    async def connect(self) -> bool:
+        if self.is_connected():
+            return True
+        connect = getattr(self._client, "connect", None)
+        if connect is None:
+            return False
+        await connect()
+        return self.is_connected()
+
+    async def close(self) -> None:
+        close = getattr(self._client, "close", None)
+        if close is None:
+            return
+        result = close()
+        if inspect.isawaitable(result):
+            await result
+
+    async def read(self, register_type: str, unit: int, address: int, count: int) -> Any:
+        kwargs = {ADDR_KW: unit} if unit is not None else {}
+        if register_type == "input":
+            return await self._client.read_input_registers(address=address, count=count, **kwargs)
+        return await self._client.read_holding_registers(address=address, count=count, **kwargs)
+
+    async def write(self, unit: int, address: int, values: list[int], *, multiple: bool) -> Any:
+        kwargs = {ADDR_KW: unit} if unit is not None else {}
+        if multiple:
+            return await self._client.write_registers(address=address, values=values, **kwargs)
+        return await self._client.write_register(address=address, value=values[0], **kwargs)
+
+
+class CoreModbusTransport:
+    """Transport delegated to a Home Assistant Core Modbus hub."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        core_hub_name: str,
+        owner_name: str,
+        *,
+        hub_getter: Callable[[HomeAssistant, str], Any] = _get_core_hub,
+        reconnect_delay: float = 10,
+    ) -> None:
+        self._hass = hass
+        self._core_hub_name = core_hub_name
+        self._owner_name = owner_name
+        self._hub_getter = hub_getter
+        self._reconnect_delay = reconnect_delay
+        self._hub_ref: ReferenceType[Any] | None = None
+        self._closed = False
+
+    def _hub_closed(self, reference: ReferenceType[Any]) -> None:
+        if reference is self._hub_ref:
+            self._hub_ref = None
+
+    def _resolve_hub(self) -> Any | None:
+        if self._closed:
+            return None
+        hub = self._hub_ref() if self._hub_ref is not None else None
+        if hub is not None:
+            return hub
+        try:
+            hub = self._hub_getter(self._hass, self._core_hub_name)
+        except KeyError:
+            return None
+        if hub is not None:
+            self._hub_ref = ref(hub, self._hub_closed)
+        return hub
+
+    @staticmethod
+    def _config_delay(hub: Any) -> Any:
+        return getattr(hub, "config_delay", getattr(hub, "_config_delay", 0))
+
+    @classmethod
+    def _hub_is_connected(cls, hub: Any) -> bool:
+        client = getattr(hub, "_client", None)
+        return bool(client and getattr(client, "connected", False) and not cls._config_delay(hub))
+
+    @property
+    def endpoint(self) -> str:
+        hub = self._resolve_hub()
+        params = getattr(hub, "_pb_params", {}) if hub is not None else {}
+        host = params.get("host", "")
+        port = params.get("port", "")
+        return f"{host}:{port}" if host or port else f"Core Modbus hub '{self._core_hub_name}'"
+
+    def is_connected(self) -> bool:
+        hub = self._resolve_hub()
+        return bool(hub and self._hub_is_connected(hub))
+
+    async def connect(self) -> bool:
+        self._closed = False
+        hub = self._resolve_hub()
+        if hub is None:
+            _LOGGER.warning("CoreModbusHub '%s' not available", self._core_hub_name)
+            return False
+        if self._hub_is_connected(hub):
+            return True
+
+        await asyncio.sleep(self._reconnect_delay)
+        hub = self._resolve_hub()
+        if hub is not None and self._hub_is_connected(hub):
+            return True
+
+        reason = " during its configured startup delay" if hub is not None and self._config_delay(hub) else ""
+        _LOGGER.warning("%s: Core Modbus hub '%s' is not ready%s", self._owner_name, self._core_hub_name, reason)
+        return False
+
+    async def close(self) -> None:
+        # The Core hub owns the shared client. Only release our reference.
+        self._closed = True
+        self._hub_ref = None
+
+    async def read(self, register_type: str, unit: int, address: int, count: int) -> Any:
+        hub = self._resolve_hub()
+        if hub is None or not self._hub_is_connected(hub):
+            return None
+        call_type = CORE_CALL_TYPE_REGISTER_INPUT if register_type == "input" else CORE_CALL_TYPE_REGISTER_HOLDING
+        return await hub.async_pb_call(unit, address, count, call_type)
+
+    async def write(self, unit: int, address: int, values: list[int], *, multiple: bool) -> Any:
+        hub = self._resolve_hub()
+        if hub is None or not self._hub_is_connected(hub):
+            return None
+        call_type = CORE_CALL_TYPE_WRITE_REGISTERS if multiple else CORE_CALL_TYPE_WRITE_REGISTER
+        value: int | list[int] = values if multiple else values[0]
+        return await hub.async_pb_call(unit, address, value, call_type)
+
+
+class UnavailableModbusTransport:
+    """Inert transport used for an invalid interface configuration."""
+
+    def __init__(self, interface: str) -> None:
+        self._interface = interface
+
+    @property
+    def endpoint(self) -> str:
+        return f"unsupported interface '{self._interface}'"
+
+    def is_connected(self) -> bool:
+        return False
+
+    async def connect(self) -> bool:
+        return False
+
+    async def close(self) -> None:
+        return
+
+    async def read(self, register_type: str, unit: int, address: int, count: int) -> None:
+        return None
+
+    async def write(self, unit: int, address: int, values: list[int], *, multiple: bool) -> None:
+        return None

--- a/tests/unit/test_modbus_transport.py
+++ b/tests/unit/test_modbus_transport.py
@@ -1,0 +1,204 @@
+"""Tests for shared native and Home Assistant Core Modbus transports."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.solax_modbus import SolaXModbusHub, block
+from custom_components.solax_modbus.modbus_transport import (
+    CORE_CALL_TYPE_REGISTER_HOLDING,
+    CORE_CALL_TYPE_REGISTER_INPUT,
+    CORE_CALL_TYPE_WRITE_REGISTER,
+    CORE_CALL_TYPE_WRITE_REGISTERS,
+    CoreModbusTransport,
+    NativeModbusTransport,
+)
+from custom_components.solax_modbus.pymodbus_compat import ADDR_KW
+
+
+class FakeNativeClient:
+    """Minimal pymodbus client for native transport contract tests."""
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.comm_params = SimpleNamespace(host="192.0.2.1", port=502)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    def close(self) -> None:
+        self.connected = False
+
+    async def read_holding_registers(self, **kwargs: Any) -> Any:
+        self.calls.append(("read_holding", kwargs))
+        return SimpleNamespace(isError=lambda: False)
+
+    async def read_input_registers(self, **kwargs: Any) -> Any:
+        self.calls.append(("read_input", kwargs))
+        return SimpleNamespace(isError=lambda: False)
+
+    async def write_register(self, **kwargs: Any) -> Any:
+        self.calls.append(("write_register", kwargs))
+        return SimpleNamespace(isError=lambda: False)
+
+    async def write_registers(self, **kwargs: Any) -> Any:
+        self.calls.append(("write_registers", kwargs))
+        return SimpleNamespace(isError=lambda: False)
+
+
+class FakeCoreHub:
+    """Minimal Core Modbus hub exposing its supported call interface."""
+
+    def __init__(self, responses: list[Any] | None = None, *, connected: bool = True, config_delay: int = 0) -> None:
+        self._client = SimpleNamespace(connected=connected)
+        self.config_delay = config_delay
+        self._responses = list(responses or [])
+        self.calls: list[tuple[int, int, int | list[int], str]] = []
+
+    async def async_pb_call(self, unit: int, address: int, value: int | list[int], call_type: str) -> Any:
+        self.calls.append((unit, address, value, call_type))
+        if self._responses:
+            return self._responses.pop(0)
+        return SimpleNamespace(isError=lambda: False)
+
+
+def make_core_transport(core_hub: FakeCoreHub) -> CoreModbusTransport:
+    """Create a Core transport backed by a test hub."""
+    return CoreModbusTransport(
+        cast(Any, object()),
+        "core",
+        "test",
+        hub_getter=lambda hass, name: core_hub,
+        reconnect_delay=0,
+    )
+
+
+def make_quarantine_hub(core_hub: FakeCoreHub) -> Any:
+    """Build the minimal integration hub state needed by quarantine probes."""
+    hub = cast(Any, object.__new__(SolaXModbusHub))
+    hub._transport = make_core_transport(core_hub)
+    hub._name = "test"
+    hub._stopping = False
+    hub._lock = asyncio.Lock()
+    hub._inflight_tasks = set()
+    hub._modbus_addr = 1
+    hub._time_out = 15
+    hub.bisect_max_depth = 10
+    hub.bad_regs = {"holding": set(), "input": set()}
+    hub.initial_groups = {}
+    hub.groups = {}
+    hub.blocks_changed = False
+    hub._comm_last_quarantined_register = None
+    hub._comm_last_recovered_register = None
+    hub._ensure_quarantine_recheck_task = Mock()
+    hub._update_communication_data = Mock()
+    hub._publish_communication_diagnostics = Mock()
+    return hub
+
+
+@pytest.mark.asyncio
+async def test_native_transport_implements_shared_read_write_contract() -> None:
+    client = FakeNativeClient()
+    transport = NativeModbusTransport(client)
+
+    assert await transport.connect() is True
+    assert transport.is_connected() is True
+    assert transport.endpoint == "192.0.2.1:502"
+
+    await transport.read("holding", unit=1, address=10, count=2)
+    await transport.read("input", unit=2, address=20, count=3)
+    await transport.write(unit=3, address=30, values=[7], multiple=False)
+    await transport.write(unit=4, address=40, values=[8, 9], multiple=True)
+
+    assert client.calls == [
+        ("read_holding", {"address": 10, "count": 2, ADDR_KW: 1}),
+        ("read_input", {"address": 20, "count": 3, ADDR_KW: 2}),
+        ("write_register", {"address": 30, "value": 7, ADDR_KW: 3}),
+        ("write_registers", {"address": 40, "values": [8, 9], ADDR_KW: 4}),
+    ]
+
+    await transport.close()
+    assert transport.is_connected() is False
+
+
+@pytest.mark.asyncio
+async def test_core_transport_delegates_reads_and_writes_to_core_hub() -> None:
+    core_hub = FakeCoreHub()
+    transport = make_core_transport(core_hub)
+
+    await transport.read("holding", unit=1, address=10, count=2)
+    await transport.read("input", unit=2, address=20, count=3)
+    await transport.write(unit=3, address=30, values=[7], multiple=False)
+    await transport.write(unit=4, address=40, values=[8, 9], multiple=True)
+
+    assert core_hub.calls == [
+        (1, 10, 2, CORE_CALL_TYPE_REGISTER_HOLDING),
+        (2, 20, 3, CORE_CALL_TYPE_REGISTER_INPUT),
+        (3, 30, 7, CORE_CALL_TYPE_WRITE_REGISTER),
+        (4, 40, [8, 9], CORE_CALL_TYPE_WRITE_REGISTERS),
+    ]
+
+
+def test_core_transport_uses_real_core_connection_state() -> None:
+    core_hub = FakeCoreHub(connected=True)
+    transport = make_core_transport(core_hub)
+
+    assert transport.is_connected() is True
+
+    core_hub.config_delay = 5
+    assert transport.is_connected() is False
+
+    core_hub.config_delay = 0
+    core_hub._client.connected = False
+    assert transport.is_connected() is False
+
+
+@pytest.mark.asyncio
+async def test_core_transport_close_does_not_close_shared_client() -> None:
+    core_hub = FakeCoreHub()
+    transport = make_core_transport(core_hub)
+
+    assert transport.is_connected() is True
+    await transport.close()
+
+    assert core_hub._client.connected is True
+    assert transport.is_connected() is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_quarantine_operates_through_core_transport() -> None:
+    success = SimpleNamespace(isError=lambda: False)
+    core_hub = FakeCoreHub([None, None, success])
+    hub = make_quarantine_hub(core_hub)
+    hub._confirm_bad_register = AsyncMock(return_value=True)
+    failing_block = block(start=10, end=12, descriptions={}, regs=[10, 11])
+
+    await hub._runtime_bisect_block(failing_block, "holding", "holding:10-12")
+
+    assert hub.bad_regs["holding"] == {10}
+    assert core_hub.calls == [
+        (1, 10, 2, CORE_CALL_TYPE_REGISTER_HOLDING),
+        (1, 10, 1, CORE_CALL_TYPE_REGISTER_HOLDING),
+        (1, 11, 1, CORE_CALL_TYPE_REGISTER_HOLDING),
+    ]
+    hub._ensure_quarantine_recheck_task.assert_called_once_with()
+    hub._update_communication_data.assert_called_once_with()
+    hub._publish_communication_diagnostics.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_quarantined_register_is_rechecked_through_core_transport() -> None:
+    core_hub = FakeCoreHub()
+    hub = make_quarantine_hub(core_hub)
+    hub.bad_regs["holding"].add(10)
+
+    await hub._recheck_quarantined_register("holding", 10)
+
+    assert hub.bad_regs["holding"] == set()
+    assert hub.blocks_changed is True
+    assert hub._comm_last_recovered_register == "holding 0xa"
+    assert core_hub.calls == [(1, 10, 1, CORE_CALL_TYPE_REGISTER_HOLDING)]

--- a/tests/unit/test_write_pipeline.py
+++ b/tests/unit/test_write_pipeline.py
@@ -11,6 +11,7 @@ from pymodbus.pdu import ExceptionResponse
 
 from custom_components.solax_modbus import PendingWrite, SolaXCoreModbusHub, SolaXModbusHub
 from custom_components.solax_modbus.const import REGISTER_S16, REGISTER_U16
+from custom_components.solax_modbus.modbus_transport import CoreModbusTransport, NativeModbusTransport
 from custom_components.solax_modbus.switch import SolaXModbusSwitch
 
 
@@ -38,7 +39,7 @@ def make_hub(client: FakeClient | None = None) -> Any:
     hub.plugin = SimpleNamespace(order32="big")
     hub.data = {}
     hub.writeLocals = {}
-    hub._client = client
+    hub._transport = NativeModbusTransport(client)
     hub._lock = asyncio.Lock()
     hub._inflight_tasks = set()
     hub._stopping = False
@@ -132,22 +133,34 @@ async def test_sleeping_write_queues_full_request_without_reporting_success() ->
 @pytest.mark.asyncio
 async def test_core_multi_write_uses_core_client_and_validates_response() -> None:
     response = SimpleNamespace(isError=lambda: False)
-    core_client = FakeClient(response)
-    core_hub = SimpleNamespace(
-        _client=core_client,
-        _lock=asyncio.Lock(),
-        _config_delay=False,
-    )
+
+    class FakeCoreHub:
+        def __init__(self) -> None:
+            self._client = SimpleNamespace(connected=True)
+            self.config_delay = 0
+            self.calls: list[tuple[int, int, int | list[int], str]] = []
+
+        async def async_pb_call(self, unit: int, address: int, value: int | list[int], call_type: str) -> object:
+            self.calls.append((unit, address, value, call_type))
+            return response
+
+    core_hub = FakeCoreHub()
     hub = cast(Any, object.__new__(SolaXCoreModbusHub))
     hub._name = "test"
     hub.plugin = SimpleNamespace(order32="big")
     hub.data = {}
     hub.writeLocals = {}
-    hub._client = SimpleNamespace()
+    hub._transport = CoreModbusTransport(
+        cast(Any, object()),
+        "core",
+        "test",
+        hub_getter=lambda hass, name: core_hub,
+        reconnect_delay=0,
+    )
     hub._lock = asyncio.Lock()
     hub._inflight_tasks = set()
     hub._stopping = False
-    hub._check_connection = AsyncMock(return_value=core_hub)
+    hub._check_connection = AsyncMock(return_value=True)
 
     result = await hub.async_write_registers_multi(
         unit=1,
@@ -156,7 +169,7 @@ async def test_core_multi_write_uses_core_client_and_validates_response() -> Non
     )
 
     assert result is response
-    assert core_client.write_registers_calls == 1
+    assert core_hub.calls == [(1, 100, [7, 65534], "write_registers")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Register quarantine currently checks the integration's local pymodbus client. For Home Assistant Core Modbus configurations this is a disconnected dummy client, so runtime register isolation and rechecks never run.

This change introduces a shared transport interface for connection state, reads, writes and shutdown. Native pymodbus and Home Assistant Core Modbus now use the same hub-level polling and write paths.

The Core adapter delegates requests to the Core hub, preserves ownership of its shared client and reports the actual Core connection state. This also removes the duplicated Core read/write implementation and manual lock handling.

Core Modbus is resolved lazily so optional Core import problems cannot prevent native configurations from loading.