### PR TITLE
Add ESPHome serial proxy support via tmodbus and SerialX

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -36,7 +36,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_track_time_interval
-from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
+from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException, ModbusIOException
 from pymodbus.framer import FramerType
 
@@ -128,6 +128,7 @@ from .const import (
 from .modbus_transport import CoreModbusTransport, ModbusTransport, NativeModbusTransport, UnavailableModbusTransport
 from .pymodbus_compat import DataType, convert_from_registers, convert_to_registers, pymodbus_version_info
 from .sensor import SolaXModbusSensor
+from .serial_modbus import AsyncSerialModbusClient, SerialModbusError
 
 RETRIES = 1  # was 6 then 0, which worked also, but 1 is probably the safe choice
 INVALID_START = 99999
@@ -518,7 +519,7 @@ class SolaXModbusHub:
         self._transport: ModbusTransport
         if interface == "serial":
             self._transport = NativeModbusTransport(
-                AsyncModbusSerialClient(
+                AsyncSerialModbusClient(
                     port=serial_port,
                     baudrate=baudrate,
                     parity="N",
@@ -1337,7 +1338,7 @@ class SolaXModbusHub:
             try:
                 _LOGGER.debug(f"{self._name}: READ {register_type.upper()} device={unit} addr=0x{address:x} cnt={count}")
                 response = await self._track_task(self._transport.read(register_type, unit, address, count))
-            except (ModbusException, AttributeError, TypeError) as exception_error:
+            except (ModbusException, SerialModbusError, AttributeError, TypeError) as exception_error:
                 error = f"Error: device: {unit} address: 0x{address:x} -> {exception_error!s}"
                 if self._is_expected_shutdown_modbus_error(exception_error):
                     _LOGGER.debug(f"{self._name}: ignoring Modbus read cancellation during shutdown: {error}")
@@ -1427,7 +1428,7 @@ class SolaXModbusHub:
                 raise HomeAssistantError(f"{self._name}: inverter is not connected")
             try:
                 response = await self._track_task(self._transport.write(unit, address, values, multiple=multiple))
-            except (ModbusException, AttributeError, TypeError) as ex:
+            except (ModbusException, SerialModbusError, AttributeError, TypeError) as ex:
                 raise HomeAssistantError(f"{self._name}: {operation} failed: {ex}") from ex
         return self._validate_write_response(
             response,

--- a/custom_components/solax_modbus/config_flow.py
+++ b/custom_components/solax_modbus/config_flow.py
@@ -184,7 +184,9 @@ OPTION_SCHEMA = vol.Schema(
 
 SERIAL_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_SERIAL_PORT, default=DEFAULT_SERIAL_PORT): str,
+        vol.Optional(CONF_SERIAL_PORT, default=DEFAULT_SERIAL_PORT): (
+            selector.SerialPortSelector() if hasattr(selector, "SerialPortSelector") else str
+        ),
         vol.Optional(CONF_BAUDRATE, default=DEFAULT_BAUDRATE): selector.SelectSelector(
             selector.SelectSelectorConfig(options=BAUDRATES),
         ),

--- a/custom_components/solax_modbus/manifest.json
+++ b/custom_components/solax_modbus/manifest.json
@@ -4,11 +4,11 @@
   "after_dependencies": ["modbus"],
   "codeowners": ["@wills106"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["usb"],
   "documentation": "https://homeassistant-solax-modbus.readthedocs.io/",
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wills106/homsassistant-solax-modbus/issues",
-  "requirements": ["pymodbus>=3.8.3"],
+  "requirements": ["pymodbus>=3.8.3", "tmodbus[async-serial,smart]==0.4.1"],
   "version": "2026.07.2"
 }

--- a/custom_components/solax_modbus/serial_modbus.py
+++ b/custom_components/solax_modbus/serial_modbus.py
@@ -1,0 +1,213 @@
+"""SerialX-backed Modbus RTU client compatibility layer."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, TypeVar
+
+from serialx import Parity, StopBits
+from tmodbus import AsyncModbusClient, create_async_rtu_client
+from tmodbus.exceptions import (
+    ModbusConnectionError as TModbusConnectionError,
+)
+from tmodbus.exceptions import TModbusError
+
+_PLACEHOLDER_UNIT_ID = 1
+
+_T = TypeVar("_T")
+
+
+class SerialModbusError(Exception):
+    """Error raised by the SerialX-backed Modbus client."""
+
+
+@dataclass(slots=True)
+class SerialModbusResponse:
+    """Pymodbus-compatible successful response used by the existing hub."""
+
+    registers: list[int]
+
+    def isError(self) -> bool:
+        """Return False because transport and Modbus errors raise exceptions."""
+        return False
+
+
+class AsyncSerialModbusClient:
+    """Expose the small client surface used by SolaX over tmodbus and SerialX."""
+
+    def __init__(
+        self,
+        *,
+        port: str,
+        baudrate: int,
+        parity: str,
+        stopbits: int,
+        bytesize: int,
+        timeout: float,
+        retries: int,
+    ) -> None:
+        self._port = port
+        self._baudrate = baudrate
+        self._parity = Parity(parity)
+        self._stopbits = StopBits(stopbits)
+        if bytesize != 8:
+            raise ValueError("Modbus RTU requires 8 data bits")
+        self._timeout = timeout
+        self._retries = max(0, retries)
+        self._client: AsyncModbusClient | None = None
+        self._unit_clients: dict[int, AsyncModbusClient] = {}
+
+        # Keep the diagnostics/logging attributes consumed by SolaXModbusHub.
+        self.comm_params = SimpleNamespace(host=port, port=baudrate)
+
+    @property
+    def connected(self) -> bool:
+        """Return whether the serial transport is connected."""
+        return bool(self._client and self._client.connected)
+
+    def _new_client(self) -> AsyncModbusClient:
+        """Create a Modbus RTU client whose byte transport is SerialX."""
+        # tmodbus 0.4.1 forwards timeout at runtime but omits it from SerialXOptions.
+        return create_async_rtu_client(  # type: ignore[call-arg]
+            self._port,
+            unit_id=_PLACEHOLDER_UNIT_ID,
+            baudrate=self._baudrate,
+            parity=self._parity,
+            stopbits=self._stopbits,
+            timeout=self._timeout,
+            auto_reconnect=False,
+            retry_on_device_busy=False,
+            retry_on_device_failure=False,
+        )
+
+    async def connect(self) -> bool:
+        """Connect to the configured local port or SerialX URL."""
+        if self.connected:
+            return True
+
+        await self.close()
+        client = self._new_client()
+        try:
+            await client.connect()
+        except (OSError, TimeoutError, TModbusError) as err:
+            try:
+                await client.disconnect()
+            except (OSError, TModbusError):
+                pass
+            raise SerialModbusError(f"Unable to open serial Modbus port {self._port}") from err
+
+        self._client = client
+        return self.connected
+
+    async def close(self) -> None:
+        """Close the serial transport and discard unit-bound clients."""
+        client = self._client
+        self._client = None
+        self._unit_clients.clear()
+        if client is None:
+            return
+        try:
+            await client.disconnect()
+        except (OSError, TModbusError):
+            pass
+
+    def _client_for_unit(self, unit_id: int) -> AsyncModbusClient:
+        """Return a client bound to one Modbus unit."""
+        if self._client is None:
+            raise SerialModbusError("Serial Modbus client is not connected")
+        if unit_id not in self._unit_clients:
+            self._unit_clients[unit_id] = self._client.for_unit_id(unit_id)
+        return self._unit_clients[unit_id]
+
+    @staticmethod
+    def _unit_id(kwargs: dict[str, Any]) -> int:
+        """Extract the unit id accepted by supported pymodbus versions."""
+        unit_id = kwargs.pop("device_id", kwargs.pop("slave", None))
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unexpected serial Modbus arguments: {unexpected}")
+        if unit_id is None:
+            raise TypeError("Serial Modbus unit id is required")
+        return int(unit_id)
+
+    async def _execute(
+        self,
+        unit_id: int,
+        operation: Callable[[AsyncModbusClient], Awaitable[_T]],
+    ) -> _T:
+        """Execute one request and preserve the previous single-retry behavior."""
+        for attempt in range(self._retries + 1):
+            if not self.connected:
+                await self.connect()
+            try:
+                return await operation(self._client_for_unit(unit_id))
+            except (OSError, TimeoutError, TModbusConnectionError) as err:
+                await self.close()
+                if attempt >= self._retries:
+                    raise SerialModbusError(str(err)) from err
+            except TModbusError as err:
+                raise SerialModbusError(str(err)) from err
+
+        raise SerialModbusError("Serial Modbus request failed")
+
+    async def read_holding_registers(
+        self,
+        *,
+        address: int,
+        count: int,
+        **kwargs: Any,
+    ) -> SerialModbusResponse:
+        """Read holding registers."""
+        unit_id = self._unit_id(kwargs)
+        registers = await self._execute(
+            unit_id,
+            lambda client: client.read_holding_registers(address, count),
+        )
+        return SerialModbusResponse(list(registers))
+
+    async def read_input_registers(
+        self,
+        *,
+        address: int,
+        count: int,
+        **kwargs: Any,
+    ) -> SerialModbusResponse:
+        """Read input registers."""
+        unit_id = self._unit_id(kwargs)
+        registers = await self._execute(
+            unit_id,
+            lambda client: client.read_input_registers(address, count),
+        )
+        return SerialModbusResponse(list(registers))
+
+    async def write_register(
+        self,
+        *,
+        address: int,
+        value: int,
+        **kwargs: Any,
+    ) -> SerialModbusResponse:
+        """Write one holding register."""
+        unit_id = self._unit_id(kwargs)
+        await self._execute(
+            unit_id,
+            lambda client: client.write_single_register(address, value),
+        )
+        return SerialModbusResponse([])
+
+    async def write_registers(
+        self,
+        *,
+        address: int,
+        values: list[int],
+        **kwargs: Any,
+    ) -> SerialModbusResponse:
+        """Write multiple holding registers."""
+        unit_id = self._unit_id(kwargs)
+        await self._execute(
+            unit_id,
+            lambda client: client.write_multiple_registers(address, values),
+        )
+        return SerialModbusResponse([])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pymodbus>=3.8.3",
+    "tmodbus[async-serial,smart]==0.4.1",
 ]
 
 [dependency-groups]

--- a/tests/unit/test_serial_config.py
+++ b/tests/unit/test_serial_config.py
@@ -1,0 +1,42 @@
+"""Regression tests for serial config compatibility."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from homeassistant.helpers import selector
+
+from custom_components.solax_modbus.config_flow import SERIAL_SCHEMA
+from custom_components.solax_modbus.const import CONF_SERIAL_PORT
+
+
+def serial_port_validator() -> Any:
+    """Return the validator assigned to the existing serial port key."""
+    for marker, validator in SERIAL_SCHEMA.schema.items():
+        if marker.schema == CONF_SERIAL_PORT:
+            return validator
+    raise AssertionError("Serial port field is missing")
+
+
+def test_existing_serial_port_key_accepts_local_path_and_proxy_url() -> None:
+    """Changing the UI selector does not change persisted config data."""
+    validator = serial_port_validator()
+
+    assert validator("/dev/serial/by-id/existing") == "/dev/serial/by-id/existing"
+    proxy_url = "esphome-hass://esphome/entry-id?port_name=Inverter%20RS485"
+    assert validator(proxy_url) == proxy_url
+
+
+def test_current_home_assistant_uses_serial_port_selector() -> None:
+    """Use HA's discovered-port selector whenever the installed HA supports it."""
+    if hasattr(selector, "SerialPortSelector"):
+        assert isinstance(serial_port_validator(), selector.SerialPortSelector)
+
+
+def test_manifest_loads_usb_and_serialx_backend() -> None:
+    """The selector and SerialX-backed transport declare their dependencies."""
+    manifest_path = Path(__file__).parents[2] / "custom_components" / "solax_modbus" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+
+    assert "usb" in manifest["dependencies"]
+    assert "tmodbus[async-serial,smart]==0.4.1" in manifest["requirements"]

--- a/tests/unit/test_serial_modbus.py
+++ b/tests/unit/test_serial_modbus.py
@@ -1,0 +1,208 @@
+"""Tests for the SerialX-backed Modbus RTU client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from serialx import Parity, StopBits
+
+from custom_components.solax_modbus import serial_modbus
+from custom_components.solax_modbus.serial_modbus import AsyncSerialModbusClient
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeUnitClient:
+    """Unit-bound tmodbus client used by the adapter tests."""
+
+    def __init__(
+        self,
+        *,
+        holding: list[int] | None = None,
+        input_registers: list[int] | None = None,
+        read_error: Exception | None = None,
+    ) -> None:
+        self.holding = holding or []
+        self.input_registers = input_registers or []
+        self.read_error = read_error
+        self.calls: list[tuple[Any, ...]] = []
+
+    async def read_holding_registers(self, address: int, count: int) -> list[int]:
+        self.calls.append(("read_holding", address, count))
+        if self.read_error:
+            raise self.read_error
+        return self.holding
+
+    async def read_input_registers(self, address: int, count: int) -> list[int]:
+        self.calls.append(("read_input", address, count))
+        if self.read_error:
+            raise self.read_error
+        return self.input_registers
+
+    async def write_single_register(self, address: int, value: int) -> None:
+        self.calls.append(("write_single", address, value))
+
+    async def write_multiple_registers(self, address: int, values: list[int]) -> None:
+        self.calls.append(("write_multiple", address, values))
+
+
+class FakeClient:
+    """Minimal tmodbus client used to verify lifecycle behavior."""
+
+    def __init__(self, unit_client: FakeUnitClient) -> None:
+        self.connected = False
+        self.unit_client = unit_client
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+        self.unit_ids: list[int] = []
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self.connected = False
+
+    def for_unit_id(self, unit_id: int) -> FakeUnitClient:
+        self.unit_ids.append(unit_id)
+        return self.unit_client
+
+
+def make_client(port: str, *, retries: int = 1) -> AsyncSerialModbusClient:
+    """Create the adapter with the existing SolaX serial defaults."""
+    return AsyncSerialModbusClient(
+        port=port,
+        baudrate=9600,
+        parity="N",
+        stopbits=1,
+        bytesize=8,
+        timeout=5,
+        retries=retries,
+    )
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        "/dev/serial/by-id/usb-existing-adapter",
+        "esphome-hass://esphome/entry-id?port_name=Inverter%20RS485",
+    ],
+)
+async def test_port_is_passed_unchanged_to_serialx_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    port: str,
+) -> None:
+    """Existing local paths and ESPHome proxy URLs use the same transport."""
+    fake = FakeClient(FakeUnitClient(holding=[27, 0]))
+    factory_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def factory(received_port: str, **kwargs: Any) -> FakeClient:
+        factory_calls.append((received_port, kwargs))
+        return fake
+
+    monkeypatch.setattr(serial_modbus, "create_async_rtu_client", factory)
+
+    client = make_client(port)
+    assert await client.connect()
+    response = await client.read_holding_registers(
+        address=16,
+        count=2,
+        device_id=1,
+    )
+
+    assert factory_calls == [
+        (
+            port,
+            {
+                "unit_id": 1,
+                "baudrate": 9600,
+                "parity": Parity.NONE,
+                "stopbits": StopBits.ONE,
+                "timeout": 5,
+                "auto_reconnect": False,
+                "retry_on_device_busy": False,
+                "retry_on_device_failure": False,
+            },
+        )
+    ]
+    assert response.registers == [27, 0]
+    assert not response.isError()
+    assert fake.unit_ids == [1]
+
+
+async def test_read_retries_once_after_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The new backend preserves the previous retries=1 behavior."""
+    clients = [
+        FakeClient(FakeUnitClient(read_error=TimeoutError("no response"))),
+        FakeClient(FakeUnitClient(input_registers=[2300])),
+    ]
+
+    def factory(*args: Any, **kwargs: Any) -> FakeClient:
+        return clients.pop(0)
+
+    monkeypatch.setattr(serial_modbus, "create_async_rtu_client", factory)
+
+    client = make_client("/dev/ttyUSB0")
+    response = await client.read_input_registers(
+        address=0,
+        count=1,
+        slave=2,
+    )
+
+    assert response.registers == [2300]
+    assert not clients
+
+
+async def test_writes_return_compatible_success_responses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing write validation continues to receive isError responses."""
+    unit = FakeUnitClient()
+    fake = FakeClient(unit)
+    monkeypatch.setattr(
+        serial_modbus,
+        "create_async_rtu_client",
+        lambda *args, **kwargs: fake,
+    )
+
+    client = make_client("/dev/ttyUSB0")
+    single = await client.write_register(
+        address=10,
+        value=5,
+        device_id=3,
+    )
+    multiple = await client.write_registers(
+        address=20,
+        values=[1, 2],
+        device_id=3,
+    )
+
+    assert not single.isError()
+    assert not multiple.isError()
+    assert unit.calls == [
+        ("write_single", 10, 5),
+        ("write_multiple", 20, [1, 2]),
+    ]
+
+
+async def test_close_waits_for_serial_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unload closes SerialX deterministically."""
+    fake = FakeClient(FakeUnitClient())
+    monkeypatch.setattr(
+        serial_modbus,
+        "create_async_rtu_client",
+        lambda *args, **kwargs: fake,
+    )
+
+    client = make_client("/dev/ttyUSB0")
+    await client.connect()
+    await client.close()
+
+    assert not client.connected
+    assert fake.disconnect_calls == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1666,6 +1666,7 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pymodbus" },
+    { name = "tmodbus", extra = ["async-serial", "smart"] },
 ]
 
 [package.dev-dependencies]
@@ -1686,7 +1687,10 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pymodbus", specifier = ">=3.8.3" }]
+requires-dist = [
+    { name = "pymodbus", specifier = ">=3.8.3" },
+    { name = "tmodbus", extras = ["async-serial", "smart"], specifier = "==0.4.1" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3457,6 +3461,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3609,6 +3632,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/5b/da5f56ad39cbb1ca49bd0d4cccde7e97ea7d01fa724fa953746fa2b32ee6/securetar-2025.2.1.tar.gz", hash = "sha256:59536a73fe5cecbc1f00b1838c8b1052464a024e2adcf6c9ce1d200d91990fb1", size = 16124, upload-time = "2025-02-25T14:17:51.784Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/e0/b93a18e9bb7f7d2573a9c6819d42d996851edde0b0406d017067d7d23a0a/securetar-2025.2.1-py3-none-any.whl", hash = "sha256:760ad9d93579d5923f3d0da86e0f185d0f844cf01795a8754539827bb6a1bab4", size = 11545, upload-time = "2025-02-25T14:17:50.832Z" },
+]
+
+[[package]]
+name = "serialx"
+version = "1.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/80/778c6da23924b718c282024bcde331cf8e417ec1274d2f198f65cff7503a/serialx-1.8.2.tar.gz", hash = "sha256:90c912ec8ceb4ae26a7dca158ca21e5bd8d73ddfc93c5e8d8b101a22ddccbb9a", size = 695526, upload-time = "2026-06-12T16:06:57.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/4b/b4c05bfbe7021874f4f8b007d0057bf50e92854d63bb1dab07fd3677e376/serialx-1.8.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d2904605e59357b9815aaa70828f28429767821638fceef228f32b8fca9ffb5c", size = 285301, upload-time = "2026-06-12T16:06:48.23Z" },
+    { url = "https://files.pythonhosted.org/packages/38/32/e6998be005770fbefd71bd3b9e095eb3a4fc055649967dcf82a6747fb6dc/serialx-1.8.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:abaee5c042194eaf95466e8e5eec6920af2eb0dbc00b91f1d765a0602bfd0d23", size = 282856, upload-time = "2026-06-12T16:06:49.91Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d5/598fc77e904c584e4420cc4be7878292f595f40e6f32092649d7cd580f28/serialx-1.8.2-cp310-abi3-win32.whl", hash = "sha256:42cd054add10e390856608a6b0abb3bdf1b8aa078f26f60d7fcd852603f91417", size = 183863, upload-time = "2026-06-12T16:06:51.191Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1d/8dfbd66cdf4129d991574c4be7878292f595f40e6f32092649d7cd580f28/serialx-1.8.2-cp310-abi3-win_amd64.whl", hash = "sha256:3e098c502639c7b220c419634101f28b9878a82fcee0cf06e074abb3e97f2c3e", size = 189886, upload-time = "2026-06-12T16:06:52.792Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b9/138584b89a109f4e4ce82176380b44a748808033d55c9cbb1b39de0f52eb/serialx-1.8.2-cp310-abi3-win_arm64.whl", hash = "sha256:36f82e21c9b0215beae4c983d221071a44ecdcf2f7a98c659af596ff7adbaa65", size = 186459, upload-time = "2026-06-12T16:06:54.283Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/90/9cd83042a221756e41ed8c018344e8833788c16e9bac144dab3292f9fa3c/serialx-1.8.2-py3-none-any.whl", hash = "sha256:6e6cffc1caec242fb06d8e16dd7880c8ba53c366ee2c43045fc38e8935ac8a6d", size = 66674, upload-time = "2026-06-12T16:06:55.724Z" },
 ]
 
 [[package]]
@@ -3806,6 +3847,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "termcolor"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3821,6 +3871,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "tmodbus"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/d2/253e6b097053287d5ac15b90589380e38a6c4d5d149c6440623447c84dca/tmodbus-0.4.1.tar.gz", hash = "sha256:240bd7c2081a73b895cb579e1fa61888ab5001bfc7a0987f8b331605672196b0", size = 110439, upload-time = "2026-07-03T04:38:11.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/22/a224e550ce9565e7cffb58bbbd7d2ef01b5b02285b11d3881e363a3ffd22/tmodbus-0.4.1-py3-none-any.whl", hash = "sha256:b0fcc5a9735aed2deec21a4e347d9a11515978e04d18e1bd536a1819c6160eb0", size = 64179, upload-time = "2026-07-03T04:38:09.761Z" },
+]
+
+[package.optional-dependencies]
+async-serial = [
+    { name = "serialx" },
+]
+smart = [
+    { name = "tenacity" },
 ]
 
 [[package]]


### PR DESCRIPTION
Home Assistant can now expose local serial ports and ESPHome Serial Proxies through its serial port selector. The previous Pymodbus serial client uses PySerial internally and cannot open `esphome-hass://` ports.

Changes made:

- Use Home Assistant's serial port selector
- Move serial Modbus RTU communication to tmodbus and SerialX
- Add support for ESPHome Serial Proxies
- Keep the existing serial port config key and support existing local serial ports without migration
- Keep TCP Modbus communication on Pymodbus


@wills106 there are some PRs addressing bigger architectural concepts. Please be prepared that some might break the integration in special cases I can't foresee. If we find an issue, we can react fast.