### PR TITLE
Fix deprecated device registry lookups

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -179,6 +179,14 @@ INFLIGHT_CANCEL_TIMEOUT = 2.0
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _get_device_by_identifier(dev_registry: Any, identifier: tuple[str, str], entry_id: str) -> Any:
+    """Return a device by identifier, scoped by config entry when HA supports it."""
+    if hasattr(dev_registry, "async_get_device_by_identifier"):
+        return dev_registry.async_get_device_by_identifier(identifier, entry_id)
+    return dev_registry.async_get_device(identifiers={identifier})
+
+
 PLATFORMS = [Platform.BUTTON, Platform.NUMBER, Platform.SELECT, Platform.SENSOR, Platform.SWITCH, Platform.TIME]
 
 # CONFIG_SCHEMA allows YAML configuration ONLY for debug_settings (DEVELOPMENT/TESTING/DEBUGGING ONLY)
@@ -1025,12 +1033,23 @@ class SolaXModbusHub:
 
     def group_device_info(self, group: str) -> DeviceInfo:
         """Return the DeviceInfo for a named sub-device (e.g. "dry_contact")."""
-        return DeviceInfo(
+        dev_registry = dr.async_get(self._hass)
+        parent_identifier = cast(tuple[str, str], (DOMAIN, self._name, INVERTER_IDENT))
+        parent_device = (
+            _get_device_by_identifier(dev_registry, parent_identifier, self.entry.entry_id)
+            if hasattr(dev_registry, "async_get_device_by_identifier")
+            else None
+        )
+        device_info = DeviceInfo(
             identifiers=cast(set[tuple[str, str]], {(DOMAIN, self._name, group)}),
             name=f"{self._name} {DEVICE_GROUP_NAMES.get(group, group.replace('_', ' ').title())}",
             manufacturer=self.plugin.plugin_manufacturer,
-            via_device=cast(tuple[str, str], (DOMAIN, self._name, INVERTER_IDENT)),
         )
+        if parent_device is not None:
+            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id
+        else:
+            device_info["via_device"] = parent_identifier
+        return device_info
 
     def register_gated_entity(self, descr: Any, factory: Any, add_entities: Any, holder: dict[Any, Any], platform: str, entity: Any = None) -> None:
         """Track a description whose entity only exists while its active_when conditions hold."""

--- a/custom_components/solax_modbus/energy_dashboard.py
+++ b/custom_components/solax_modbus/energy_dashboard.py
@@ -15,7 +15,7 @@ handle:
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
@@ -25,6 +25,7 @@ from homeassistant.const import (
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import (
@@ -40,6 +41,14 @@ from .const import (
 from .debug import get_debug_setting
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_device_by_identifier(dev_registry: Any, identifier: tuple[str, str], entry_id: str) -> Any:
+    """Return a device by identifier, scoped by config entry when HA supports it."""
+    if hasattr(dev_registry, "async_get_device_by_identifier"):
+        return dev_registry.async_get_device_by_identifier(identifier, entry_id)
+    return dev_registry.async_get_device(identifiers={identifier})
+
 
 # Central Riemann sum configuration (applies to all Riemann sensors)
 RIEMANN_METHOD = "trapezoidal"  # Integration method: "trapezoidal", "left", "right"
@@ -357,21 +366,35 @@ class EnergyDashboardMapping:
 
 
 def create_energy_dashboard_device_info(hub: Any, hass: Any = None) -> DeviceInfo:
-    """Create DeviceInfo for Energy Dashboard virtual device."""
-    # Normalize hub name to lowercase with underscores for consistent identifier
+    """Create DeviceInfo for the Energy Dashboard virtual device."""
+    # Normalize hub name for unique identifier
     normalized_hub_name = hub._name.lower().replace(" ", "_")
 
     # Use documentation URL for configuration_url
     config_url = "https://homeassistant-solax-modbus.readthedocs.io/en/latest/"
 
-    return DeviceInfo(
+    device_info = DeviceInfo(
         identifiers={(DOMAIN, f"{normalized_hub_name}_energy_dashboard", "ENERGY_DASHBOARD")},  # type: ignore[arg-type]  # Runtime requires 3-element tuple
         manufacturer="providing curated Grid, Solar, Battery power & energy sensors with parallel mode aggregation support for Home Assistant Energy Dashboard integration",
         model="Energy Dashboard Metrics",
         name=f"{hub._name} Energy Dashboard",
-        via_device=(DOMAIN, hub._name, INVERTER_IDENT),  # type: ignore[typeddict-item]  # Runtime requires 3-element tuple
         configuration_url=config_url,
     )
+    parent_identifier = cast(tuple[str, str], (DOMAIN, hub._name, INVERTER_IDENT))
+    if hass is not None:
+        dev_registry = dr.async_get(hass)
+        parent_device = (
+            _get_device_by_identifier(dev_registry, parent_identifier, hub.entry.entry_id)
+            if hasattr(dev_registry, "async_get_device_by_identifier")
+            else None
+        )
+        if parent_device is not None:
+            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id
+        else:
+            device_info["via_device"] = parent_identifier
+    else:
+        device_info["via_device"] = parent_identifier
+    return device_info
 
 
 ED_SWITCH_PV_VARIANTS = "energy_dashboard_pv_variants_enabled"

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -35,6 +35,13 @@ from .debug import get_debug_setting
 _LOGGER = logging.getLogger(__name__)
 
 
+def _get_device_by_identifier(dev_registry: Any, identifier: tuple[str, str], entry_id: str) -> Any:
+    """Return a device by identifier, scoped by config entry when HA supports it."""
+    if hasattr(dev_registry, "async_get_device_by_identifier"):
+        return dev_registry.async_get_device_by_identifier(identifier, entry_id)
+    return dev_registry.async_get_device(identifiers={identifier})
+
+
 COMMUNICATION_SENSOR_TYPES: list[BaseModbusSensorEntityDescription] = [
     BaseModbusSensorEntityDescription(
         name="Communication Health",
@@ -154,7 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     async def readFollowUp(old_data: Any, new_data: Any) -> bool:
         dev_registry = dr.async_get(hass)
-        device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, INVERTER_IDENT)}))
+        device = _get_device_by_identifier(dev_registry, cast(tuple[str, str], (DOMAIN, hub_name, INVERTER_IDENT)), entry.entry_id)
         if device is not None:
             sw_version = plugin.getSoftwareVersion(new_data)
             hw_version = plugin.getHardwareVersion(new_data)
@@ -217,7 +224,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
                 batt_pack_id = f"battery_{batt_nr + 1}_{batt_pack_nr + 1}"
                 dev_registry = dr.async_get(hass)
-                device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, batt_pack_id)}))
+                device = _get_device_by_identifier(dev_registry, cast(tuple[str, str], (DOMAIN, hub_name, batt_pack_id)), entry.entry_id)
                 if device is not None:
                     _LOGGER.debug("batt pack serial: %s", device.serial_number)
                     await battery_config.init_batt_pack(hub, device.serial_number)
