### PR TITLE
Improve Modbus timeout handling and preserve partial poll updates

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -1306,6 +1306,21 @@ class SolaXModbusHub:
         _LOGGER.debug(f"{self._name}: trying to connect to inverter through {self._transport.endpoint}")
         return await self._transport.connect()
 
+    async def _handle_transport_exception(self, exception_error: BaseException, operation: str) -> None:
+        """Reset only connections that are known to be unusable."""
+        if getattr(self, "_stopping", False):
+            return
+
+        connection_lost = isinstance(exception_error, ConnectionException) or not self._transport.is_connected()
+        if connection_lost:
+            _LOGGER.debug(f"{self._name}: {operation} lost the connection; resetting transport before the next request")
+            await self._transport.close()
+            return
+
+        _LOGGER.debug(
+            f"{self._name}: {operation} failed while the transport remains connected; leaving retry and reconnect handling to the transport"
+        )
+
     async def async_read_holding_registers(self, unit: int, address: int, count: int) -> Any:
         """Read holding registers."""
         return await self._async_read_registers("holding", unit, address, count)
@@ -1333,8 +1348,7 @@ class SolaXModbusHub:
                 if getattr(self, "_stopping", False):
                     _LOGGER.debug(f"{self._name}: ModbusException during shutdown - skipping reconnect")
                     return None
-                _LOGGER.debug(f"{self._name}: ModbusException – closing transport and deferring reconnect")
-                await self._transport.close()
+                await self._handle_transport_exception(exception_error, f"{register_type} read")
                 return None
         return response
 
@@ -1448,6 +1462,7 @@ class SolaXModbusHub:
             try:
                 response = await self._track_task(self._transport.write(unit, address, values, multiple=multiple))
             except (ModbusException, SerialModbusError, AttributeError, TypeError) as ex:
+                await self._handle_transport_exception(ex, operation)
                 raise HomeAssistantError(f"{self._name}: {operation} failed: {ex}") from ex
         return self._validate_write_response(
             response,

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -495,6 +495,16 @@ class PendingWrite:
     register_data_type: str | None = None
 
 
+@dataclass(frozen=True)
+class BlockReadResult:
+    """Result of reading and decoding one Modbus block."""
+
+    data_succeeded: bool
+    communication_succeeded: bool
+    tolerated: bool = False
+    fresh_keys: frozenset[str] = frozenset()
+
+
 class RegisterEncodingError(HomeAssistantError):
     """Raised when a value cannot be represented by its Modbus register type."""
 
@@ -1100,7 +1110,7 @@ class SolaXModbusHub:
         for group in list(interval_group.device_groups.values()):
             group_outcome = await self.async_read_modbus_data(group)
             outcomes.append(group_outcome)
-            if group_outcome is PollOutcome.SUCCESS and getattr(group, "publish_updates", True):
+            if group_outcome.communication_succeeded and getattr(group, "publish_updates", True):
                 for sensor in group.sensors:
                     sensor.modbus_data_updated()
                 updated_sensors += len(group.sensors)
@@ -1108,6 +1118,8 @@ class SolaXModbusHub:
 
         if PollOutcome.FAILED in outcomes:
             outcome = PollOutcome.FAILED
+        elif PollOutcome.PARTIAL in outcomes:
+            outcome = PollOutcome.PARTIAL
         elif PollOutcome.SUCCESS in outcomes:
             outcome = PollOutcome.SUCCESS
         elif PollOutcome.DISCARDED in outcomes:
@@ -1592,7 +1604,16 @@ class SolaXModbusHub:
             _LOGGER.exception(f"Something went wrong reading from modbus: {ex}")
         return PollOutcome.FAILED
 
-    def treat_address(self, data: dict[str, Any], regs: list[int], idx: int, descr: Any, initval: int = 0, advance: bool = True) -> int:
+    def treat_address(
+        self,
+        data: dict[str, Any],
+        regs: list[int],
+        idx: int,
+        descr: Any,
+        initval: int = 0,
+        advance: bool = True,
+        fresh_keys: set[str] | None = None,
+    ) -> int:
         return_value: int | None = None
         read_scale = descr.read_scale  # read scale might still be wrong the first polling cycle
         order32 = getattr(descr, "order32", None) or self.plugin.order32
@@ -1725,10 +1746,13 @@ class SolaXModbusHub:
             and (self.localsLoaded or not descr.read_scale_exceptions)  # ignore as long as read scale is not adapted; may delay real startup a bit
         ):
             data[descr.key] = return_value  # case prevent_update number
