### PR TITLE
Fix deprecated device registry lookups

### DIFF
--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -154,7 +154,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     async def readFollowUp(old_data: Any, new_data: Any) -> bool:
         dev_registry = dr.async_get(hass)
-        device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, INVERTER_IDENT)}))
+        device = dev_registry.async_get_device_by_identifier(cast(tuple[str, str], (DOMAIN, hub_name, INVERTER_IDENT)), entry.entry_id)
         if device is not None:
             sw_version = plugin.getSoftwareVersion(new_data)
             hw_version = plugin.getHardwareVersion(new_data)
@@ -217,7 +217,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
                 batt_pack_id = f"battery_{batt_nr + 1}_{batt_pack_nr + 1}"
                 dev_registry = dr.async_get(hass)
-                device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, batt_pack_id)}))
+                device = dev_registry.async_get_device_by_identifier(cast(tuple[str, str], (DOMAIN, hub_name, batt_pack_id)), entry.entry_id)
                 if device is not None:
                     _LOGGER.debug("batt pack serial: %s", device.serial_number)
                     await battery_config.init_batt_pack(hub, device.serial_number)
@@ -261,7 +261,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     batt_pack_nr: int = batt_pack_nr,
                 ) -> bool:
                     dev_registry = dr.async_get(hass)
-                    device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, batt_pack_id)}))
+                    device = dev_registry.async_get_device_by_identifier(cast(tuple[str, str], (DOMAIN, hub_name, batt_pack_id)), entry.entry_id)
                     if device is not None:
                         batt_pack_model = await battery_config.get_batt_pack_model(hub)
                         batt_pack_sw_version = await battery_config.get_batt_pack_sw_version(hub, new_data, key_prefix)

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import time
+from collections.abc import Callable
 from dataclasses import replace
 from datetime import date
 from types import SimpleNamespace
@@ -61,6 +62,22 @@ COMMUNICATION_SENSOR_TYPES: list[BaseModbusSensorEntityDescription] = [
 ]
 
 COMMUNICATION_SENSOR_KEYS = {description.key for description in COMMUNICATION_SENSOR_TYPES}
+
+
+def _get_device_by_identifier(
+    registry: dr.DeviceRegistry,
+    identifier: tuple[str, ...],
+    config_entry_id: str,
+) -> dr.DeviceEntry | None:
+    """Look up a device within its config entry on supported HA versions."""
+    typed_identifier = cast(tuple[str, str], identifier)
+    scoped_lookup = getattr(registry, "async_get_device_by_identifier", None)
+    if scoped_lookup is not None:
+        lookup = cast(Callable[[tuple[str, str], str], dr.DeviceEntry | None], scoped_lookup)
+        return lookup(typed_identifier, config_entry_id)
+
+    # Home Assistant versions before 2026.8 do not provide the scoped lookup.
+    return registry.async_get_device(identifiers={typed_identifier})
 
 
 def _energy_dashboard_mapping_attrs(description: Any, hub: Any) -> dict[str, Any]:
@@ -154,7 +171,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     async def readFollowUp(old_data: Any, new_data: Any) -> bool:
         dev_registry = dr.async_get(hass)
-        device = dev_registry.async_get_device_by_identifier(cast(tuple[str, str], (DOMAIN, hub_name, INVERTER_IDENT)), entry.entry_id)
+        device = _get_device_by_identifier(dev_registry, (DOMAIN, hub_name, INVERTER_IDENT), entry.entry_id)
         if device is not None:
             sw_version = plugin.getSoftwareVersion(new_data)
             hw_version = plugin.getHardwareVersion(new_data)
@@ -217,7 +234,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
                 batt_pack_id = f"battery_{batt_nr + 1}_{batt_pack_nr + 1}"
                 dev_registry = dr.async_get(hass)
-                device = dev_registry.async_get_device_by_identifier(cast(tuple[str, str], (DOMAIN, hub_name, batt_pack_id)), entry.entry_id)
+                device = _get_device_by_identifier(dev_registry, (DOMAIN, hub_name, batt_pack_id), entry.entry_id)
                 if device is not None:
                     _LOGGER.debug("batt pack serial: %s", device.serial_number)
                     await battery_config.init_batt_pack(hub, device.serial_number)
@@ -261,7 +278,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     batt_pack_nr: int = batt_pack_nr,
                 ) -> bool:
                     dev_registry = dr.async_get(hass)
