### PR TITLE
Keep unavailable states in virtual energy dashboard

### DIFF
--- a/custom_components/solax_modbus/energy_dashboard.py
+++ b/custom_components/solax_modbus/energy_dashboard.py
@@ -319,14 +319,20 @@ class EnergyDashboardSensorMapping:
 
         return self.source_key  # Use regular sensor (single mode or Slave)
 
-    def get_value(self, datadict: dict[str, float]) -> float:
+    def get_value(self, datadict: dict[str, float]) -> float | None:
         """Get value from source sensor, applying filter, invert, and custom functions."""
         source_key = self.get_source_key(datadict)  # Handles parallel mode
-        value = datadict.get(source_key, 0)
 
+        # Check if source sensor exists in data. If not warn about the failure and return as unavailable.
+        if source_key not in datadict:
+            _LOGGER.warning(f"Source sensor {source_key} not found, marking unavailable")
+            return None
+
+        # Grab the value for the source. If it is unavailable, return None value to propagate unavailable state.
+        # This avoids resetting total increasing sensors and unintentionally breaking energy statistics.
+        value = datadict.get(source_key)
         if value is None:
-            _LOGGER.warning(f"Source sensor {source_key} not found, using 0")  # type: ignore[unreachable]
-            return 0
+            return None
 
         # Apply filter function first (universal - applies to all sensor types)
         if self.filter_function:

--- a/custom_components/solax_modbus/energy_dashboard.py
+++ b/custom_components/solax_modbus/energy_dashboard.py
@@ -323,15 +323,11 @@ class EnergyDashboardSensorMapping:
         """Get value from source sensor, applying filter, invert, and custom functions."""
         source_key = self.get_source_key(datadict)  # Handles parallel mode
 
-        # Check if source sensor exists in data. If not warn about the failure and return as unavailable.
-        if source_key not in datadict:
-            _LOGGER.warning(f"Source sensor {source_key} not found, marking unavailable")
-            return None
-
         # Grab the value for the source. If it is unavailable, return None value to propagate unavailable state.
         # This avoids resetting total increasing sensors and unintentionally breaking energy statistics.
-        value = datadict.get(source_key)
+        value = datadict.get(source_key, None)
         if value is None:
+            _LOGGER.debug(f"Source sensor {source_key} not found or has no value, marking unavailable")
             return None
 
         # Apply filter function first (universal - applies to all sensor types)


### PR DESCRIPTION
If the value of the source sensor is None, keep that None value so that the energy dashboard reports unavailable rather than an arbitrary value.

This should avoid glitches in energy statistics caused by momentarily unavailable states in the source triggering an unexpected jump to zero in energy totals.

Fixes #2252 and possibly fixes #2267.

---

Currently this only applies to individual inverters and not to those operating in parallel mode. The latter will be handled in a later patch once the best approach is determined.