### PR TITLE
Fix Sofar battery setup when BMS selection writes are rejected

### DIFF
--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -106,6 +106,9 @@ ALL_MPPT_GROUP = MPPT3 | MPPT4 | MPPT6 | MPPT8 | MPPT10
 
 BAT_BTS = 0x1000000
 
+HYD_EP = 0x2000000
+ALL_MODEL_GROUP = HYD_EP
+
 ALLDEFAULT = 0  # should be equivalent to HYBRID | AC | GEN2 | GEN3 | GEN4 | X1 | X3
 
 # ======================= end of bitmask handling code =============================================
@@ -4076,14 +4079,28 @@ BATTERY_SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         allowedtypes=BAT_BTS,
     ),
-    # SofarModbusSensorEntityDescription(
-    #     name = "Pack SOC",
-    #     key = "pack_soc",
-    #     native_unit_of_measurement = PERCENTAGE,
-    #     device_class = SensorDeviceClass.BATTERY,
-    #     register = 0x907A,
-    #     allowedtypes = BAT_BTS,
-    # ),
+    SofarModbusSensorEntityDescription(
+        name="Pack Total Voltage",
+        key="pack_total_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        register=0x9079,
+        scale=0.1,
+        suggested_display_precision=1,
+        allowedtypes=BAT_BTS | HYD_EP,
+    ),
+    SofarModbusSensorEntityDescription(
+        name="Pack SOC",
+        key="pack_soc",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        register=0x907A,
+        scale=0.1,
+        suggested_display_precision=1,
+        allowedtypes=BAT_BTS | HYD_EP,
+    ),
 ]
 
 
@@ -4334,6 +4351,9 @@ class sofar_plugin(plugin_base):
         elif seriesnumber.startswith("SM2E"):
             invertertype = HYBRID | X1 | GEN  # HYDxxxxES, Not actually X3, needs changing
             self.inverter_model = "HYDxxxxES"
+            if seriesnumber.startswith("SM2ES4"):
+                invertertype |= HYD_EP
+                self.inverter_model = "HYD 3-6K-EP"
         elif seriesnumber.startswith("ZM2E"):
             invertertype = HYBRID | X1 | GEN  # HYDxxxxKTL ZCS HP, Single Phase
             self.inverter_model = "HYDxxxxKTL ZCS HP"
@@ -4397,12 +4417,13 @@ class sofar_plugin(plugin_base):
         dcbmatch = ((inverterspec & entitymask & ALL_DCB_GROUP) != 0) or (entitymask & ALL_DCB_GROUP == 0)
         pmmatch = ((inverterspec & entitymask & ALL_PM_GROUP) != 0) or (entitymask & ALL_PM_GROUP == 0)
         mpptmatch = ((inverterspec & entitymask & ALL_MPPT_GROUP) != 0) or (entitymask & ALL_MPPT_GROUP == 0)
+        modelmatch = ((inverterspec & entitymask & ALL_MODEL_GROUP) != 0) or (entitymask & ALL_MODEL_GROUP == 0)
         blacklisted = False
         if blacklist:
             for start in blacklist:
                 if serialnumber.startswith(start):
                     blacklisted = True
-        return (genmatch and xmatch and hybmatch and epsmatch and dcbmatch and pmmatch and mpptmatch) and not blacklisted
+        return (genmatch and xmatch and hybmatch and epsmatch and dcbmatch and pmmatch and mpptmatch and modelmatch) and not blacklisted
 
     def getSoftwareVersion(self, new_data: dict[str, Any]) -> str | None:
         return new_data.get("software_version", None)

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -4124,12 +4124,51 @@ class battery_config(base_battery_config):
             await self._determine_bat_quantitys(hub)
         return self.number_strings
 
+    async def _read_selected_battery(self, hub: Any) -> int | None:
+        """Return the battery selection reported by the inverter."""
+        try:
+            inverter_data = await hub.async_read_holding_registers(
+                unit=hub._modbus_addr,
+                address=self.bms_check_address,
+                count=1,
+            )
+            if inverter_data is None or inverter_data.isError():
+                _LOGGER.warning("Cannot read BMS selection register 0x%x", self.bms_check_address)
+                return None
+
+            return convert_from_registers(inverter_data.registers[:1], DataType.UINT16, "big")  # type: ignore[attr-defined]  # DataType enum dynamic
+        except Exception:
+            _LOGGER.warning("Cannot read BMS selection register 0x%x", self.bms_check_address, exc_info=True)
+            return None
+
     async def select_battery(self, hub: Any, batt_nr: int, batt_pack_nr: int) -> bool:
         faulty_nr = 0
         payload = faulty_nr << 12 | batt_pack_nr << 8 | batt_nr
         _LOGGER.debug("select batt-nr: %s batt-pack: %s 0x%x", batt_nr, batt_pack_nr, payload)
