### PR TITLE
Added Charge cut-off SOC to limit battery charge SOC

### DIFF
--- a/custom_components/solax_modbus/plugin_solinteg.py
+++ b/custom_components/solax_modbus/plugin_solinteg.py
@@ -581,19 +581,19 @@ NUMBER_TYPES = [
         icon="mdi:import",
     ),
     SolintegModbusNumberEntityDescription(
-        name="Charge Cutoff SOC",         
+        name="Charge Cutoff SOC",
         key="charge_cutoff_soc",
         register=52506,
-        fmt="i",  
+        fmt="i",
         native_min_value=10,
         native_max_value=98,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
-        read_scale=0.1,               
-        scale=1,       
+        read_scale=0.1,
+        scale=1,
         allowedtypes=HYBRID,
         entity_category=EntityCategory.CONFIG,
-        icon="mdi:battery-arrow-up",  
+        icon="mdi:battery-arrow-up",
     ),
 ]
 
@@ -1873,9 +1873,9 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         key="charge_cutoff_soc",
         register=52506,
         scale=0.1,
-        internal=True,      
+        internal=True,
         allowedtypes=HYBRID,
-    ),                
+    ),
 ]
 
 

--- a/custom_components/solax_modbus/plugin_solinteg.py
+++ b/custom_components/solax_modbus/plugin_solinteg.py
@@ -580,6 +580,21 @@ NUMBER_TYPES = [
         allowedtypes=HYBRID,
         icon="mdi:import",
     ),
+    SolintegModbusNumberEntityDescription(
+        name="Charge Cutoff SOC",         
+        key="charge_cutoff_soc",
+        register=52506,
+        fmt="i",  
+        native_min_value=10,
+        native_max_value=98,
+        native_step=1,
+        native_unit_of_measurement=PERCENTAGE,
+        read_scale=0.1,               
+        scale=1,       
+        allowedtypes=HYBRID,
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:battery-arrow-up",  
+    ),
 ]
 
 # ================================= Select Declarations ============================================================
@@ -1854,6 +1869,13 @@ SENSOR_TYPES: list[SolintegModbusSensorEntityDescription] = [
         allowedtypes=X3,
         icon="mdi:current-ac",
     ),
+    SolintegModbusSensorEntityDescription(
+        key="charge_cutoff_soc",
+        register=52506,
+        scale=0.1,
+        internal=True,      
+        allowedtypes=HYBRID,
+    ),                
 ]
 
 


### PR DESCRIPTION
Adds a number entity (charge_cutoff_soc) to set an upper SOC limit for battery charging, plus a matching sensor to read the current value back.

**Why:**
On cloudy days in spring/autumn/winter, when the forecast suggests the battery won't fully charge from PV, you may want to partially charge from the grid during low-tariff periods. This entity sets the upper boundary.

**Testing:**
Tested and working on my own MHT-10K-25 (FW V08.03.00.04-V10.26.05.00).

**Note on the register:**
Register 52506 is undocumented in Solinteg's official Modbus documentation. I located it by changing the cut-off SOC in Solinteg's UI and diffing against a full register readout from the inverter. I've only been able to verify it on my own unit, so I can't confirm it applies unchanged across other Solinteg models/firmware.