+            if fresh_keys is not None:
+                fresh_keys.add(descr.key)
         return idx + (words_used if advance else 0)
 
-    async def async_read_modbus_block(self, data: dict[str, Any], block: Any, typ: str) -> bool:
+    async def async_read_modbus_block(self, data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
         errmsg = None
+        communication_succeeded = False
         if self.cyclecount < VERBOSE_CYCLES:
             _LOGGER.debug(
                 f"{self._name}: modbus {typ} block start: 0x{block.start:x} end: 0x{block.end:x}  len: {block.end - block.start} regs: {block.regs}"
@@ -1750,11 +1774,16 @@ class SolaXModbusHub:
             errmsg = f"exception {str(ex)} "
             _LOGGER.debug(f"{self._name}: exception reading {typ} {block.start} {errmsg}")
         else:
-            if realtime_data is None or realtime_data.isError():
+            if realtime_data is None:
                 errmsg = "read_error "
+            else:
+                communication_succeeded = True
+                if realtime_data.isError():
+                    errmsg = "read_error "
         if errmsg is None:
             regs = realtime_data.registers
             idx = 0
+            fresh_keys: set[str] = set()
             for reg in block.regs:
                 expected_idx = reg - block.start
                 if idx < expected_idx:
@@ -1767,12 +1796,16 @@ class SolaXModbusHub:
                 if isinstance(descr, dict):
                     base16 = convert_from_registers(regs[idx : idx + 1], DataType.UINT16, self.plugin.order32)  # type: ignore[attr-defined]
                     for k in descr:
-                        self.treat_address(data, regs, idx, descr[k], initval=base16, advance=False)
+                        self.treat_address(data, regs, idx, descr[k], initval=base16, advance=False, fresh_keys=fresh_keys)
                     idx += 1
                 else:
-                    idx = self.treat_address(data, regs, idx, descr, initval=0, advance=True)
+                    idx = self.treat_address(data, regs, idx, descr, initval=0, advance=True, fresh_keys=fresh_keys)
             self._record_block_result(block, typ, True)
-            return True
+            return BlockReadResult(
+                data_succeeded=True,
+                communication_succeeded=True,
+                fresh_keys=frozenset(fresh_keys),
+            )
         else:  # block read failure
             self._record_block_result(block, typ, False, errmsg)
             # Check only the first item in the block for ignore_readerror behavior.
@@ -1781,35 +1814,37 @@ class SolaXModbusHub:
             _LOGGER.debug(
                 f"{self._name}: failed {typ} block {errmsg} start 0x{block.start:x} {firstdescr.key} ignore_readerror: {firstdescr.ignore_readerror}"
             )
-            if firstdescr.ignore_readerror is False:  # dont ignore block read errors and return static data
-                _LOGGER.debug(f"{self._name}: failed block analysis started firstignore: {firstdescr.ignore_readerror}")
-                for reg in block.regs:
-                    descr = block.descriptions[reg]
-                    if type(descr) is dict:
-                        items = descr.items()  # special case: multiple U8x entities
+            tolerated = firstdescr.ignore_readerror is not False
+            _LOGGER.debug(f"{self._name}: failed block analysis started firstignore: {firstdescr.ignore_readerror}")
+            for reg in block.regs:
+                descr = block.descriptions[reg]
+                if type(descr) is dict:
+                    items = descr.items()  # special case: multiple U8x entities
+                else:
+                    items = {
+                        descr.key: descr,
+                    }.items()  # normal case, one entity
+                for k, d in items:
+                    d_ignore = d.ignore_readerror
+                    if (d_ignore is not True) and (d_ignore is not False):
+                        _LOGGER.debug(f"{self._name}: returning static {k} = {d_ignore}")
+                        data[k] = d_ignore  # return something static
                     else:
-                        items = {
-                            descr.key: descr,
-                        }.items()  # normal case, one entity
-                    for k, d in items:
-                        d_ignore = d.ignore_readerror
-                        if (d_ignore is not True) and (d_ignore is not False):
-                            _LOGGER.debug(f"{self._name}: returning static {k} = {d_ignore}")
-                            data[k] = d_ignore  # return something static
+                        if d_ignore is False:  # remove potentially faulty data
+                            popped = data.pop(k, None)  # added 20250716
+                            _LOGGER.debug(f"{self._name}: popping {k} = {popped}")
                         else:
-                            if d_ignore is False:  # remove potentially faulty data
-                                popped = data.pop(k, None)  # added 20250716
-                                _LOGGER.debug(f"{self._name}: popping {k} = {popped}")
-                            else:
-                                _LOGGER.debug(f"{self._name}: not touching {k} ")
-                return True
-            else:  # ignore readerrors and keep old data
-                if self.slowdown == 1:
-                    _LOGGER.info(
-                        f"{self._name} : {errmsg}: cannot read {typ} registers at device {self._modbus_addr} position 0x{block.start:x}",
-                        exc_info=True,
-                    )
-                return False
+                            _LOGGER.debug(f"{self._name}: not touching {k} ")
+            if tolerated and self.slowdown == 1:
+                _LOGGER.info(
+                    f"{self._name} : {errmsg}: cannot read {typ} registers at device {self._modbus_addr} position 0x{block.start:x}",
+                    exc_info=True,
+                )
+            return BlockReadResult(
+                data_succeeded=False,
+                communication_succeeded=communication_succeeded,
+                tolerated=tolerated,
+            )
 
     def _commit_poll_snapshot(self, previous_data: dict[str, Any], new_data: dict[str, Any]) -> None:
         """Commit polling changes without replacing the shared data dictionary."""
@@ -1828,6 +1863,43 @@ class SolaXModbusHub:
             if current_value is missing or current_value == previous_value:
                 self.data[key] = value
 
+    def _compute_poll_sensors(self, data: dict[str, Any], fresh_keys: set[str]) -> set[str]:
+        """Compute sensors whose explicitly declared dependencies are fresh."""
+        computed_fresh_keys: set[str] = set()
+        pending = list(self.computedSensors.items())
+
+        while pending:
+            remaining: list[tuple[str, Any]] = []
+            made_progress = False
+
+            for key, descr in pending:
+                dependencies = getattr(descr, "depends_on", None)
+                if isinstance(dependencies, str):
+                    dependencies = [dependencies]
+                if dependencies is not None and not set(dependencies).issubset(fresh_keys):
+                    remaining.append((key, descr))
+                    continue
+
+                try:
+                    data[key] = descr.value_function(0, descr, data)
+                except Exception as ex:
+                    _LOGGER.debug(f"{self._name}: cannot compute value for {key}: {ex}")
+                    continue
+
+                fresh_keys.add(key)
+                computed_fresh_keys.add(key)
+                made_progress = True
+
+            if not made_progress:
+                for key, descr in remaining:
+                    dependencies = getattr(descr, "depends_on", None)
+                    missing = set(dependencies or []) - fresh_keys
+                    _LOGGER.debug(f"{self._name}: keeping previous value for {key}; dependencies not fresh: {sorted(missing)}")
+                break
+            pending = remaining
+
+        return computed_fresh_keys
+
     async def async_read_modbus_registers_all(self, group: Any) -> PollOutcome:
         group.publish_updates = False
         if group.readPreparation is not None:
@@ -1839,17 +1911,36 @@ class SolaXModbusHub:
 
         previous_data = self.data.copy()
         data = previous_data.copy()
-        res = True
+        block_results: list[BlockReadResult] = []
+        fresh_keys: set[str] = set()
         for block in group.holdingBlocks:
-            _LOGGER.debug(f"{self._name}: ** trying to read holding block 0x{block.start:x} previous res:{res}")
-            block_res = await self.async_read_modbus_block(data, block, "holding")
-            res = res and block_res
-            _LOGGER.debug(f"{self._name}: holding block 0x{block.start:x} read done; new res: {res}")
+            _LOGGER.debug(f"{self._name}: ** trying to read holding block 0x{block.start:x}")
+            block_result = await self.async_read_modbus_block(data, block, "holding")
+            block_results.append(block_result)
+            fresh_keys.update(block_result.fresh_keys)
+            _LOGGER.debug(
+                f"{self._name}: holding block 0x{block.start:x} read done; "
+                f"data_succeeded={block_result.data_succeeded}, communication_succeeded={block_result.communication_succeeded}"
+            )
         for block in group.inputBlocks:
-            _LOGGER.debug(f"{self._name}: ** trying to read input block 0x{block.start:x} previous res: {res}")
-            block_res = await self.async_read_modbus_block(data, block, "input")
-            res = res and block_res
-            _LOGGER.debug(f"{self._name}: input block 0x{block.start:x} read done; new res: {res}")
+            _LOGGER.debug(f"{self._name}: ** trying to read input block 0x{block.start:x}")
+            block_result = await self.async_read_modbus_block(data, block, "input")
+            block_results.append(block_result)
+            fresh_keys.update(block_result.fresh_keys)
+            _LOGGER.debug(
+                f"{self._name}: input block 0x{block.start:x} read done; "
+                f"data_succeeded={block_result.data_succeeded}, communication_succeeded={block_result.communication_succeeded}"
+            )
+
+        all_data_succeeded = all(result.data_succeeded for result in block_results)
+        communication_succeeded = not block_results or any(result.communication_succeeded for result in block_results)
+        required_block_failed = any(not result.data_succeeded and not result.tolerated for result in block_results)
+        if all_data_succeeded:
+            poll_outcome = PollOutcome.SUCCESS
+        elif communication_succeeded:
+            poll_outcome = PollOutcome.PARTIAL
+        else:
+            poll_outcome = PollOutcome.FAILED
 
         local_callback_needed = self.localsUpdated
         if self.localsUpdated:
@@ -1864,12 +1955,9 @@ class SolaXModbusHub:
             if key in self.data:
                 data[key] = self.data[key]
 
-        if res:
-            for key, descr in list(self.computedSensors.items()):
-                try:
-                    data[key] = descr.value_function(0, descr, data)
-                except Exception as ex:
-                    _LOGGER.debug(f"{self._name}: cannot compute value for {key}: {ex}")
+        computed_fresh_keys: set[str] = set()
+        if poll_outcome.communication_succeeded:
+            computed_fresh_keys = self._compute_poll_sensors(data, fresh_keys)
 
             if group.readFollowUp is not None:
                 if not await group.readFollowUp(previous_data, data):
@@ -1881,6 +1969,8 @@ class SolaXModbusHub:
                 self.plugin.localDataCallback(self)
 
             for key, descr in list(self.computedSensors.items()):
+                if key not in computed_fresh_keys:
+                    continue
                 sens = self.sensorEntities.get(key)
                 _LOGGER.debug(f"{self._name}: quickly updating state for computed sensor {sens} {key} {self.data.get(descr.key)} ")
                 if sens and (not descr.internal):
@@ -1890,7 +1980,7 @@ class SolaXModbusHub:
                         _LOGGER.debug(f"{self._name}: cannot send update for {key} - probably disabled ")
             group.publish_updates = True
 
-        if res and self.writequeue and self.plugin.isAwake(self.data):  # self.awakeplugin(self.data):
+        if poll_outcome.communication_succeeded and not required_block_failed and self.writequeue and self.plugin.isAwake(self.data):
             # process outstanding write requests
             _LOGGER.info(f"inverter is now awake, processing outstanding write requests {self.writequeue}")
             for queue_key, request in list(self.writequeue.items()):
@@ -1945,7 +2035,7 @@ class SolaXModbusHub:
                                 address=reg,
                                 payload=payload.get("data"),
                             )
-        return PollOutcome.SUCCESS if res else PollOutcome.FAILED
+        return poll_outcome
 
     # --------------------------------------------- Check if sensor is a dependency -----------------------------------------------
 

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -136,6 +136,7 @@ class PollOutcome(StrEnum):
     """Result of a scheduled Modbus poll."""
 
     SUCCESS = "success"
+    PARTIAL = "partial"
     FAILED = "failed"
     SKIPPED = "skipped"
     DISCARDED = "discarded"
@@ -143,7 +144,7 @@ class PollOutcome(StrEnum):
     @property
     def communication_succeeded(self) -> bool:
         """Return whether the poll completed without a communication failure."""
-        return self in (PollOutcome.SUCCESS, PollOutcome.DISCARDED)
+        return self in (PollOutcome.SUCCESS, PollOutcome.PARTIAL, PollOutcome.DISCARDED)
 
 
 # ==================================== plugin base class ====================================================================
@@ -270,7 +271,9 @@ class BaseModbusSensorEntityDescription(SensorEntityDescription):
     # The name and key must contain a placeholder {} that is replaced by the preceding number
     min_value: int | None = None
     max_value: int | None = None
-    depends_on: list[str] | None = None  # list of modbus register keys that must be read
+    # Register keys that must be read. On partial polls, computed sensors are only
+    # recalculated when every explicitly declared dependency is fresh.
+    depends_on: list[str] | None = None
     _energy_dashboard_device_info: Any = None  # DeviceInfo for energy dashboard
     _energy_dashboard_mapping: Any = None  # EnergyDashboardMapping
     _energy_dashboard_source_hub: Any = None  # Source hub reference

--- a/tests/unit/test_modbus_transport.py
+++ b/tests/unit/test_modbus_transport.py
@@ -6,8 +6,11 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
+from pymodbus.exceptions import ConnectionException, ModbusIOException
 
 from custom_components.solax_modbus import SolaXModbusHub, block
+from custom_components.solax_modbus.const import REGISTER_U16
 from custom_components.solax_modbus.modbus_transport import (
     CORE_CALL_TYPE_REGISTER_HOLDING,
     CORE_CALL_TYPE_REGISTER_INPUT,
@@ -22,31 +25,43 @@ from custom_components.solax_modbus.pymodbus_compat import ADDR_KW
 class FakeNativeClient:
     """Minimal pymodbus client for native transport contract tests."""
 
-    def __init__(self) -> None:
-        self.connected = False
+    def __init__(self, *, connected: bool = False, read_error: Exception | None = None, write_error: Exception | None = None) -> None:
+        self.connected = connected
         self.comm_params = SimpleNamespace(host="192.0.2.1", port=502)
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.close_calls = 0
+        self.read_error = read_error
+        self.write_error = write_error
 
     async def connect(self) -> None:
         self.connected = True
 
     def close(self) -> None:
+        self.close_calls += 1
         self.connected = False
 
     async def read_holding_registers(self, **kwargs: Any) -> Any:
         self.calls.append(("read_holding", kwargs))
+        if self.read_error is not None:
+            raise self.read_error
         return SimpleNamespace(isError=lambda: False)
 
     async def read_input_registers(self, **kwargs: Any) -> Any:
         self.calls.append(("read_input", kwargs))
+        if self.read_error is not None:
+            raise self.read_error
         return SimpleNamespace(isError=lambda: False)
 
     async def write_register(self, **kwargs: Any) -> Any:
         self.calls.append(("write_register", kwargs))
+        if self.write_error is not None:
+            raise self.write_error
         return SimpleNamespace(isError=lambda: False)
 
     async def write_registers(self, **kwargs: Any) -> Any:
         self.calls.append(("write_registers", kwargs))
+        if self.write_error is not None:
+            raise self.write_error
         return SimpleNamespace(isError=lambda: False)
 
 
@@ -64,6 +79,16 @@ class FakeCoreHub:
         if self._responses:
             return self._responses.pop(0)
         return SimpleNamespace(isError=lambda: False)
+
+
+def make_modbus_io_exception(message: str) -> ModbusIOException:
+    """Create a pymodbus I/O exception despite its untyped constructor."""
+    return ModbusIOException(message)  # type: ignore[no-untyped-call]
+
+
+def make_connection_exception(message: str) -> ConnectionException:
+    """Create a pymodbus connection exception despite its untyped constructor."""
+    return ConnectionException(message)  # type: ignore[no-untyped-call]
 
 
 def make_core_transport(core_hub: FakeCoreHub) -> CoreModbusTransport:
@@ -100,6 +125,18 @@ def make_quarantine_hub(core_hub: FakeCoreHub) -> Any:
     return hub
 
 
+def make_native_hub(client: FakeNativeClient) -> Any:
+    """Build the minimal integration hub state needed by native I/O tests."""
+    hub = cast(Any, object.__new__(SolaXModbusHub))
+    hub._transport = NativeModbusTransport(client)
+    hub._name = "test"
+    hub._stopping = False
+    hub._lock = asyncio.Lock()
+    hub._inflight_tasks = set()
+    hub.plugin = SimpleNamespace(order32="big")
+    return hub
+
+
 @pytest.mark.asyncio
 async def test_native_transport_implements_shared_read_write_contract() -> None:
     client = FakeNativeClient()
@@ -123,6 +160,54 @@ async def test_native_transport_implements_shared_read_write_contract() -> None:
 
     await transport.close()
     assert transport.is_connected() is False
+
+
+@pytest.mark.asyncio
+async def test_read_timeout_leaves_connected_native_transport_open() -> None:
+    client = FakeNativeClient(connected=True, read_error=make_modbus_io_exception("no response"))
+    hub = make_native_hub(client)
+
+    response = await hub.async_read_holding_registers(unit=1, address=9, count=5)
+
+    assert response is None
+    assert client.connected is True
+    assert client.close_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_read_connection_error_resets_native_transport() -> None:
+    client = FakeNativeClient(connected=True, read_error=make_connection_exception("connection lost"))
+    hub = make_native_hub(client)
+
+    response = await hub.async_read_holding_registers(unit=1, address=9, count=5)
+
+    assert response is None
+    assert client.connected is False
+    assert client.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_write_timeout_leaves_connected_native_transport_open() -> None:
+    client = FakeNativeClient(connected=True, write_error=make_modbus_io_exception("no response"))
+    hub = make_native_hub(client)
+
+    with pytest.raises(HomeAssistantError, match="single-register write failed"):
+        await hub.async_lowlevel_write_register(unit=1, address=9, payload=1, register_data_type=REGISTER_U16)
+
+    assert client.connected is True
+    assert client.close_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_write_connection_error_resets_native_transport() -> None:
+    client = FakeNativeClient(connected=True, write_error=make_connection_exception("connection lost"))
+    hub = make_native_hub(client)
+
+    with pytest.raises(HomeAssistantError, match="single-register write failed"):
+        await hub.async_lowlevel_write_register(unit=1, address=9, payload=1, register_data_type=REGISTER_U16)
+
+    assert client.connected is False
+    assert client.close_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_poll_snapshot.py
+++ b/tests/unit/test_poll_snapshot.py
@@ -7,8 +7,8 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from custom_components.solax_modbus import SolaXModbusHub
-from custom_components.solax_modbus.const import PollOutcome
+from custom_components.solax_modbus import PendingWrite, SolaXModbusHub
+from custom_components.solax_modbus.const import REGISTER_U16, PollOutcome
 
 
 def make_hub() -> Any:
@@ -107,6 +107,32 @@ async def test_tolerated_block_failure_commits_rest_of_snapshot() -> None:
     assert hub.data["raw"] == 10
     assert "unavailable" not in hub.data
     assert group.publish_updates is True
+
+
+@pytest.mark.asyncio
+async def test_successful_awake_poll_retries_queued_sleep_write() -> None:
+    hub = make_hub()
+    group = make_group()
+    request = PendingWrite(
+        unit=2,
+        address=36,
+        payload=40000,
+        register_data_type=REGISTER_U16,
+    )
+    hub.writequeue[(request.unit, request.address)] = request
+    hub.async_read_modbus_block = AsyncMock(return_value=True)
+    hub.async_lowlevel_write_register = AsyncMock(return_value=SimpleNamespace(isError=lambda: False))
+
+    result = await hub.async_read_modbus_registers_all(group)
+
+    assert result is PollOutcome.SUCCESS
+    hub.async_lowlevel_write_register.assert_awaited_once_with(
+        unit=2,
+        address=36,
+        payload=40000,
+        register_data_type=REGISTER_U16,
+    )
+    assert hub.writequeue == {}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_poll_snapshot.py
+++ b/tests/unit/test_poll_snapshot.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from custom_components.solax_modbus import PendingWrite, SolaXModbusHub
+from custom_components.solax_modbus import BlockReadResult, PendingWrite, SolaXModbusHub
 from custom_components.solax_modbus.const import REGISTER_U16, PollOutcome
 
 
@@ -57,8 +57,17 @@ def prepare_communication_diagnostics(hub: Any) -> None:
     hub.bad_regs = {"holding": set(), "input": set()}
 
 
+def successful_block(*fresh_keys: str) -> BlockReadResult:
+    """Return a successful block result for polling tests."""
+    return BlockReadResult(
+        data_succeeded=True,
+        communication_succeeded=True,
+        fresh_keys=frozenset(fresh_keys),
+    )
+
+
 @pytest.mark.asyncio
-async def test_failed_group_discards_all_partial_values() -> None:
+async def test_partial_group_commits_successful_values_and_legacy_computed_sensor() -> None:
     hub = make_hub()
     group = make_group()
     computed_sensor = Mock()
@@ -69,21 +78,113 @@ async def test_failed_group_discards_all_partial_values() -> None:
     )
     hub.sensorEntities["computed"] = computed_sensor
 
-    async def read_block(data: dict[str, Any], block: Any, typ: str) -> bool:
-        data["raw"] = block.start * 10
-        return bool(block.start == 1)
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
+        if block.start == 1:
+            data["raw"] = 10
+            return successful_block("raw")
+        return BlockReadResult(data_succeeded=False, communication_succeeded=False)
 
     hub.async_read_modbus_block = read_block
     original_data_object = hub.data
 
     result = await hub.async_read_modbus_registers_all(group)
 
-    assert result is PollOutcome.FAILED
+    assert result is PollOutcome.PARTIAL
     assert hub.data is original_data_object
-    assert hub.data["raw"] == 1
-    assert "computed" not in hub.data
-    assert group.publish_updates is False
+    assert hub.data["raw"] == 10
+    assert hub.data["computed"] == 20
+    assert group.publish_updates is True
+    computed_sensor.modbus_data_updated.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_partial_group_keeps_computed_value_when_dependency_is_not_fresh() -> None:
+    hub = make_hub()
+    hub.data.update({"source_a": 1, "source_b": 2, "computed": 3})
+    group = make_group()
+    computed_sensor = Mock()
+    hub.computedSensors["computed"] = SimpleNamespace(
+        key="computed",
+        internal=False,
+        depends_on=["source_a", "source_b"],
+        value_function=lambda initval, descr, data: data["source_a"] + data["source_b"],
+    )
+    hub.sensorEntities["computed"] = computed_sensor
+
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
+        if block.start == 1:
+            data["source_a"] = 10
+            return BlockReadResult(
+                data_succeeded=True,
+                communication_succeeded=True,
+                fresh_keys=frozenset({"source_a"}),
+            )
+        return BlockReadResult(data_succeeded=False, communication_succeeded=False)
+
+    hub.async_read_modbus_block = read_block
+
+    result = await hub.async_read_modbus_registers_all(group)
+
+    assert result is PollOutcome.PARTIAL
+    assert hub.data["source_a"] == 10
+    assert hub.data["source_b"] == 2
+    assert hub.data["computed"] == 3
+    assert group.publish_updates is True
     computed_sensor.modbus_data_updated.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_computed_dependency_chain_uses_fresh_values() -> None:
+    hub = make_hub()
+    group = make_group()
+    hub.computedSensors["second"] = SimpleNamespace(
+        key="second",
+        internal=True,
+        depends_on=["first"],
+        value_function=lambda initval, descr, data: data["first"] + 1,
+    )
+    hub.computedSensors["first"] = SimpleNamespace(
+        key="first",
+        internal=True,
+        depends_on=["raw"],
+        value_function=lambda initval, descr, data: data["raw"] * 2,
+    )
+
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
+        if block.start == 1:
+            data["raw"] = 5
+            return BlockReadResult(
+                data_succeeded=True,
+                communication_succeeded=True,
+                fresh_keys=frozenset({"raw"}),
+            )
+        return BlockReadResult(data_succeeded=False, communication_succeeded=False)
+
+    hub.async_read_modbus_block = read_block
+
+    result = await hub.async_read_modbus_registers_all(group)
+
+    assert result is PollOutcome.PARTIAL
+    assert hub.data["first"] == 10
+    assert hub.data["second"] == 11
+
+
+@pytest.mark.asyncio
+async def test_total_communication_failure_still_discards_snapshot() -> None:
+    hub = make_hub()
+    group = make_group()
+
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
+        data["raw"] = 99
+        return BlockReadResult(data_succeeded=False, communication_succeeded=False)
+
+    hub.async_read_modbus_block = read_block
+
+    result = await hub.async_read_modbus_registers_all(group)
+
+    assert result is PollOutcome.FAILED
+    assert hub.data["raw"] == 1
+    assert group.publish_updates is False
 
 
 @pytest.mark.asyncio
@@ -92,12 +193,12 @@ async def test_tolerated_block_failure_commits_rest_of_snapshot() -> None:
     hub.data["unavailable"] = 5
     group = make_group()
 
-    async def read_block(data: dict[str, Any], block: Any, typ: str) -> bool:
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
         if block.start == 1:
             data["raw"] = 10
         else:
             data.pop("unavailable", None)
-        return True
+        return successful_block("raw" if block.start == 1 else "unavailable")
 
     hub.async_read_modbus_block = read_block
 
@@ -107,6 +208,43 @@ async def test_tolerated_block_failure_commits_rest_of_snapshot() -> None:
     assert hub.data["raw"] == 10
     assert "unavailable" not in hub.data
     assert group.publish_updates is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("ignore_readerror", "tolerated", "value_is_kept"),
+    [
+        (True, True, True),
+        (False, False, False),
+    ],
+)
+async def test_block_error_preserves_ignore_readerror_semantics(
+    ignore_readerror: bool,
+    tolerated: bool,
+    value_is_kept: bool,
+) -> None:
+    hub = make_hub()
+    hub.cyclecount = 20
+    hub._modbus_addr = 1
+    hub._record_block_result = Mock()
+    hub.async_read_holding_registers = AsyncMock(return_value=SimpleNamespace(isError=lambda: True))
+    description = SimpleNamespace(key="vpp_status", ignore_readerror=ignore_readerror)
+    block = SimpleNamespace(
+        start=0x7594,
+        end=0x7595,
+        regs=[0x7594],
+        descriptions={0x7594: description},
+    )
+    data = {"vpp_status": 5}
+
+    result = await hub.async_read_modbus_block(data, block, "holding")
+
+    assert result == BlockReadResult(
+        data_succeeded=False,
+        communication_succeeded=True,
+        tolerated=tolerated,
+    )
+    assert ("vpp_status" in data) is value_is_kept
 
 
 @pytest.mark.asyncio
