### PR TITLE
added Faultcode 411(01) for Growatt GEN4

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -568,6 +568,7 @@ def value_function_inverter_fault_text(initval: int, descr: Any, datadict: dict[
         (408, 0): "Over-temperature",
         (409, 0): "Bus voltage abnormal",
         (411, 0): "Internal communication failure",
+        (411, 1): "Communication fault",    # from event mail from growatt for a MOD 10000 TL3-HU Hybrid
         (412, 0): "Temperature sensor disconnected",
         (416, 0): "DC/AC overcurrent protection",
         (420, 0): "GFCI module abnormal",

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -568,7 +568,7 @@ def value_function_inverter_fault_text(initval: int, descr: Any, datadict: dict[
         (408, 0): "Over-temperature",
         (409, 0): "Bus voltage abnormal",
         (411, 0): "Internal communication failure",
-        (411, 1): "Communication fault", # from event mail from growatt for a MOD 10000 TL3-HU Hybrid
+        (411, 1): "Communication fault",  # from event mail from growatt for a MOD 10000 TL3-HU Hybrid
         (412, 0): "Temperature sensor disconnected",
         (416, 0): "DC/AC overcurrent protection",
         (420, 0): "GFCI module abnormal",

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -568,7 +568,7 @@ def value_function_inverter_fault_text(initval: int, descr: Any, datadict: dict[
         (408, 0): "Over-temperature",
         (409, 0): "Bus voltage abnormal",
         (411, 0): "Internal communication failure",
-        (411, 1): "Communication fault",    # from event mail from growatt for a MOD 10000 TL3-HU Hybrid
+        (411, 1): "Communication fault", # from event mail from growatt for a MOD 10000 TL3-HU Hybrid
         (412, 0): "Temperature sensor disconnected",
         (416, 0): "DC/AC overcurrent protection",
         (420, 0): "GFCI module abnormal",


### PR DESCRIPTION
Got a faultcode 411(01) event on my own inverter, that mapped to: Unknown Fault (main_code=411, sub_code=1)
in Home Assistant

and got this in an email from growatt;
Device serial number:	DKSxxxxxxx
DataLog serial number:	ZGQxxxxxxx
Plant name:	My Plant
Time:	2026-08-13 04:19:33
Event id:	411(01)
Event description:	Communication fault
Suggestion:	1.After shutdown,Check communication board wiring 2.If the error message still exists, contact manufacturer
GrowattServer
