### PR TITLE
Fix Growatt VPP Allow AC Charging writes

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -1181,7 +1181,7 @@ SELECT_TYPES = [
         name="VPP Allow AC charging",
         key="vpp_allow_ac_charging",
         register=30410,
-        register_data_type=REGISTER_U8L,
+        register_data_type=REGISTER_U16,
         option_dict={
             0: "Disabled",
             1: "Enabled",

--- a/tests/unit/test_write_pipeline.py
+++ b/tests/unit/test_write_pipeline.py
@@ -9,7 +9,13 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 from pymodbus.pdu import ExceptionResponse
 
-from custom_components.solax_modbus import PendingWrite, RegisterEncodingError, SolaXCoreModbusHub, SolaXModbusHub
+from custom_components.solax_modbus import (
+    PendingWrite,
+    RegisterEncodingError,
+    SolaXCoreModbusHub,
+    SolaXModbusHub,
+    plugin_growatt,
+)
 from custom_components.solax_modbus.const import REGISTER_S16, REGISTER_S32, REGISTER_U16, REGISTER_U32
 from custom_components.solax_modbus.modbus_transport import CoreModbusTransport, NativeModbusTransport
 from custom_components.solax_modbus.switch import SolaXModbusSwitch
@@ -126,6 +132,18 @@ def test_legacy_unspecified_single_register_type_remains_signed_16_bit() -> None
     assert hub._encode_write_value(32767, None, single_register=True) == [32767]
     with pytest.raises(RegisterEncodingError, match="outside"):
         hub._encode_write_value(32768, None, single_register=True)
+
+
+def test_growatt_vpp_allow_ac_charging_uses_supported_u16_write() -> None:
+    description = next(
+        description for description in plugin_growatt.SELECT_TYPES if description.key == "vpp_allow_ac_charging"
+    )
+    hub = make_hub()
+
+    assert description.register == 30410
+    assert description.register_data_type == REGISTER_U16
+    assert hub._encode_write_value(0, description.register_data_type, single_register=True) == [0]
+    assert hub._encode_write_value(1, description.register_data_type, single_register=True) == [1]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_write_pipeline.py
+++ b/tests/unit/test_write_pipeline.py
@@ -135,9 +135,7 @@ def test_legacy_unspecified_single_register_type_remains_signed_16_bit() -> None
 
 
 def test_growatt_vpp_allow_ac_charging_uses_supported_u16_write() -> None:
-    description = next(
-        description for description in plugin_growatt.SELECT_TYPES if description.key == "vpp_allow_ac_charging"
-    )
+    description = next(description for description in plugin_growatt.SELECT_TYPES if description.key == "vpp_allow_ac_charging")
     hub = make_hub()
 
     assert description.register == 30410


### PR DESCRIPTION
The Growatt `VPP Allow AC Charging` select was configured as `REGISTER_U8L`, which is not supported by the validated single-register write encoder. This caused writes to fail locally before any Modbus request was sent.

Use `REGISTER_U16` for the select write while keeping the internal readback as `REGISTER_U8L`. Values `0` and `1` therefore retain the previously working Modbus representation.

Fixes #2258