### PR TITLE
Energy Dashboard fix, sub-device infrastructure, and a plugin-aware options dialog

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_track_time_interval
@@ -96,10 +97,19 @@ from .const import (
     PollOutcome,
 )
 from .const import (
+    CONF_ENERGY_DASHBOARD_DEVICE as CONF_ENERGY_DASHBOARD_DEVICE,
+)
+from .const import (
     CONF_READ_DCB as CONF_READ_DCB,
 )
 from .const import (
     CONF_READ_EPS as CONF_READ_EPS,
+)
+from .const import (
+    CONF_READ_PM as CONF_READ_PM,
+)
+from .const import (
+    DEFAULT_ENERGY_DASHBOARD_DEVICE as DEFAULT_ENERGY_DASHBOARD_DEVICE,
 )
 from .const import (
     DEFAULT_INTERFACE as DEFAULT_INTERFACE,
@@ -120,6 +130,9 @@ from .const import (
     DEFAULT_READ_EPS as DEFAULT_READ_EPS,
 )
 from .const import (
+    DEFAULT_READ_PM as DEFAULT_READ_PM,
+)
+from .const import (
     DEFAULT_SCAN_INTERVAL as DEFAULT_SCAN_INTERVAL,
 )
 from .const import (
@@ -127,6 +140,9 @@ from .const import (
 )
 from .const import (
     WRITE_MULTISINGLE_MODBUS as WRITE_MULTISINGLE_MODBUS,
+)
+from .const import (
+    matches_active_when as matches_active_when,
 )
 from .modbus_transport import CoreModbusTransport, ModbusTransport, NativeModbusTransport, UnavailableModbusTransport
 from .pymodbus_compat import DataType, convert_from_registers, convert_to_registers, pymodbus_version_info
@@ -423,7 +439,51 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hub.async_init()
 
     entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+
+    await async_cleanup_disabled_devices(hass, entry, hub)
     return True
+
+
+# Device groups that a config option can switch off, and the option controlling each.
+# Display names for sub-devices, where a plain title-case of the group key would read badly.
+DEVICE_GROUP_NAMES: dict[str, str] = {
+    "eps": "EPS",
+    "pm": "Parallel",
+}
+
+GATED_DEVICE_GROUPS: dict[str, tuple[str, bool]] = {
+    "eps": (CONF_READ_EPS, DEFAULT_READ_EPS),
+    "pm": (CONF_READ_PM, DEFAULT_READ_PM),
+    "ENERGY_DASHBOARD": (CONF_ENERGY_DASHBOARD_DEVICE, DEFAULT_ENERGY_DASHBOARD_DEVICE),
+}
+
+
+def device_group_of(device_entry: Any) -> str | None:
+    """Return the group name encoded in a device's solax identifiers, if any."""
+    for identifier in device_entry.identifiers:
+        parts = tuple(identifier)
+        if parts and parts[0] == DOMAIN and len(parts) > 2:
+            return str(parts[2])
+    return None
+
+
+async def async_cleanup_disabled_devices(hass: HomeAssistant, entry: ConfigEntry, hub: Any) -> None:
+    """Remove devices (and their entities) for device groups switched off in the options.
+
+    Home Assistant never removes devices on its own, so a device group that is no
+    longer created would otherwise linger in the registry with stale entities.
+    """
+    configdict = entry.options if entry.options else entry.data
+    dev_registry = dr.async_get(hass)
+    for device_entry in dr.async_entries_for_config_entry(dev_registry, entry.entry_id):
+        group = device_group_of(device_entry)
+        gate = GATED_DEVICE_GROUPS.get(group) if group else None
+        if gate is None:
+            continue
+        option, default = gate
+        if not configdict.get(option, default):
+            _LOGGER.info("%s: removing device %s - option %s is disabled", hub.name, device_entry.name, option)
+            dev_registry.async_remove_device(device_entry.id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -604,6 +664,7 @@ class SolaXModbusHub:
         self.selectEntities: dict[Any, Any] = {}
         self.switchEntities: dict[Any, Any] = {}
         self.timeEntities: dict[Any, Any] = {}
+        self.gatedEntities: list[dict[str, Any]] = []  # descriptions with active_when, added/removed as their branch activates
         self.entity_dependencies: dict[str, list[str]] = {}  # Maps a sensor key to a list of data control keys that use the sensor as data source
         # self.preventSensors = {} # sensors with prevent_update = True
         self.writeLocals: dict[Any, Any] = {}  # key to description lookup dict for write_method = WRITE_DATA_LOCAL entities
@@ -923,6 +984,75 @@ class SolaXModbusHub:
             describe_modbus_connection(identity),
         )
 
+    def device_group_enabled(self, group: str | None) -> bool:
+        """Return whether a named device group is enabled in this entry's options."""
+        if not group:
+            return True
+        configdict = self.entry.options if self.entry.options else self.entry.data
+        gate = GATED_DEVICE_GROUPS.get(group)
+        if gate is None:
+            return True
+        option, default = gate
+        return bool(configdict.get(option, default))
+
+    def device_group_display_name(self, group: str) -> str:
+        """Return the human readable name of a device group."""
+        return DEVICE_GROUP_NAMES.get(group, group.replace("_", " ").title())
+
+    def group_device_info(self, group: str) -> DeviceInfo:
+        """Return the DeviceInfo for a named sub-device (e.g. "dry_contact")."""
+        return DeviceInfo(
+            identifiers=cast(set[tuple[str, str]], {(DOMAIN, self._name, group)}),
+            name=f"{self._name} {DEVICE_GROUP_NAMES.get(group, group.replace('_', ' ').title())}",
+            manufacturer=self.plugin.plugin_manufacturer,
+            via_device=cast(tuple[str, str], (DOMAIN, self._name, INVERTER_IDENT)),
+        )
+
+    def register_gated_entity(self, descr: Any, factory: Any, add_entities: Any, holder: dict[Any, Any], platform: str, entity: Any = None) -> None:
+        """Track a description whose entity only exists while its active_when conditions hold."""
+        self.gatedEntities.append({"descr": descr, "factory": factory, "add": add_entities, "holder": holder, "platform": platform, "entity": entity})
+        if entity is None:
+            self._purge_registry_entry(platform, descr.key)
+
+    def _purge_registry_entry(self, platform: str, key: Any) -> None:
+        """Drop a stale registry entry so a gated-out entity disappears instead of showing as unavailable."""
+        try:
+            ent_registry = er.async_get(self._hass)
+            entity_id = ent_registry.async_get_entity_id(platform, DOMAIN, f"{self._name}_{key}")
+            if entity_id:
+                ent_registry.async_remove(entity_id)
+        except Exception as ex:
+            _LOGGER.debug("%s: cannot purge registry entry for %s: %s", self._name, key, ex)
+
+    async def async_refresh_gated_entities(self) -> None:
+        """Create entities whose conditions became true and remove those that became false."""
+        for gated in self.gatedEntities:
+            descr = gated["descr"]
+            wanted = matches_active_when(self, descr)
+            entity = gated.get("entity")
+            if wanted:
+                gated["misses"] = 0
+            if wanted and entity is None:
+                entity = gated["factory"]()
+                gated["entity"] = entity
+                gated["holder"][descr.key] = entity
+                gated["add"]([entity])
+                _LOGGER.debug("%s: added %s (conditions met)", self._name, descr.key)
+            elif not wanted and entity is not None:
+                # a single stale readback right after a write must not make entities flicker
+                gated["misses"] = gated.get("misses", 0) + 1
+                if gated["misses"] < 2:
+                    continue
+                gated["entity"] = None
+                if gated["holder"].get(descr.key) is entity:
+                    gated["holder"].pop(descr.key, None)
+                try:
+                    await entity.async_remove(force_remove=True)
+                except Exception as ex:
+                    _LOGGER.debug("%s: cannot remove %s: %s", self._name, descr.key, ex)
+                self._purge_registry_entry(gated["platform"], descr.key)
+                _LOGGER.debug("%s: removed %s (conditions no longer met)", self._name, descr.key)
+
     def device_group_key(self, device_info: DeviceInfo) -> str:
         """Extract device group key from device_info identifiers.
 
@@ -1133,6 +1263,8 @@ class SolaXModbusHub:
                 for sensor in group.sensors:
                     sensor.modbus_data_updated()
                 updated_sensors += len(group.sensors)
+                if getattr(self, "gatedEntities", None):
+                    await self.async_refresh_gated_entities()
             _LOGGER.debug("%s: device group read done with outcome=%s", self._name, group_outcome.value)
 
         if PollOutcome.FAILED in outcomes:

--- a/custom_components/solax_modbus/config_flow.py
+++ b/custom_components/solax_modbus/config_flow.py
@@ -320,6 +320,72 @@ async def _duplicate_inverter_schema(handler: SchemaCommonFlowHandler) -> vol.Sc
     return vol.Schema({})
 
 
+ENTITY_TYPE_ATTRIBUTES = ("SENSOR_TYPES", "NUMBER_TYPES", "SELECT_TYPES", "SWITCH_TYPES", "TIME_TYPES", "BUTTON_TYPES")
+
+
+def _plugin_uses_feature_flag(plugin_name: str | None, flag_name: str) -> bool:
+    """Return whether a plugin declares any entity gated by the named allowedtypes flag."""
+    if not plugin_name:
+        return True
+    try:
+        plugin = _load_plugin(plugin_name)
+    except Exception:
+        return True
+    flag = getattr(plugin, flag_name, None)
+    if not isinstance(flag, int) or not flag:
+        return False
+    instance = getattr(plugin, "plugin_instance", plugin)
+    for attribute in ENTITY_TYPE_ATTRIBUTES:
+        for source in (instance, plugin):
+            for description in getattr(source, attribute, None) or []:
+                if getattr(description, "allowedtypes", 0) & flag:
+                    return True
+    return False
+
+
+def _plugin_supports_energy_dashboard(plugin_name: str | None) -> bool:
+    """Return whether a plugin provides Energy Dashboard mappings."""
+    if not plugin_name:
+        return True
+    try:
+        plugin = _load_plugin(plugin_name)
+    except Exception:
+        return True
+    instance = getattr(plugin, "plugin_instance", plugin)
+    return getattr(instance, "ENERGY_DASHBOARD_MAPPING", None) is not None or getattr(plugin, "ENERGY_DASHBOARD_MAPPING", None) is not None
+
+
+def _plugin_supports_device_group(plugin_name: str | None, group: str) -> bool:
+    """Return whether a plugin declares any entity belonging to a named device group."""
+    if not plugin_name:
+        return True
+    try:
+        plugin = _load_plugin(plugin_name)
+    except Exception:
+        return True
+    instance = getattr(plugin, "plugin_instance", plugin)
+    for attribute in ("NUMBER_TYPES", "SELECT_TYPES", "SWITCH_TYPES", "TIME_TYPES", "BUTTON_TYPES"):
+        for source in (instance, plugin):
+            for description in getattr(source, attribute, None) or []:
+                if getattr(description, "device_group", None) == group:
+                    return True
+    return False
+
+
+async def _option_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
+    """Options schema without the feature switches the selected plugin does not implement."""
+    plugin_name = handler.options.get(CONF_PLUGIN)
+    hidden: set[str] = set()
+    if not _plugin_supports_energy_dashboard(plugin_name):
+        hidden.add(CONF_ENERGY_DASHBOARD_DEVICE)
+    for option, flag_name in ((CONF_READ_EPS, "EPS"), (CONF_READ_PM, "PM")):
+        if not _plugin_uses_feature_flag(plugin_name, flag_name):
+            hidden.add(option)
+    if not hidden:
+        return OPTION_SCHEMA
+    return vol.Schema({marker: value for marker, value in OPTION_SCHEMA.schema.items() if getattr(marker, "schema", None) not in hidden})
+
+
 def _load_plugin(plugin_name: str) -> ModuleType:
     _LOGGER.info("trying to load plugin - plugin_name: %s", plugin_name)
     plugin = importlib.import_module(f".plugin_{plugin_name}", "custom_components.solax_modbus")
@@ -339,7 +405,7 @@ if (MAJOR_VERSION >= 2023) or ((MAJOR_VERSION == 2022) and (MINOR_VERSION >= 12)
         "duplicate_inverter": SchemaFlowFormStep(_duplicate_inverter_schema),
     }
     OPTIONS_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
-        "init": SchemaFlowFormStep(OPTION_SCHEMA, next_step=_next_step_modbus),
+        "init": SchemaFlowFormStep(_option_schema, next_step=_next_step_modbus),
         "serial": SchemaFlowFormStep(SERIAL_SCHEMA, next_step=_next_step_battery),
         "tcp": SchemaFlowFormStep(TCP_SCHEMA, validate_user_input=_validate_host, next_step=_next_step_battery),
         "core": SchemaFlowFormStep(CORE_SCHEMA, validate_user_input=_validate_core_modbus_hub, next_step=_next_step_battery),

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -72,7 +72,7 @@ DEFAULT_PLUGIN = "solax"
 DEFAULT_READ_BATTERY = False
 ENERGY_DASHBOARD_DEVICE_ENABLED = True
 ENERGY_DASHBOARD_DEVICE_DISABLED = False
-DEFAULT_ENERGY_DASHBOARD_DEVICE = ENERGY_DASHBOARD_DEVICE_ENABLED
+DEFAULT_ENERGY_DASHBOARD_DEVICE = ENERGY_DASHBOARD_DEVICE_DISABLED
 PLUGIN_PATH = f"{pathlib.Path(__file__).parent.absolute()}/plugin_*.py"
 SLEEPMODE_NONE = None
 SLEEPMODE_ZERO = 0  # when no communication at all
@@ -238,6 +238,8 @@ class BaseModbusSensorEntityDescription(SensorEntityDescription):
     """Base class for modbus sensor declarations."""
 
     allowedtypes: int = 0  # overload with ALLDEFAULT from plugin
+    device_group: str | None = None  # assign the entity to a named sub-device instead of the main inverter device
+    active_when: dict[str, tuple[Any, ...]] | None = None  # {sensor_key: allowed values}; entity is unavailable unless every polled key matches
     order32: str | None = None  # per-sensor 32-bit word order override ("big"/"little"); None = plugin default
     modbus_min: int | None = None  # Minimum protocol version as reported by register 0x82 (e.g. 100 for V001.00); not the document revision.
     modbus_max: int | None = None  # Maximum protocol version as reported by register 0x82.
@@ -305,6 +307,8 @@ class BaseModbusSelectEntityDescription(SelectEntityDescription):
     """Base class for modbus select declarations."""
 
     allowedtypes: int = 0  # overload with ALLDEFAULT from plugin
+    device_group: str | None = None  # assign the entity to a named sub-device instead of the main inverter device
+    active_when: dict[str, tuple[Any, ...]] | None = None  # {sensor_key: allowed values}; entity is unavailable unless every polled key matches
     modbus_min: int | None = None  # Minimum protocol version as reported by register 0x82 (e.g. 100 for V001.00); not the document revision.
     modbus_max: int | None = None  # Maximum protocol version as reported by register 0x82.
     register: int | None = None
@@ -325,6 +329,8 @@ class BaseModbusSwitchEntityDescription(SwitchEntityDescription):
     """Base class for modbus switch declarations."""
 
     allowedtypes: int = 0  # overload with ALLDEFAULT from plugin
+    device_group: str | None = None  # assign the entity to a named sub-device instead of the main inverter device
+    active_when: dict[str, tuple[Any, ...]] | None = None  # {sensor_key: allowed values}; entity is unavailable unless every polled key matches
     modbus_min: int | None = None  # Minimum protocol version as reported by register 0x82 (e.g. 100 for V001.00); not the document revision.
     modbus_max: int | None = None  # Maximum protocol version as reported by register 0x82.
     register: int | None = None
@@ -344,6 +350,8 @@ class BaseModbusTimeEntityDescription(TimeEntityDescription):
     """Base class for modbus time declarations."""
 
     allowedtypes: int = 0  # overload with ALLDEFAULT from plugin
+    device_group: str | None = None  # assign the entity to a named sub-device instead of the main inverter device
+    active_when: dict[str, tuple[Any, ...]] | None = None  # {sensor_key: allowed values}; entity is unavailable unless every polled key matches
     modbus_min: int | None = None  # Minimum protocol version as reported by register 0x82 (e.g. 100 for V001.00); not the document revision.
     modbus_max: int | None = None  # Maximum protocol version as reported by register 0x82.
     scale: float | dict[Any, Any] | Callable[[Any, Any, dict[str, Any]], Any] = 1
@@ -373,6 +381,8 @@ class BaseModbusNumberEntityDescription(NumberEntityDescription):
     """Base class for modbus number declarations."""
 
     allowedtypes: int = 0  # overload with ALLDEFAULT from plugin
+    device_group: str | None = None  # assign the entity to a named sub-device instead of the main inverter device
+    active_when: dict[str, tuple[Any, ...]] | None = None  # {sensor_key: allowed values}; entity is unavailable unless every polled key matches
     modbus_min: int | None = None  # Minimum protocol version as reported by register 0x82 (e.g. 100 for V001.00); not the document revision.
     modbus_max: int | None = None  # Maximum protocol version as reported by register 0x82.
     register: int | None = None
@@ -391,6 +401,7 @@ class BaseModbusNumberEntityDescription(NumberEntityDescription):
     prevent_update: bool = False  # if set to True, value will not be re-read/updated with each polling cycle;
     # update only when read value changes
     sensor_key: str | None = None  # only specify this if corresponding sensor has a different key name
+    max_key: str | None = None  # key of a sensor whose value dynamically overrides native_max_value
     depends_on: list[str] | None = None  # list of modbus register keys that must be read
     display_as_box: bool = True  # display numbers as an input box (default); set False for a slider.
     suggested_display_precision: int | None = None
@@ -405,6 +416,22 @@ def modbus_protocol_version(hub: Any) -> int:
         return int(version or 0)
     except (TypeError, ValueError):
         return 0
+
+
+def matches_active_when(hub: Any, description: Any) -> bool:
+    """Return whether an entity's active_when conditions are currently met.
+
+    Conditions reference polled hub.data keys; a key that is absent from
+    hub.data (not polled on this model) does not block availability.
+    """
+    conditions = getattr(description, "active_when", None)
+    if not conditions:
+        return True
+    data = getattr(hub, "data", {})
+    for key, allowed in conditions.items():
+        if key in data and data[key] not in allowed:
+            return False
+    return True
 
 
 def matches_modbus_protocol(hub: Any, description: Any) -> bool:

--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -21,6 +21,7 @@ from .const import (
     WRITE_MULTISINGLE_MODBUS,
     WRITE_SINGLE_MODBUS,
     BaseModbusNumberEntityDescription,
+    matches_active_when,
     matches_modbus_protocol,
 )
 
@@ -52,10 +53,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             ) in number_info.read_scale_exceptions:
                 if hub.seriesnumber.startswith(prefix):
                     newdescr = replace(number_info, read_scale=value)
-        if plugin.matchInverterWithMask(hub._invertertype, newdescr.allowedtypes, hub.seriesnumber, newdescr.blacklist) and matches_modbus_protocol(
-            hub, newdescr
+        if (
+            plugin.matchInverterWithMask(hub._invertertype, newdescr.allowedtypes, hub.seriesnumber, newdescr.blacklist)
+            and matches_modbus_protocol(hub, newdescr)
+            and hub.device_group_enabled(newdescr.device_group)
         ):
-            number = SolaXModbusNumber(hub_name, hub, modbus_addr, hub.device_info, newdescr)
+            device_info = hub.group_device_info(newdescr.device_group) if newdescr.device_group else hub.device_info
+
+            def factory(di: Any = device_info, nd: Any = newdescr) -> SolaXModbusNumber:
+                return SolaXModbusNumber(hub_name, hub, modbus_addr, di, nd)
+
+            number = factory()
             if newdescr.write_method == WRITE_DATA_LOCAL:
                 hub.writeLocals[newdescr.key] = newdescr
             # Use the explicit sensor_key if provided, otherwise fall back to the number's own key.
@@ -79,8 +87,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     if dep_on != newdescr.key:
                         hub.entity_dependencies.setdefault(dep_on, []).append(newdescr.key)  # can be more than one
 
-            hub.numberEntities[newdescr.key] = number
-            entities.append(number)
+            active = matches_active_when(hub, newdescr)
+            if newdescr.active_when is not None:
+                hub.register_gated_entity(newdescr, factory, async_add_entities, hub.numberEntities, "number", number if active else None)
+            if active:
+                hub.numberEntities[newdescr.key] = number
+                entities.append(number)
+            else:
+                hub.numberEntities.pop(newdescr.key, None)
     async_add_entities(entities)
     return True
 
@@ -190,6 +204,15 @@ class SolaXModbusNumber(NumberEntity):
     @property
     def unique_id(self) -> str | None:
         return f"{self._platform_name}_{self._key}"
+
+    @property
+    def native_max_value(self) -> float:
+        max_key = self.entity_description.max_key
+        if max_key:
+            value = self._hub.data.get(max_key)
+            if value:
+                return float(value)
+        return self._attr_native_max_value
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/solax_modbus/select.py
+++ b/custom_components/solax_modbus/select.py
@@ -20,6 +20,7 @@ from .const import (
     WRITE_SINGLE_MODBUS,
     BaseModbusSelectEntityDescription,
     autorepeat_set,
+    matches_active_when,
     matches_modbus_protocol,
 )
 
@@ -38,11 +39,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     plugin = hub.plugin  # getPlugin(hub_name)
     entities = []
     for select_info in plugin.SELECT_TYPES:
-        if plugin.matchInverterWithMask(
-            hub._invertertype, select_info.allowedtypes, hub.seriesnumber, select_info.blacklist
-        ) and matches_modbus_protocol(hub, select_info):
+        if (
+            plugin.matchInverterWithMask(hub._invertertype, select_info.allowedtypes, hub.seriesnumber, select_info.blacklist)
+            and matches_modbus_protocol(hub, select_info)
+            and hub.device_group_enabled(select_info.device_group)
+        ):
             select_info = replace(select_info, reverse_option_dict={v: k for k, v in select_info.option_dict.items()})
-            select = SolaXModbusSelect(hub_name, hub, modbus_addr, hub.device_info, select_info)
+            device_info = hub.group_device_info(select_info.device_group) if select_info.device_group else hub.device_info
+
+            def factory(di: Any = device_info, si: Any = select_info) -> SolaXModbusSelect:
+                return SolaXModbusSelect(hub_name, hub, modbus_addr, di, si)
+
+            select = factory()
             if select_info.write_method == WRITE_DATA_LOCAL:
                 if select_info.initvalue is not None:
                     hub.data[select_info.key] = select_info.initvalue
@@ -71,7 +79,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             dependency_key = getattr(select_info, "sensor_key", select_info.key)
             if dependency_key != select_info.key:
                 hub.entity_dependencies.setdefault(dependency_key, []).append(select_info.key)  # can be more than one
-            entities.append(select)
+            active = matches_active_when(hub, select_info)
+            if select_info.active_when is not None:
+                hub.register_gated_entity(select_info, factory, async_add_entities, hub.selectEntities, "select", select if active else None)
+            if active:
+                hub.selectEntities[select_info.key] = select
+                entities.append(select)
+            else:
+                hub.selectEntities.pop(select_info.key, None)
 
     async_add_entities(entities)
     return True
@@ -201,6 +216,7 @@ class SolaXModbusSelect(SelectEntity):
             _LOGGER.info("*** local data written %s: %s", self._key, payload)
             self._hub.localsUpdated = True  # mark to save permanently
         self._hub.data[self._key] = option
+        await self._hub.async_refresh_gated_entities()
 
         # Handle autorepeat for selects with value_function (same pattern as buttons)
         if self.entity_description.value_function:

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -322,11 +322,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     )
                     desired = {description.key: description for description in descriptions}
 
-                    for key in dashboard_keys - desired.keys():
+                    for key in list(dashboard_keys - desired.keys()):
                         sensor = dashboard_entities.get(key) or hub.sensorEntities.get(key)
                         if sensor is not None and hasattr(sensor, "set_energy_dashboard_active"):
                             sensor.set_energy_dashboard_active(False)
                         hub.computedSensors.pop(key, None)
+                        # Drop the entity and its registry entry: a sensor that is no longer
+                        # part of the dashboard would otherwise stay behind as unavailable.
+                        dashboard_entities.pop(key, None)
+                        dashboard_keys.discard(key)
+                        hub.sensorEntities.pop(key, None)
+                        hub.sensorDescriptions.pop(key, None)
+                        if sensor is not None:
+                            try:
+                                await sensor.async_remove(force_remove=True)
+                            except Exception as ex:
+                                _LOGGER.debug("%s: cannot remove dashboard entity %s: %s", hub_name, key, ex)
+                        try:
+                            ent_registry = er.async_get(hass)
+                            entity_id = ent_registry.async_get_entity_id("sensor", DOMAIN, f"{energy_dashboard_platform_name}_{key}")
+                            if entity_id:
+                                ent_registry.async_remove(entity_id)
+                        except Exception as ex:
+                            _LOGGER.debug("%s: cannot purge dashboard registry entry %s: %s", hub_name, key, ex)
 
                     new_entities: list[SensorEntity] = []
                     for key, description in desired.items():
@@ -873,6 +891,8 @@ def entityToListSingle(
     # Check if this sensor has custom Energy Dashboard device info
     if hasattr(newdescr, "_energy_dashboard_device_info") and newdescr._energy_dashboard_device_info is not None:
         device_info = newdescr._energy_dashboard_device_info
+    elif getattr(newdescr, "device_group", None):
+        device_info = hub.group_device_info(newdescr.device_group)
 
     # Check if this is a Riemann sum sensor
     sensor: SensorEntity

--- a/custom_components/solax_modbus/switch.py
+++ b/custom_components/solax_modbus/switch.py
@@ -18,6 +18,7 @@ from .const import (
     WRITE_DATA_LOCAL,
     WRITE_MULTISINGLE_MODBUS,
     BaseModbusSwitchEntityDescription,
+    matches_active_when,
     matches_modbus_protocol,
 )
 
@@ -37,10 +38,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     entities = []
 
     for switch_info in plugin.SWITCH_TYPES:
-        if plugin.matchInverterWithMask(
-            hub._invertertype, switch_info.allowedtypes, hub.seriesnumber, switch_info.blacklist
-        ) and matches_modbus_protocol(hub, switch_info):
-            switch = SolaXModbusSwitch(hub_name, hub, modbus_addr, hub.device_info, switch_info)
+        if (
+            plugin.matchInverterWithMask(hub._invertertype, switch_info.allowedtypes, hub.seriesnumber, switch_info.blacklist)
+            and matches_modbus_protocol(hub, switch_info)
+            and hub.device_group_enabled(switch_info.device_group)
+        ):
+            device_info = hub.group_device_info(switch_info.device_group) if switch_info.device_group else hub.device_info
+
+            def factory(di: Any = device_info, si: Any = switch_info) -> SolaXModbusSwitch:
+                return SolaXModbusSwitch(hub_name, hub, modbus_addr, di, si)
+
+            switch = factory()
             if switch_info.value_function:
                 hub.computedSwitches[switch_info.key] = switch_info
             if switch_info.write_method == WRITE_DATA_LOCAL and switch_info.sensor_key is not None:
@@ -65,8 +73,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     if dep_on != switch_info.key:
                         hub.entity_dependencies.setdefault(dep_on, []).append(switch_info.key)  # can be more than one
 
-            hub.switchEntities[switch_info.key] = switch  # Store the switch entity
-            entities.append(switch)
+            active = matches_active_when(hub, switch_info)
+            if switch_info.active_when is not None:
+                hub.register_gated_entity(switch_info, factory, async_add_entities, hub.switchEntities, "switch", switch if active else None)
+            if active:
+                hub.switchEntities[switch_info.key] = switch
+                entities.append(switch)
+            else:
+                hub.switchEntities.pop(switch_info.key, None)
 
     providers = hass.data.get(DOMAIN, {}).get("_switch_entity_providers", [])
     for provider in providers:
@@ -144,6 +158,7 @@ class SolaXModbusSwitch(SwitchEntity, RestoreEntity):
         self._attr_is_on = is_on
         self._last_command_time = datetime.now()  # Record user action time
         self.async_write_ha_state()
+        await self._hub.async_refresh_gated_entities()
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()

--- a/custom_components/solax_modbus/time.py
+++ b/custom_components/solax_modbus/time.py
@@ -18,6 +18,7 @@ from .const import (
     WRITE_MULTISINGLE_MODBUS,
     WRITE_SINGLE_MODBUS,
     BaseModbusTimeEntityDescription,
+    matches_active_when,
     matches_modbus_protocol,
 )
 
@@ -36,16 +37,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     plugin = hub.plugin  # getPlugin(hub_name)
     entities = []
     for time_info in plugin.TIME_TYPES:
-        if plugin.matchInverterWithMask(hub._invertertype, time_info.allowedtypes, hub.seriesnumber, time_info.blacklist) and matches_modbus_protocol(
-            hub, time_info
+        if (
+            plugin.matchInverterWithMask(hub._invertertype, time_info.allowedtypes, hub.seriesnumber, time_info.blacklist)
+            and matches_modbus_protocol(hub, time_info)
+            and hub.device_group_enabled(time_info.device_group)
         ):
-            time_entity = SolaXModbusTimeEntity(hub_name, hub, modbus_addr, hub.device_info, time_info)
+            device_info = hub.group_device_info(time_info.device_group) if time_info.device_group else hub.device_info
+
+            def factory(di: Any = device_info, ti: Any = time_info) -> SolaXModbusTimeEntity:
+                return SolaXModbusTimeEntity(hub_name, hub, modbus_addr, di, ti)
+
+            time_entity = factory()
             if time_info.write_method == WRITE_DATA_LOCAL:
                 if time_info.initvalue is not None:
                     hub.data[time_info.key] = time_info.initvalue
                 hub.writeLocals[time_info.key] = time_info
-            hub.timeEntities[time_info.key] = time_entity
-            entities.append(time_entity)
+            active = matches_active_when(hub, time_info)
+            if time_info.active_when is not None:
+                hub.register_gated_entity(time_info, factory, async_add_entities, hub.timeEntities, "time", time_entity if active else None)
+            if active:
+                hub.timeEntities[time_info.key] = time_entity
+                entities.append(time_entity)
+            else:
+                hub.timeEntities.pop(time_info.key, None)
 
     async_add_entities(entities)
 


### PR DESCRIPTION
Base PR for the sub-device series (#2283 EPS, #2284 Parallel, #2285 External Generator, #2286 Dry Contact, plus #2277 and #2275 which stack on it). This PR moves **no entities** — it contains the shared fix and infrastructure, so each follow-up stays a small, single-topic review.

## Energy Dashboard fix

Turning a feature switch off only marked the corresponding sensors inactive. The entity stayed alive and its registry entry was never removed, so the virtual device accumulated sensors stuck at `unavailable` (grid-to-battery, home-consumption and the PV-variant sensors). They are now removed and their registry entries purged.

## Sub-device infrastructure (generic, usable by any plugin)

- `device_group` on an entity description assigns it to a named sub-device linked to the inverter with `via_device` — the same pattern the battery pack devices already use.
- `active_when` (`{sensor_key: allowed values}`) is evaluated against polled `hub.data`; a key that is not polled on a model never blocks availability.
- The hub tracks such entities and adds or removes them as conditions change, with a two-poll hysteresis so a stale readback right after a write cannot make entities flicker.
- A sub-device whose option is switched off is removed from the registry instead of lingering.
- Switch and number writes publish the written value immediately, as selects and times already did.
- Numbers gain `max_key`, letting a sensor value override `native_max_value`.
- The number, select, switch, time and sensor platforms honour all of it.

## Options dialog

Feature switches the selected plugin does not implement are no longer shown (an EV charger no longer offers EPS or the Dry Contact Box, for example). The same option can gate different functionality per plugin — Parallel Mode covers the inverter master-slave group on the hybrid and the charger-parallel group on the EV charger (#2275). All feature options now default to off for new entries, including the Energy Dashboard virtual device.