@@ -120,7 +258,7 @@ async def test_successful_awake_poll_retries_queued_sleep_write() -> None:
         register_data_type=REGISTER_U16,
     )
     hub.writequeue[(request.unit, request.address)] = request
-    hub.async_read_modbus_block = AsyncMock(return_value=True)
+    hub.async_read_modbus_block = AsyncMock(return_value=successful_block())
     hub.async_lowlevel_write_register = AsyncMock(return_value=SimpleNamespace(isError=lambda: False))
 
     result = await hub.async_read_modbus_registers_all(group)
@@ -153,9 +291,9 @@ async def test_successful_group_commits_raw_and_computed_values_together() -> No
     )
     hub.sensorEntities["computed"] = computed_sensor
 
-    async def read_block(data: dict[str, Any], block: Any, typ: str) -> bool:
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
         data["raw"] = block.start
-        return True
+        return successful_block("raw")
 
     hub.async_read_modbus_block = read_block
     original_data_object = hub.data
@@ -183,9 +321,9 @@ async def test_failed_follow_up_discards_snapshot_without_publishing() -> None:
     )
     hub.sensorEntities["computed"] = computed_sensor
 
-    async def read_block(data: dict[str, Any], block: Any, typ: str) -> bool:
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
         data["raw"] = 9