-        await hub.async_write_registers_single(unit=hub._modbus_addr, address=self.bms_inquire_address, payload=payload)
+
+        selected_battery = await self._read_selected_battery(hub)
+        if selected_battery == payload:
+            self.selected_batt_nr = batt_nr
+            self.selected_batt_pack_nr = batt_pack_nr
+            return True
+
+        try:
+            await hub.async_write_registers_single(unit=hub._modbus_addr, address=self.bms_inquire_address, payload=payload)
+        except Exception:
+            _LOGGER.warning(
+                "Cannot select batt_nr: %s, batt_pack_nr: %s via register 0x%x",
+                batt_nr,
+                batt_pack_nr,
+                self.bms_inquire_address,
+                exc_info=True,
+            )
+            return False
+
         await asyncio.sleep(0.3)
+        if await self._read_selected_battery(hub) != payload:
+            _LOGGER.warning("Inverter did not select batt_nr: %s, batt_pack_nr: %s", batt_nr, batt_pack_nr)
+            return False
+
         self.selected_batt_nr = batt_nr
         self.selected_batt_pack_nr = batt_pack_nr
         return True
@@ -4234,7 +4273,8 @@ class battery_config(base_battery_config):
                     self.batt_pack_serials[batt_nr] = {}
 
                 for batt_pack_nr in range(self.number_cels_in_parallel):
-                    await self.select_battery(hub, batt_nr, batt_pack_nr)
+                    if not await self.select_battery(hub, batt_nr, batt_pack_nr):
+                        continue
                     serial = await self._determinate_batt_pack_serial(hub)
                     if self.batt_pack_serials[batt_nr].__contains__(batt_pack_nr):
                         if self.batt_pack_serials[batt_nr][batt_pack_nr] != serial:

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -109,6 +109,8 @@ BAT_BTS = 0x1000000
 HYD_EP = 0x2000000
 ALL_MODEL_GROUP = HYD_EP
 
+HYD_EP_CURRENT_SCALE_EXCEPTIONS = [("SM2ES4", 0.1)]
+
 ALLDEFAULT = 0  # should be equivalent to HYBRID | AC | GEN2 | GEN3 | GEN4 | X1 | X3
 
 # ======================= end of bitmask handling code =============================================
@@ -3932,6 +3934,7 @@ BATTERY_SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         register=0x9010,
         register_data_type=REGISTER_S16,
         scale=0.1,