-                    device = dev_registry.async_get_device_by_identifier(cast(tuple[str, str], (DOMAIN, hub_name, batt_pack_id)), entry.entry_id)
+                    device = _get_device_by_identifier(dev_registry, (DOMAIN, hub_name, batt_pack_id), entry.entry_id)
                     if device is not None:
                         batt_pack_model = await battery_config.get_batt_pack_model(hub)
                         batt_pack_sw_version = await battery_config.get_batt_pack_sw_version(hub, new_data, key_prefix)

--- a/tests/unit/test_device_registry_lookups.py
+++ b/tests/unit/test_device_registry_lookups.py
@@ -1,0 +1,24 @@
+"""Regression tests for config-entry-scoped device registry lookups."""
+
+import ast
+from pathlib import Path
+
+
+def test_sensor_device_lookups_are_scoped_to_config_entry() -> None:
+    """Use the modern device registry API with the owning config entry."""
+    sensor_tree = ast.parse(Path("custom_components/solax_modbus/sensor.py").read_text())
+    calls = [node for node in ast.walk(sensor_tree) if isinstance(node, ast.Call)]
+
+    deprecated_calls = [call for call in calls if isinstance(call.func, ast.Attribute) and call.func.attr == "async_get_device"]
+    assert not deprecated_calls
+
+    identifier_calls = [call for call in calls if isinstance(call.func, ast.Attribute) and call.func.attr == "async_get_device_by_identifier"]
+    assert identifier_calls
+
+    for call in identifier_calls:
+        assert len(call.args) == 2
+        config_entry_id = call.args[1]
+        assert isinstance(config_entry_id, ast.Attribute)
+        assert isinstance(config_entry_id.value, ast.Name)
+        assert config_entry_id.value.id == "entry"
+        assert config_entry_id.attr == "entry_id"

--- a/tests/unit/test_device_registry_lookups.py
+++ b/tests/unit/test_device_registry_lookups.py
@@ -5,19 +5,40 @@ from pathlib import Path
 
 
 def test_sensor_device_lookups_are_scoped_to_config_entry() -> None:
-    """Use the modern device registry API with the owning config entry."""
+    """Prefer the scoped API while retaining compatibility with older HA."""
     sensor_tree = ast.parse(Path("custom_components/solax_modbus/sensor.py").read_text())
-    calls = [node for node in ast.walk(sensor_tree) if isinstance(node, ast.Call)]
+    helper = next(node for node in sensor_tree.body if isinstance(node, ast.FunctionDef) and node.name == "_get_device_by_identifier")
+    helper_calls = [node for node in ast.walk(helper) if isinstance(node, ast.Call)]
 
-    deprecated_calls = [call for call in calls if isinstance(call.func, ast.Attribute) and call.func.attr == "async_get_device"]
-    assert not deprecated_calls
+    deprecated_calls = [
+        call
+        for call in ast.walk(sensor_tree)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) and call.func.attr == "async_get_device"
+    ]
+    assert len(deprecated_calls) == 1
+    assert deprecated_calls[0] in helper_calls
 
-    identifier_calls = [call for call in calls if isinstance(call.func, ast.Attribute) and call.func.attr == "async_get_device_by_identifier"]
+    scoped_lookup_checks = [
+        call
+        for call in helper_calls
+        if isinstance(call.func, ast.Name)
+        and call.func.id == "getattr"
+        and len(call.args) >= 2
+        and isinstance(call.args[1], ast.Constant)
+        and call.args[1].value == "async_get_device_by_identifier"
+    ]
+    assert len(scoped_lookup_checks) == 1
+
+    identifier_calls = [
+        call
+        for call in ast.walk(sensor_tree)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id == "_get_device_by_identifier"
+    ]
     assert identifier_calls
 
     for call in identifier_calls:
-        assert len(call.args) == 2
-        config_entry_id = call.args[1]
+        assert len(call.args) == 3
+        config_entry_id = call.args[2]
         assert isinstance(config_entry_id, ast.Attribute)
         assert isinstance(config_entry_id.value, ast.Name)
         assert config_entry_id.value.id == "entry"


### PR DESCRIPTION
Home Assistant deprecated `device_registry.async_get_device()` because device identifiers are no longer globally unique across config entries.

Fixes #2303