### PR TITLE
Add support for Solis S6-EH3P10K02-NV-YD-L

### DIFF
--- a/custom_components/solax_modbus/plugin_solis.py
+++ b/custom_components/solax_modbus/plugin_solis.py
@@ -2763,6 +2763,8 @@ class solis_plugin(plugin_base):
             invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  10kW - HV
         elif seriesnumber.startswith("103314"):
             invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  12kW - HV
+        elif seriesnumber.startswith("103330"):
+            invertertype = HYBRID | X3  # Hybrid Gen6 10kW - 48v
         elif seriesnumber.startswith("110C"):
             invertertype = HYBRID | X3  # Hybrid Gen5 0CA2 / 0C92 10kW - HV
         elif seriesnumber.startswith("114C"):

--- a/custom_components/solax_modbus/plugin_solis_fb00.py
+++ b/custom_components/solax_modbus/plugin_solis_fb00.py
@@ -4499,6 +4499,8 @@ class solis_fb00_plugin(plugin_base):
             invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  10kW - HV
         elif seriesnumber.startswith("103314"):
             invertertype = HYBRID | X3 | MPPT4  # Hybrid Gen6  12kW - HV
+        elif seriesnumber.startswith("103330"):
+            invertertype = HYBRID | X3  # Hybrid Gen6  10kW - 48v
         elif seriesnumber.startswith("110C"):
             invertertype = HYBRID | X3  # Hybrid Gen5 0CA2 / 0C92 10kW - HV
         elif seriesnumber.startswith("114C"):


### PR DESCRIPTION
Adds support for Solis S6-EH3P10K02-NV-YD-L. This is a Hybrid Gen6 inverter 48V; 10KW with 2MPPTs

Serial prefix: 103330

Manual: https://zonnigewinkel.nl/wp-content/uploads/2026/03/Handleiding-Solis-3-fase-laag-voltage-omvormer.pdf 

