### PR TITLE
Add Minimum SoC exception for SolaX X1-VAST

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -383,6 +383,7 @@ class BaseModbusNumberEntityDescription(NumberEntityDescription):
     state: str | None = None
     max_exceptions: list[tuple[str, int | float]] | None = None  #  None or list with structure [ ('U50EC' , 40,) ]
     min_exceptions_minus: list[tuple[str, int | float]] | None = None  # same structure as max_exceptions, values are applied with a minus
+    min_exceptions: list[tuple[str, int | float]] | None = None  # None or list with structure [ ('U50EC' , 10,) ]
     blacklist: list[str] | None = None  # None or list of serial number prefixes like
     write_method: int = WRITE_SINGLE_MODBUS  # WRITE_SINGLE_MOBUS or WRITE_MULTI_MODBUS or WRITE_DATA_LOCAL
     initvalue: int | None = None  # initial default value for WRITE_DATA_LOCAL entities

--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -122,6 +122,13 @@ class SolaXModbusNumber(NumberEntity):
             ) in number_info.max_exceptions:
                 if hub.seriesnumber.startswith(prefix):
                     self._attr_native_max_value = native_value
+        if number_info.min_exceptions:
+            for (
+                prefix,
+                native_value,
+            ) in number_info.min_exceptions:
+                if hub.seriesnumber.startswith(prefix):
+                    self._attr_native_min_value = native_value
         if number_info.min_exceptions_minus:
             for (
                 prefix,

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -1800,6 +1800,10 @@ CHARGE_SCALE_EXCEPTIONS = [
     #    ('H1E', 1 ), # more specific entry comes last and wins
 ]
 
+MIN_SOC: list[tuple[str, int | float]] = [
+    ("10M", 0),  # Gen6 X1-VAST allow discharge to 0% per #2187
+]
+
 NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
     ###
     #
@@ -1934,6 +1938,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
+        min_exceptions=MIN_SOC,
         initvalue=95,
         register_data_type=REGISTER_U16,
         write_method=WRITE_DATA_LOCAL,
@@ -1948,6 +1953,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
+        min_exceptions=MIN_SOC,
         initvalue=10,
         register_data_type=REGISTER_U16,
         write_method=WRITE_DATA_LOCAL,
@@ -2199,6 +2205,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=25,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
+        min_exceptions=MIN_SOC,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6 | EPS,
         icon="mdi:battery-charging-low",
     ),
@@ -2250,6 +2257,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
+        min_exceptions=MIN_SOC,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         icon="mdi:battery-charging-low",
     ),
@@ -2412,6 +2420,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
+        min_exceptions=MIN_SOC,
         allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
         icon="mdi:battery-charging-low",
     ),

--- a/tests/unit/test_number_exceptions_type_regressions.py
+++ b/tests/unit/test_number_exceptions_type_regressions.py
@@ -137,6 +137,30 @@ def test_exception_value_used_as_native_max_value() -> None:
     assert isinstance(native_max_value, float)
 
 
+def test_exception_value_used_as_native_min_value() -> None:
+    """Test that exception values are used as native_min_value (float).
+
+    This documents why the exception values need to support float: they are
+    directly assigned to native_min_value which is typed as float in number.py.
+    """
+    max_exceptions: list[tuple[str, int | float]] = [
+        ("L30E", 15.0),
+        ("10M", 1.0),
+    ]
+
+    serial_number = "10M123456"
+    native_min_value: float = 10.0  # Default
+
+    # Simulate exception lookup and assignment
+    for prefix, value in max_exceptions:
+        if serial_number.startswith(prefix):
+            native_min_value = float(value)  # Must be float
+            break
+
+    assert native_min_value == 1.0
+    assert isinstance(native_min_value, float)
+
+
 def test_list_invariance_with_mixed_types() -> None:
     """Test that list invariance is satisfied with int | float union type.
 


### PR DESCRIPTION
Allow the battery SoC limits to be set down to 0 for the X1-VAST inverter.

This inverter has a weird quirk where the SoC values are relative to the useable range rather than absolute.

Fixes #2187.