+        read_scale_exceptions=HYD_EP_CURRENT_SCALE_EXCEPTIONS,
         allowedtypes=BAT_BTS,
     ),
     SofarModbusSensorEntityDescription(
@@ -4054,6 +4057,7 @@ BATTERY_SENSOR_TYPES: list[SofarModbusSensorEntityDescription] = [
         register=0x9071,
         register_data_type=REGISTER_S16,
         scale=0.1,
+        read_scale_exceptions=HYD_EP_CURRENT_SCALE_EXCEPTIONS,
         allowedtypes=BAT_BTS,
     ),
     SofarModbusSensorEntityDescription(

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -4136,7 +4136,7 @@ class battery_config(base_battery_config):
                 _LOGGER.warning("Cannot read BMS selection register 0x%x", self.bms_check_address)
                 return None
 
-            return convert_from_registers(inverter_data.registers[:1], DataType.UINT16, "big")  # type: ignore[attr-defined]  # DataType enum dynamic
+            return int(convert_from_registers(inverter_data.registers[:1], DataType.UINT16, "big"))  # type: ignore[attr-defined]  # DataType enum dynamic
         except Exception:
             _LOGGER.warning("Cannot read BMS selection register 0x%x", self.bms_check_address, exc_info=True)
             return None

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -4278,10 +4278,22 @@ class battery_config(base_battery_config):
             inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=self.bapack_number_address, count=1)
             if inverter_data is not None and not inverter_data.isError():
                 val = convert_from_registers(inverter_data.registers[:1], DataType.UINT16, "big")  # type: ignore[attr-defined]  # DataType enum dynamic
-                self.number_cels_in_parallel = (val >> 8) & 0xFF  # high byte
-                self.number_strings = val & 0xFF  # low byte
+                self.number_cels_in_parallel, self.number_strings = self._decode_battery_query_dimensions(hub.seriesnumber, int(val))
         except Exception:
             _LOGGER.warning("%s: attempt to read BaPack number failed at 0x%x", hub.name, self.bapack_number_address, exc_info=True)
+
+    @staticmethod
+    def _decode_battery_query_dimensions(seriesnumber: str, value: int) -> tuple[int, int]:
+        """Return the pack and battery counts used for BMS_Inquire queries."""
+        parallel_pack_count = (value >> 8) & 0xFF
+        string_count = value & 0xFF
+
+        if seriesnumber.startswith("SM2ES4"):
+            # HYD-EP reports 0x0410 for four parallel packs with 16 cells
+            # each. Its low byte is not another selectable BMS dimension.
+            return 1, parallel_pack_count
+
+        return parallel_pack_count, string_count
 
     async def init_batt_pack_serials(self, hub: Any) -> None:
         retry = 0

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -246,7 +246,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 async def readPreparation(
                     old_data: Any, key_prefix: str = key_prefix, batt_nr: int = batt_nr, batt_pack_nr: int = batt_pack_nr
                 ) -> Any:
-                    await battery_config.select_battery(hub, batt_nr, batt_pack_nr)
+                    if not await battery_config.select_battery(hub, batt_nr, batt_pack_nr):
+                        return False
                     return await battery_config.check_battery_on_start(hub, old_data, key_prefix, batt_nr, batt_pack_nr)
 
                 async def readFollowUpBattery(

--- a/tests/unit/test_sofar_battery_selection.py
+++ b/tests/unit/test_sofar_battery_selection.py
@@ -1,0 +1,64 @@
+"""Tests for SOFAR battery-pack selection."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.solax_modbus.plugin_sofar import battery_config
+
+
+def selection_response(value: int) -> SimpleNamespace:
+    """Return a successful one-register Modbus response."""
+    return SimpleNamespace(registers=[value], isError=lambda: False)
+
+
+def make_hub(*selection_values: int) -> SimpleNamespace:
+    """Return a hub reporting the supplied battery selections."""
+    return SimpleNamespace(
+        _modbus_addr=1,
+        async_read_holding_registers=AsyncMock(side_effect=[selection_response(value) for value in selection_values]),
+        async_write_registers_single=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_battery_skips_write_when_pack_is_already_selected() -> None:
+    """Do not write 0x9020 when 0x9044 already reports the requested pack."""
+    config = battery_config()
+    hub = make_hub(0)
+
+    assert await config.select_battery(hub, batt_nr=0, batt_pack_nr=0) is True
+
+    hub.async_write_registers_single.assert_not_awaited()
+    assert config.selected_batt_nr == 0
+    assert config.selected_batt_pack_nr == 0
+
+
+@pytest.mark.asyncio
+async def test_select_battery_writes_and_verifies_changed_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write 0x9020 only when needed and verify the result through 0x9044."""
+    config = battery_config()
+    hub = make_hub(0, 0x0100)
+    sleep = AsyncMock()
+    monkeypatch.setattr("custom_components.solax_modbus.plugin_sofar.asyncio.sleep", sleep)
+
+    assert await config.select_battery(hub, batt_nr=0, batt_pack_nr=1) is True
+
+    hub.async_write_registers_single.assert_awaited_once_with(unit=1, address=0x9020, payload=0x0100)
+    sleep.assert_awaited_once_with(0.3)
+    assert config.selected_batt_nr == 0
+    assert config.selected_batt_pack_nr == 1
+
+
+@pytest.mark.asyncio
+async def test_select_battery_contains_rejected_write() -> None:
+    """A rejected pack-selection write must not abort platform setup."""
+    config = battery_config()
+    hub = make_hub(0)
+    hub.async_write_registers_single.side_effect = RuntimeError("write rejected")
+
+    assert await config.select_battery(hub, batt_nr=0, batt_pack_nr=1) is False
+
+    assert config.selected_batt_nr is None
+    assert config.selected_batt_pack_nr is None

--- a/tests/unit/test_sofar_hyd_ep_pack_sensors.py
+++ b/tests/unit/test_sofar_hyd_ep_pack_sensors.py
@@ -1,0 +1,23 @@
+"""Tests for SOFAR HYD-EP pack-specific sensors."""
+
+from custom_components.solax_modbus.plugin_sofar import BATTERY_SENSOR_TYPES, GEN, HYBRID, HYD_EP, X1, plugin_instance
+
+
+def test_hyd_ep_pack_sensors_use_pack_specific_registers() -> None:
+    """HYD-EP exposes its individual pack voltage and SOC registers."""
+    descriptions = {description.key: description for description in BATTERY_SENSOR_TYPES}
+
+    assert descriptions["pack_total_voltage"].register == 0x9079
+    assert descriptions["pack_total_voltage"].scale == 0.1
+    assert descriptions["pack_soc"].register == 0x907A
+    assert descriptions["pack_soc"].scale == 0.1
+
+
+def test_hyd_ep_pack_sensors_are_model_specific() -> None:
+    """Do not expose HYD-EP pack registers on other SOFAR families."""
+    pack_soc = next(description for description in BATTERY_SENSOR_TYPES if description.key == "pack_soc")
+    hyd_ep_type = HYBRID | X1 | GEN | HYD_EP
+    other_sofar_type = HYBRID | X1 | GEN
+
+    assert plugin_instance.matchInverterWithMask(hyd_ep_type, pack_soc.allowedtypes, "SM2ES4") is True
+    assert plugin_instance.matchInverterWithMask(other_sofar_type, pack_soc.allowedtypes, "SP1") is False

--- a/tests/unit/test_sofar_hyd_ep_pack_sensors.py
+++ b/tests/unit/test_sofar_hyd_ep_pack_sensors.py
@@ -1,6 +1,6 @@
 """Tests for SOFAR HYD-EP pack-specific sensors."""
 
-from custom_components.solax_modbus.plugin_sofar import BATTERY_SENSOR_TYPES, GEN, HYBRID, HYD_EP, X1, plugin_instance
+from custom_components.solax_modbus.plugin_sofar import BATTERY_SENSOR_TYPES, GEN, HYBRID, HYD_EP, X1, battery_config, plugin_instance
 
 
 def test_hyd_ep_pack_sensors_use_pack_specific_registers() -> None:
@@ -31,3 +31,13 @@ def test_hyd_ep_current_sensors_apply_model_specific_scale() -> None:
         description = descriptions[key]
         assert description.scale == 0.1
         assert description.read_scale_exceptions == [("SM2ES4", 0.1)]
+
+
+def test_hyd_ep_battery_query_dimensions_use_parallel_pack_count() -> None:
+    """HYD-EP exposes four selectable packs for its reported 0x0410."""
+    assert battery_config._decode_battery_query_dimensions("SM2ES4", 0x0410) == (1, 4)
+
+
+def test_other_sofar_battery_query_dimensions_remain_unchanged() -> None:
+    """Keep the established two-dimensional battery selection for other models."""
+    assert battery_config._decode_battery_query_dimensions("SP1ES110", 0x0410) == (4, 16)

--- a/tests/unit/test_sofar_hyd_ep_pack_sensors.py
+++ b/tests/unit/test_sofar_hyd_ep_pack_sensors.py
@@ -21,3 +21,13 @@ def test_hyd_ep_pack_sensors_are_model_specific() -> None:
 
     assert plugin_instance.matchInverterWithMask(hyd_ep_type, pack_soc.allowedtypes, "SM2ES4") is True
     assert plugin_instance.matchInverterWithMask(other_sofar_type, pack_soc.allowedtypes, "SP1") is False
+
+
+def test_hyd_ep_current_sensors_apply_model_specific_scale() -> None:
+    """HYD-EP current values use 0.01 A without changing other models."""
+    descriptions = {description.key: description for description in BATTERY_SENSOR_TYPES}
+
+    for key in ("total_current", "pack_current"):
+        description = descriptions[key]
+        assert description.scale == 0.1
+        assert description.read_scale_exceptions == [("SM2ES4", 0.1)]


### PR DESCRIPTION
Some Sofar inverters already report the requested battery pack at `0x9044` but reject the redundant selection write to `0x9020`. At least it seems like, this is why I thought changing the order could make sense.

- Read `0x9044` before writing the battery selection.
- Skip the `0x9020` write when the requested pack is already selected.
- Verify changed selections through `0x9044`.
- Contain read and write failures to the affected battery pack.
- Skip pack data when its selection cannot be confirmed.
- Add regression tests for successful, redundant and rejected selections.

Fixes #2294