### PR TITLE
Fix computed sensors with model-specific dependencies

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -1863,8 +1863,17 @@ class SolaXModbusHub:
             if current_value is missing or current_value == previous_value:
                 self.data[key] = value
 
+    def _active_computed_dependencies(self, descr: Any) -> set[str] | None:
+        """Return declared dependencies that are available for this inverter."""
+        dependencies = getattr(descr, "depends_on", None)
+        if dependencies is None:
+            return None
+        if isinstance(dependencies, str):
+            dependencies = [dependencies]
+        return {dependency for dependency in dependencies if dependency in self.sensorDescriptions}
+
     def _compute_poll_sensors(self, data: dict[str, Any], fresh_keys: set[str]) -> set[str]:
-        """Compute sensors whose explicitly declared dependencies are fresh."""
+        """Compute sensors whose active, explicitly declared dependencies are fresh."""
         computed_fresh_keys: set[str] = set()
         pending = list(self.computedSensors.items())
 
@@ -1873,10 +1882,8 @@ class SolaXModbusHub:
             made_progress = False
 
             for key, descr in pending:
-                dependencies = getattr(descr, "depends_on", None)
-                if isinstance(dependencies, str):
-                    dependencies = [dependencies]
-                if dependencies is not None and not set(dependencies).issubset(fresh_keys):
+                dependencies = self._active_computed_dependencies(descr)
+                if dependencies is not None and not dependencies.issubset(fresh_keys):
                     remaining.append((key, descr))
                     continue
 
@@ -1892,7 +1899,7 @@ class SolaXModbusHub:
 
             if not made_progress:
                 for key, descr in remaining:
-                    dependencies = getattr(descr, "depends_on", None)
+                    dependencies = self._active_computed_dependencies(descr)
                     missing = set(dependencies or []) - fresh_keys
                     _LOGGER.debug(f"{self._name}: keeping previous value for {key}; dependencies not fresh: {sorted(missing)}")
                 break

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -271,8 +271,8 @@ class BaseModbusSensorEntityDescription(SensorEntityDescription):
     # The name and key must contain a placeholder {} that is replaced by the preceding number
     min_value: int | None = None
     max_value: int | None = None
-    # Register keys that must be read. On partial polls, computed sensors are only
-    # recalculated when every explicitly declared dependency is fresh.
+    # Possible register keys required by the value function. On partial polls,
+    # computed sensors are only recalculated when every active dependency is fresh.
     depends_on: list[str] | None = None
     _energy_dashboard_device_info: Any = None  # DeviceInfo for energy dashboard
     _energy_dashboard_mapping: Any = None  # EnergyDashboardMapping

--- a/tests/unit/test_poll_snapshot.py
+++ b/tests/unit/test_poll_snapshot.py
@@ -18,6 +18,7 @@ def make_hub() -> Any:
     hub.data = {"_repeatUntil": {}, "raw": 1}
     hub.computedSensors = {}
     hub.computedEntities = {}
+    hub.sensorDescriptions = {}
     hub.sensorEntities = {}
     hub.writeLocals = {}
     hub.writequeue = {}
@@ -101,6 +102,7 @@ async def test_partial_group_commits_successful_values_and_legacy_computed_senso
 async def test_partial_group_keeps_computed_value_when_dependency_is_not_fresh() -> None:
     hub = make_hub()
     hub.data.update({"source_a": 1, "source_b": 2, "computed": 3})
+    hub.sensorDescriptions.update({"source_a": SimpleNamespace(), "source_b": SimpleNamespace()})
     group = make_group()
     computed_sensor = Mock()
     hub.computedSensors["computed"] = SimpleNamespace(
@@ -137,18 +139,20 @@ async def test_partial_group_keeps_computed_value_when_dependency_is_not_fresh()
 async def test_computed_dependency_chain_uses_fresh_values() -> None:
     hub = make_hub()
     group = make_group()
-    hub.computedSensors["second"] = SimpleNamespace(
+    second = SimpleNamespace(
         key="second",
         internal=True,
         depends_on=["first"],
         value_function=lambda initval, descr, data: data["first"] + 1,
     )
-    hub.computedSensors["first"] = SimpleNamespace(
+    first = SimpleNamespace(
         key="first",
         internal=True,
         depends_on=["raw"],
         value_function=lambda initval, descr, data: data["raw"] * 2,
     )
+    hub.computedSensors.update({"second": second, "first": first})
+    hub.sensorDescriptions.update({"raw": SimpleNamespace(), "first": first, "second": second})
 
     async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
         if block.start == 1:
@@ -167,6 +171,36 @@ async def test_computed_dependency_chain_uses_fresh_values() -> None:
     assert result is PollOutcome.PARTIAL
     assert hub.data["first"] == 10
     assert hub.data["second"] == 11
+
+
+@pytest.mark.asyncio
+async def test_partial_group_ignores_dependencies_not_available_for_inverter() -> None:
+    hub = make_hub()
+    hub.data.update({"pv_power_1": 100, "pv_power_2": 200, "pv_power_total": 300})
+    hub.sensorDescriptions.update({"pv_power_1": SimpleNamespace(), "pv_power_2": SimpleNamespace()})
+    group = make_group()
+    computed_sensor = Mock()
+    hub.computedSensors["pv_power_total"] = SimpleNamespace(
+        key="pv_power_total",
+        internal=False,
+        depends_on=[f"pv_power_{index}" for index in range(1, 7)],
+        value_function=lambda initval, descr, data: data["pv_power_1"] + data["pv_power_2"],
+    )
+    hub.sensorEntities["pv_power_total"] = computed_sensor
+
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
+        if block.start == 1:
+            data.update({"pv_power_1": 150, "pv_power_2": 250})
+            return successful_block("pv_power_1", "pv_power_2")
+        return BlockReadResult(data_succeeded=False, communication_succeeded=False)
+
+    hub.async_read_modbus_block = read_block
+
+    result = await hub.async_read_modbus_registers_all(group)
+
+    assert result is PollOutcome.PARTIAL
+    assert hub.data["pv_power_total"] == 400
+    computed_sensor.modbus_data_updated.assert_called_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The partial-poll freshness check introduced in 2026.08.1 treated every key in `depends_on` as mandatory. Some computed sensors declare all possible source registers across several inverter variants.

For example, `pv_power_total` lists PV1 through PV6, while an X1 Hybrid Gen3 only exposes PV1 and PV2. As a result, the total was never recalculated even when every source available on that inverter was read successfully.

Fixes #2242