@@ -232,13 +239,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
                 # Battery pack device name = hub name + pack identity (unique per config entry);
                 # entity names never repeat it, HA composes the friendly name.
+                parent_identifier = cast(tuple[str, str], (DOMAIN, hub_name, INVERTER_IDENT))
+                inverter_device = (
+                    _get_device_by_identifier(dev_registry, parent_identifier, entry.entry_id)
+                    if hasattr(dev_registry, "async_get_device_by_identifier")
+                    else None
+                )
                 device_info_battery = DeviceInfo(
                     identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, batt_pack_id)}),
                     name=f"{hub_name} Battery {batt_nr + 1}/{batt_pack_nr + 1}",
                     manufacturer=hub.plugin.plugin_manufacturer,
                     serial_number=batt_pack_serial,
-                    via_device=cast(tuple[str, str], (DOMAIN, hub_name, INVERTER_IDENT)),
                 )
+                if inverter_device is not None:
+                    cast(dict[str, Any], device_info_battery)["via_device_id"] = inverter_device.id
+                else:
+                    device_info_battery["via_device"] = parent_identifier
 
                 key_prefix = battery_config.battery_sensor_key_prefix.replace("{batt-nr}", str(batt_nr + 1)).replace(
                     "{pack-nr}", str(batt_pack_nr + 1)
@@ -261,7 +277,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     batt_pack_nr: int = batt_pack_nr,
                 ) -> bool:
                     dev_registry = dr.async_get(hass)
-                    device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, batt_pack_id)}))
+                    device = _get_device_by_identifier(dev_registry, cast(tuple[str, str], (DOMAIN, hub_name, batt_pack_id)), entry.entry_id)
                     if device is not None:
                         batt_pack_model = await battery_config.get_batt_pack_model(hub)
                         batt_pack_sw_version = await battery_config.get_batt_pack_sw_version(hub, new_data, key_prefix)


### PR DESCRIPTION
## Summary

Fix Home Assistant deprecation warnings in the device registry usage:

- replace deprecated `DeviceRegistry.async_get_device(...)` calls with `async_get_device_by_identifier(..., entry.entry_id)`
- replace deprecated `DeviceInfo(via_device=...)` usage with `via_device_id` after resolving the parent device in the current config entry

## Why

Home Assistant warns that these APIs/parameters are deprecated because device identifiers and connections are no longer unique across config entries. The deprecated usage is scheduled to stop working in Home Assistant 2027.8.

## Test

- Installed locally in Home Assistant `custom_components` for runtime verification
- Confirmed the previous `async_get_device` / `via_device` warnings no longer appear after restart
- Ran syntax check:

```bash
python3 -m py_compile custom_components/solax_modbus/__init__.py custom_components/solax_modbus/energy_dashboard.py custom_components/solax_modbus/sensor.py custom_components/solax_modbus/switch.py
```
