### PR TITLE
Derive number limits from register types

### DIFF
--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -1,10 +1,11 @@
 import logging
 from dataclasses import replace
+from decimal import Decimal
 from time import time
 from typing import Any
 
 # from .const import GEN2, GEN3, GEN4, X1, X3, HYBRID, AC, EPS
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import DEFAULT_MAX_VALUE, DEFAULT_MIN_VALUE, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
@@ -15,6 +16,7 @@ from .const import (
     CONF_MODBUS_ADDR,
     DEFAULT_MODBUS_ADDR,
     DOMAIN,
+    REGISTER_INT_RANGES,
     TMPDATA_EXPIRY,
     WRITE_DATA_LOCAL,
     WRITE_MULTI_MODBUS,
@@ -31,6 +33,25 @@ _LOGGER = logging.getLogger(__name__)
 def _scale_native_value_to_register(value: float, scale: float, read_scale: float) -> int:
     """Convert a native number value to its integer register representation."""
     return int(round(value / (scale * read_scale)))
+
+
+def _native_value_bounds(number_info: BaseModbusNumberEntityDescription) -> tuple[float, float]:
+    """Return explicit limits or derive them from the register representation."""
+    register_data_type = number_info.register_data_type
+    register_bounds = REGISTER_INT_RANGES.get(register_data_type) if register_data_type is not None else None
+    if register_bounds is None:
+        derived_min, derived_max = DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE
+    else:
+        native_scale = Decimal(str(number_info.scale)) * Decimal(str(number_info.read_scale))
+        scaled_bounds = (
+            float(Decimal(str(register_bounds[0])) * native_scale),
+            float(Decimal(str(register_bounds[1])) * native_scale),
+        )
+        derived_min, derived_max = min(scaled_bounds), max(scaled_bounds)
+
+    native_min = number_info.native_min_value if number_info.native_min_value is not None else derived_min
+    native_max = number_info.native_max_value if number_info.native_max_value is not None else derived_max
+    return float(native_min), float(native_max)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> bool:
@@ -125,8 +146,7 @@ class SolaXModbusNumber(NumberEntity):
         self._register = number_info.register
         self._fmt = number_info.fmt
         self._unit = number_info.register_data_type
-        self._attr_native_min_value: float = number_info.native_min_value  # type: ignore[assignment]
-        self._attr_native_max_value: float = number_info.native_max_value  # type: ignore[assignment]
+        self._attr_native_min_value, self._attr_native_max_value = _native_value_bounds(number_info)
         self._attr_scale = number_info.scale
         self.entity_description = number_info
         if number_info.max_exceptions:

--- a/tests/unit/test_number_default_bounds.py
+++ b/tests/unit/test_number_default_bounds.py
@@ -1,0 +1,64 @@
+"""Tests for number entity limits derived from Modbus data types."""
+
+import pytest
+from homeassistant.components.number import DEFAULT_MAX_VALUE, DEFAULT_MIN_VALUE
+
+from custom_components.solax_modbus.const import (
+    REGISTER_F32,
+    REGISTER_INT_RANGES,
+    REGISTER_S16,
+    REGISTER_S32,
+    REGISTER_U16,
+    REGISTER_U32,
+    BaseModbusNumberEntityDescription,
+)
+from custom_components.solax_modbus.number import _native_value_bounds
+from custom_components.solax_modbus.plugin_sofar import NUMBER_TYPES as SOFAR_NUMBER_TYPES
+
+
+@pytest.mark.parametrize("register_data_type", [REGISTER_U16, REGISTER_S16, REGISTER_U32, REGISTER_S32])
+def test_integer_register_bounds_are_derived(register_data_type: str) -> None:
+    """An entity without explicit limits should accept its full wire range."""
+    description = BaseModbusNumberEntityDescription(key="test", register_data_type=register_data_type)
+
+    assert _native_value_bounds(description) == REGISTER_INT_RANGES[register_data_type]
+
+
+def test_derived_bounds_include_native_scaling() -> None:
+    """Raw register bounds should be exposed in the entity's native units."""
+    description = BaseModbusNumberEntityDescription(
+        key="test",
+        register_data_type=REGISTER_S16,
+        scale=0.1,
+        read_scale=2,
+    )
+
+    assert _native_value_bounds(description) == (-6553.6, 6553.4)
+
+
+def test_explicit_bounds_override_derived_bounds_independently() -> None:
+    """Plugins may constrain either side of the data type's native range."""
+    description = BaseModbusNumberEntityDescription(
+        key="test",
+        register_data_type=REGISTER_U16,
+        native_min_value=10,
+        native_max_value=20000,
+    )
+
+    assert _native_value_bounds(description) == (10, 20000)
+
+
+def test_non_integer_type_uses_home_assistant_defaults() -> None:
+    """A type without integer bounds should retain HA's defaults."""
+    description = BaseModbusNumberEntityDescription(key="test", register_data_type=REGISTER_F32)
+
+    assert _native_value_bounds(description) == (DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE)
+
+
+def test_sofar_passive_grid_power_uses_signed_32_bit_bounds() -> None:
+    """Parallel Sofar systems should accept totals above one inverter's rating."""
+    description = next(item for item in SOFAR_NUMBER_TYPES if item.key == "passive_mode_grid_power")
+
+    assert description.native_min_value is None
+    assert description.native_max_value is None
+    assert _native_value_bounds(description) == (-(1 << 31), (1 << 31) - 1)


### PR DESCRIPTION
Fixes #2288.

Number entities without explicit minimum or maximum values currently assign `None` to Home Assistant's native limit attributes, causing `number.set_value` to fail.

Derive missing limits centrally from the Modbus register data type, including native scaling. Explicit plugin-specific limits continue to take precedence.

This allows values above a single inverter's rating, such as Sofar Passive Desired Grid Power in parallel installations, without duplicating artificial limits in individual register definitions.