-        return True
+        return successful_block("raw")
 
     hub.async_read_modbus_block = read_block
 
@@ -296,6 +434,28 @@ async def test_slowdown_skip_does_not_read_or_change_slowdown() -> None:
     assert updated_sensors == 0
     assert hub.slowdown == 10
     hub.async_read_modbus_data.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_partial_poll_publishes_updates_without_enabling_slowdown() -> None:
+    hub = make_hub()
+    sensor = Mock()
+    group = make_group()
+    group.sensors = [sensor]
+    group.publish_updates = True
+    hub.blocks_changed = False
+    hub.cyclecount = 1
+    hub.sleepnone = []
+    hub.sleepzero = []
+    hub.async_read_modbus_data = AsyncMock(return_value=PollOutcome.PARTIAL)
+    interval_group = SimpleNamespace(device_groups={"test": group})
+
+    outcome, updated_sensors = await hub._refresh_interval_group_once(interval_group)
+
+    assert outcome is PollOutcome.PARTIAL
+    assert updated_sensors == 1
+    assert hub.slowdown == 1
+    sensor.modbus_data_updated.assert_called_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A timeout or read error in a single Modbus block currently causes the complete poll to fail. This discards unrelated successful readings, triggers the 10x polling slowdown, and may reset an otherwise usable connection.

- Preserve Modbus connections after request timeouts unless the transport reports an actual connection loss.
- Track block data success separately from communication success.
- Add a partial poll outcome for polls where some blocks succeeded.
- Commit values from successful blocks while retaining or removing failed block values according to `ignore_readerror`.
- Do not trigger the polling slowdown when communication is still working.
- Track which entity values were freshly read during the poll.
- Recalculate computed sensors with `depends_on` only when all declared dependencies are fresh.
- Keep the existing behavior for computed sensors without `depends_on`, allowing dependencies to be added gradually.
- Continue to discard snapshots and enable slowdown when communication fails completely.

Fixes #2232, #2233