### PR TITLE
Prevent refresh failure for descriptions without internal attribute

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -185,7 +185,7 @@ def should_register_be_loaded(hass: HomeAssistant, hub: Any, descriptor: Any) ->
     """
     Check if an entity is enabled in the entity registry, checking across multiple platforms.
     """
-    if descriptor.internal:
+    if getattr(descriptor, "internal", False):
         _LOGGER.debug(f"{hub.name}: should be loaded: entity with key {descriptor.key} is internal, returning True.")
         return True
     unique_id = f"{hub._name}_{descriptor.key}"

--- a/tests/unit/test_entity_loading.py
+++ b/tests/unit/test_entity_loading.py
@@ -1,0 +1,26 @@
+"""Tests for entity-description loading decisions."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.solax_modbus import should_register_be_loaded
+from custom_components.solax_modbus.const import BaseModbusSwitchEntityDescription
+
+
+def test_descriptor_without_internal_is_loaded_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Control descriptions without an internal field must not stop polling."""
+    descriptor = BaseModbusSwitchEntityDescription(key="test_switch")
+    hub = SimpleNamespace(name="Test hub", _name="Test hub")
+    registry = SimpleNamespace(async_get_entity_id=lambda *_args: None)
+    fake_hass: Any = object()
+    monkeypatch.setattr(
+        "custom_components.solax_modbus.er.async_get",
+        lambda _hass: registry,
+    )
+
+    assert not hasattr(descriptor, "internal")
+    assert should_register_be_loaded(fake_hass, hub, descriptor)


### PR DESCRIPTION
Fixes #2221

`should_register_be_loaded()` assumed that every entity description provides an `internal` attribute. Control descriptions such as `SolisModbusSwitchEntityDescription` do not provide it, causing `rebuild_blocks()` to raise an `AttributeError` after entity registry changes and stopping periodic updates.

This change safely treats a missing `internal` attribute as `False` and adds a regression test covering switch descriptions without that attribute.