### PR TITLE
Avoid warnings for optional Growatt identifier probes

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -118,7 +118,7 @@ async def async_read_serialnr(hub: Any, address: int) -> str | None:
     except Exception:
         _LOGGER.warning(f"{hub.name}: attempt to read inverter identifier failed at 0x{address:x}", exc_info=True)
     if not res:
-        _LOGGER.warning(f"{hub.name}: reading inverter identifier from address 0x{address:x} failed; other address may succeed")
+        _LOGGER.debug(f"{hub.name}: no inverter identifier at 0x{address:x}; other address may succeed")
     _LOGGER.info(f"Read {hub.name} 0x{address:x} inverter identifier before potential swap: {res}")
     return res
 

--- a/tests/unit/test_growatt_inverter_detection.py
+++ b/tests/unit/test_growatt_inverter_detection.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import pytest
@@ -104,7 +105,10 @@ async def test_known_secondary_serial_is_not_blocked_by_unknown_primary_value() 
 
 
 @pytest.mark.asyncio
-async def test_existing_firmware_fallback_is_preserved() -> None:
+async def test_existing_firmware_fallback_is_preserved_without_probe_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="custom_components.solax_modbus.plugin_growatt")
     hub = GrowattHub(
         {
             9: "GH1.0 ZAAa",
@@ -116,3 +120,7 @@ async def test_existing_firmware_fallback_is_preserved() -> None:
     assert invertertype == PV | GEN4 | X1
     assert hub.seriesnumber == "GH1.0 ZAAa"
     assert hub.read_addresses == [3001, 209, 23, 9]
+    assert "no inverter identifier at 0x17; other address may succeed" in caplog.text
+    assert not [
+        record for record in caplog.records if record.name == "custom_components.solax_modbus.plugin_growatt" and record.levelno >= logging.WARNING
+    ]


### PR DESCRIPTION
Growatt inverter detection probes several possible identifier registers. Some models do not expose an identifier at every location, including `0x17`.

These expected empty responses were logged as warnings during every Home Assistant restart, even when a later firmware fallback successfully identified the inverter.

#### What changed

- Log empty optional identifier probes at debug level
- Keep warnings for actual read exceptions
- Add a regression test covering successful firmware fallback without warnings

Addresses #2228