### PR TITLE
Fix X1 charge current key collision on EV charger

### DIFF
--- a/custom_components/solax_modbus/plugin_solax_ev_charger.py
+++ b/custom_components/solax_modbus/plugin_solax_ev_charger.py
@@ -945,7 +945,7 @@ SENSOR_TYPES_MAIN: list[SolaXEVChargerModbusSensorEntityDescription] = [
     # ---- 0x0004–0x0006  Phase currents L1 (A) / L2 (B) / L3 (C), 0.01A ----
     SolaXEVChargerModbusSensorEntityDescription(
         name="Charge Current",
-        key="charge_current",
+        key="charge_current_measured",
         register=0x4,
         register_type=REG_INPUT,
         scale=0.01,


### PR DESCRIPTION
## Problem

In `plugin_solax_ev_charger.py`, two sensor descriptions share the key `charge_current`:

- the internal readback sensor at holding register `0x628` (backs the **Charge Current** number entity)
- the X1 diagnostic measurement sensor at input register `0x4` (disabled by default)

Both write to `hub.data["charge_current"]`. If an X1 user enables the diagnostic sensor, the Charge Current number entity alternates between the written setpoint and the live measured current on each poll cycle.

## Fix

Rename the input-register measurement sensor key to `charge_current_measured` so it no longer collides with the setpoint readback. The entity display name ("Charge Current") is unchanged.