### PR TITLE
fix: switches no longer pollute local persistent data; restore last state at startup

### DIFF
--- a/custom_components/solax_modbus/switch.py
+++ b/custom_components/solax_modbus/switch.py
@@ -43,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             switch = SolaXModbusSwitch(hub_name, hub, modbus_addr, hub.device_info, switch_info)
             if switch_info.value_function:
                 hub.computedSwitches[switch_info.key] = switch_info
-            if switch_info.sensor_key is not None:
+            if switch_info.write_method == WRITE_DATA_LOCAL and switch_info.sensor_key is not None:
                 hub.writeLocals[switch_info.sensor_key] = switch_info
             dependency_key = getattr(switch_info, "sensor_key", switch_info.key)
             if dependency_key != switch_info.key:
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             )
             if switch_info.value_function:
                 hub.computedSwitches[switch_info.key] = switch_info
-            if switch_info.sensor_key is not None:
+            if switch_info.write_method == WRITE_DATA_LOCAL and switch_info.sensor_key is not None:
                 hub.writeLocals[switch_info.sensor_key] = switch_info
             dependency_key = getattr(switch_info, "sensor_key", switch_info.key)
             if dependency_key != switch_info.key:
@@ -148,6 +148,11 @@ class SolaXModbusSwitch(SwitchEntity, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         if self.entity_description.write_method != WRITE_DATA_LOCAL:
+            if self._sensor_key is not None and self._sensor_key in self._hub.data:
+                return
+            last_state = await self.async_get_last_state()
+            if last_state and last_state.state in ("on", "off"):
+                self._attr_is_on = last_state.state == "on"
             return
         self.async_on_remove(self.hass.bus.async_listen("solax_modbus_local_data_loaded", self._handle_local_data_loaded))
         if self._sensor_key is not None and self._sensor_key in self._hub.data:


### PR DESCRIPTION
Follow-up to #2210 — the branch update containing this fix was pushed ~4 hours after the PR had been merged, so it never reached upstream (my comment there announcing "three fixes" was outdated the moment it was posted; apologies for the confusion). This PR carries the remaining fix, rebased onto current main (2026.07.3).

## Root cause of the startup `no value yet` / unknown switches (reported by @wills106 and @rosenrot00 on #2210)

`switch.py` registered **every** switch's readback `sensor_key` in `hub.writeLocals` — but that dict is reserved for `WRITE_DATA_LOCAL` entities (select/number/time all guard the registration with exactly that check). Effects:

1. every readback key was persisted into `{hub}_data.json` on each local-data save (visible in rosenrot00's debug dump),
2. stale persisted values were re-imported into the data dict at startup, masquerading as fresh register reads,
3. the first-time-init path seeded `data[key] = None` — precisely the `has no value yet, state unknown` condition logged before the first real register read.

## Fix

- `writeLocals` registration is now guarded by `write_method == WRITE_DATA_LOCAL`, matching the other platforms.
- Switches restore their last on/off state at startup (`RestoreEntity` was already inherited but only used for `WRITE_DATA_LOCAL`), so the short window before the first register read shows the last known state instead of an unknown toggle — addressing the "why does it look so weird" screenshot.

One file, single commit. After this, a stray `{hub}_data.json` may still contain the previously-persisted readback keys; they are ignored from now on and get dropped on the next save.
