### PR TITLE
Add Growatt MIN 3000TL-XE (DCF) serial prefix

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -9769,6 +9769,7 @@ SERIAL_PREFIX_TYPES = {
     "QYL": PV | GEN4 | X1,  # MIN 2500 TL-X, 2 MPPT
     "XTD": PV | GEN4 | X1,  # MIN 5000 TL-X, 2 MPPT
     "BDK": PV | GEN4 | X1,  # MIN 4200 TL-XE, 2 MPPT
+    "DCF": PV | GEN4 | X1,  # MIN 3000 TL-XE, 2 MPPT
     "WVN": PV | GEN4 | X1 | MPPT3,  # MIN 8000 TL-X2, 3 MPPT
     # MOD, MID and MAX PV
     "RDH": PV | GEN2 | X3,  # MOD 4000 TL3-X, 2 MPPT
@@ -9806,6 +9807,9 @@ FIRMWARE_PREFIX_TYPES = {
     "SPH": HYBRID | GEN3 | X3,  # Hybrid SPH 4kW - 10kW
     "YA1": HYBRID | GEN3 | X3,  # Hybrid SPH 4kW - 10kW 3P TL UP
     "RH1": AC | GEN3 | X1,  # SPA 3000TL BL AC, no PV MPPT
+    # The PV MIN TL-XE reports this firmware prefix too, despite having no
+    # battery; it is caught by its serial prefix above. An unlisted TL-XE
+    # serial falls through to here and is mislabelled HYBRID.
     "AL1": HYBRID | GEN4 | X1,  # Hybrid TL-XH 2.5kW - 6kW (MIN)
     "DN1": HYBRID | GEN4 | X3,  # Hybrid TL3-XH (BP) 3kW - 10kW (MOD), 11kW - 30kW (MID)
     "V": HYBRID | GEN4 | X3,  # Hybrid TL3-XH 3kW - 10kW (MOD)


### PR DESCRIPTION
Adds the serial prefix `DCF` (Growatt MIN 3000TL-XE) to `SERIAL_PREFIX_TYPES`
so the inverter is detected as `PV | GEN4 | X1`.

### Why

`DCF` is not in `SERIAL_PREFIX_TYPES`, so detection falls through to the
firmware fallback. This unit's firmware prefix is `AL1`, which
`FIRMWARE_PREFIX_TYPES` maps to `HYBRID | GEN4 | X1`. So instead of being
unrecognised, the inverter is detected as a hybrid, and a PV-only unit gets the
battery/BMS entities of a model it isn't.

(The `AL1` entry is labelled "Hybrid TL-XH 2.5kW - 6kW (MIN)" with no device
reference. This PV TL-XE reporting `AL1` shows the prefix is not
hybrid-exclusive; whether real TL-XH units also report it, I can't confirm.
Either way, the listed serial prefix is the reliable fix, since the serial is
checked before the firmware fallback.) I added a short comment on the `AL1`
entry noting the shared prefix.

### Confirmed against the real unit

- Nameplate: MIN 3000TL-XE, "PV Grid Inverter", 230 V single-phase,
  PV Isc 16 A x2 (2 MPPT), so `PV | GEN4 | X1`
- Serial (holding 23): `DCF2A2509G`
- Firmware (holding 9): `AL1.0ZABA`

<img width="3072" height="4080" alt="PXL_20260310_182950027" src="https://github.com/user-attachments/assets/39cab9da-9efb-479c-bb4a-0ea42aab6b04" />


### Related

The same fix is submitted to the growatt-modbus library, which ports its
register maps from this project: balloobbot/growatt-modbus#1
