### PR TITLE
Fix async_get_device & via_device deprecations (consolidate: #2304 and #2306)

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -1036,7 +1036,7 @@ class SolaXModbusHub:
         parent_identifier = (DOMAIN, self._name, INVERTER_IDENT)
         parent_device = get_device_by_identifier(dr.async_get(self._hass), parent_identifier, self.entry.entry_id)
         if parent_device is not None:
-            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id  # type: ignore[typeddict-item]
+            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id
         else:
             device_info["via_device"] = parent_identifier  # type: ignore[typeddict-item]
         return device_info

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -162,6 +162,7 @@ from .const import (
 from .const import (
     matches_active_when as matches_active_when,
 )
+from .device_registry_lookup import get_device_by_identifier
 from .modbus_transport import CoreModbusTransport, ModbusTransport, NativeModbusTransport, UnavailableModbusTransport
 from .pymodbus_compat import DataType, convert_from_registers, convert_to_registers, pymodbus_version_info
 from .sensor import SolaXModbusSensor
@@ -1025,12 +1026,20 @@ class SolaXModbusHub:
 
     def group_device_info(self, group: str) -> DeviceInfo:
         """Return the DeviceInfo for a named sub-device (e.g. "dry_contact")."""
-        return DeviceInfo(
+        device_info = DeviceInfo(
             identifiers=cast(set[tuple[str, str]], {(DOMAIN, self._name, group)}),
             name=f"{self._name} {DEVICE_GROUP_NAMES.get(group, group.replace('_', ' ').title())}",
             manufacturer=self.plugin.plugin_manufacturer,
-            via_device=cast(tuple[str, str], (DOMAIN, self._name, INVERTER_IDENT)),
         )
+        # Link to the parent inverter via via_device_id (scoped to this config
+        # entry) on HA 2026.8+, falling back to the deprecated via_device tuple.
+        parent_identifier = (DOMAIN, self._name, INVERTER_IDENT)
+        parent_device = get_device_by_identifier(dr.async_get(self._hass), parent_identifier, self.entry.entry_id)
+        if parent_device is not None:
+            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id  # type: ignore[typeddict-item]
+        else:
+            device_info["via_device"] = parent_identifier  # type: ignore[typeddict-item]
+        return device_info
 
     def register_gated_entity(self, descr: Any, factory: Any, add_entities: Any, holder: dict[Any, Any], platform: str, entity: Any = None) -> None:
         """Track a description whose entity only exists while its active_when conditions hold."""

--- a/custom_components/solax_modbus/device_registry_lookup.py
+++ b/custom_components/solax_modbus/device_registry_lookup.py
@@ -1,0 +1,57 @@
+"""Shared helpers for config-entry-scoped device registry lookups.
+
+Home Assistant 2026.8 made device identifiers and connections unique *per
+config entry*. The legacy ``device_registry.async_get_device(identifiers=...)``
+lookup is therefore deprecated (breaking in HA 2027.8.0) because the same
+identifier can belong to devices owned by different config entries.
+
+This module centralises a single, typed helper that prefers the scoped
+``async_get_device_by_identifier`` API while retaining compatibility with
+older HA versions that only expose the legacy ``async_get_device`` lookup.
+"""
+
+from collections.abc import Callable
+from typing import cast
+
+from homeassistant.helpers.device_registry import DeviceEntry, DeviceRegistry
+
+# A device identifier is a 3-element tuple: (domain, device_name, device_type).
+DeviceIdentifier = tuple[str, str, str]
+
+
+def _scoped_lookup(registry: DeviceRegistry) -> Callable[[DeviceIdentifier, str], DeviceEntry | None]:
+    """Return ``async_get_device_by_identifier`` when available, else the legacy lookup.
+
+    The returned callable is typed for the scoped API. When falling back to the
+    legacy ``async_get_device`` we wrap it so the signature matches the scoped
+    API: it ignores the config-entry scope and matches on the identifier alone.
+    """
+    scoped = getattr(registry, "async_get_device_by_identifier", None)
+    if scoped is not None:
+        return cast(
+            Callable[[DeviceIdentifier, str], DeviceEntry | None],
+            scoped,
+        )
+
+    legacy = registry.async_get_device
+
+    def _fallback(identifier: DeviceIdentifier, _config_entry_id: str) -> DeviceEntry | None:
+        # The legacy API expects a set of identifier tuples.
+        identifiers = {cast(tuple[str, str], identifier)}
+        return legacy(identifiers=cast(set[tuple[str, str]], identifiers))
+
+    return _fallback
+
+
+def get_device_by_identifier(
+    registry: DeviceRegistry,
+    identifier: DeviceIdentifier,
+    config_entry_id: str,
+) -> DeviceEntry | None:
+    """Look up a device scoped to ``config_entry_id``.
+
+    Uses ``async_get_device_by_identifier`` on HA 2026.8+ and transparently
+    falls back to the legacy ``async_get_device`` lookup on older versions.
+    """
+    scoped_lookup = _scoped_lookup(registry)
+    return scoped_lookup(cast(DeviceIdentifier, identifier), config_entry_id)

--- a/custom_components/solax_modbus/device_registry_lookup.py
+++ b/custom_components/solax_modbus/device_registry_lookup.py
@@ -38,7 +38,7 @@ def _scoped_lookup(registry: DeviceRegistry) -> Callable[[DeviceIdentifier, str]
     def _fallback(identifier: DeviceIdentifier, _config_entry_id: str) -> DeviceEntry | None:
         # The legacy API expects a set of identifier tuples.
         identifiers = {cast(tuple[str, str], identifier)}
-        return legacy(identifiers=cast(set[tuple[str, str]], identifiers))
+        return legacy(identifiers=identifiers)
 
     return _fallback
 
@@ -54,4 +54,4 @@ def get_device_by_identifier(
     falls back to the legacy ``async_get_device`` lookup on older versions.
     """
     scoped_lookup = _scoped_lookup(registry)
-    return scoped_lookup(cast(DeviceIdentifier, identifier), config_entry_id)
+    return scoped_lookup(identifier, config_entry_id)

--- a/custom_components/solax_modbus/energy_dashboard.py
+++ b/custom_components/solax_modbus/energy_dashboard.py
@@ -379,7 +379,7 @@ def create_energy_dashboard_device_info(hub: Any, hass: Any = None) -> DeviceInf
     if hass is not None:
         parent_device = get_device_by_identifier(dr.async_get(hass), parent_identifier, hub.entry.entry_id)
         if parent_device is not None:
-            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id  # type: ignore[typeddict-item]
+            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id
         else:
             device_info["via_device"] = parent_identifier  # type: ignore[typeddict-item]
     else:

--- a/custom_components/solax_modbus/energy_dashboard.py
+++ b/custom_components/solax_modbus/energy_dashboard.py
@@ -15,7 +15,7 @@ handle:
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
@@ -25,6 +25,7 @@ from homeassistant.const import (
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import (
@@ -38,6 +39,7 @@ from .const import (
     BaseModbusSwitchEntityDescription,
 )
 from .debug import get_debug_setting
+from .device_registry_lookup import get_device_by_identifier
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -357,21 +359,32 @@ class EnergyDashboardMapping:
 
 
 def create_energy_dashboard_device_info(hub: Any, hass: Any = None) -> DeviceInfo:
-    """Create DeviceInfo for Energy Dashboard virtual device."""
+    """Create DeviceInfo for the Energy Dashboard virtual device."""
     # Normalize hub name to lowercase with underscores for consistent identifier
     normalized_hub_name = hub._name.lower().replace(" ", "_")
 
     # Use documentation URL for configuration_url
     config_url = "https://homeassistant-solax-modbus.readthedocs.io/en/latest/"
 
-    return DeviceInfo(
+    device_info = DeviceInfo(
         identifiers={(DOMAIN, f"{normalized_hub_name}_energy_dashboard", "ENERGY_DASHBOARD")},  # type: ignore[arg-type]  # Runtime requires 3-element tuple
         manufacturer="providing curated Grid, Solar, Battery power & energy sensors with parallel mode aggregation support for Home Assistant Energy Dashboard integration",
         model="Energy Dashboard Metrics",
         name=f"{hub._name} Energy Dashboard",
-        via_device=(DOMAIN, hub._name, INVERTER_IDENT),  # type: ignore[typeddict-item]  # Runtime requires 3-element tuple
         configuration_url=config_url,
     )
+    # Link to the parent inverter via via_device_id (scoped to this config entry)
+    # on HA 2026.8+, falling back to the deprecated via_device tuple.
+    parent_identifier = (DOMAIN, hub._name, INVERTER_IDENT)
+    if hass is not None:
+        parent_device = get_device_by_identifier(dr.async_get(hass), parent_identifier, hub.entry.entry_id)
+        if parent_device is not None:
+            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id  # type: ignore[typeddict-item]
+        else:
+            device_info["via_device"] = parent_identifier  # type: ignore[typeddict-item]
+    else:
+        device_info["via_device"] = parent_identifier  # type: ignore[typeddict-item]
+    return device_info
 
 
 ED_SWITCH_PV_VARIANTS = "energy_dashboard_pv_variants_enabled"

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -244,7 +244,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 parent_identifier = (DOMAIN, hub_name, INVERTER_IDENT)
                 parent_device = get_device_by_identifier(dev_registry, parent_identifier, entry.entry_id)
                 if parent_device is not None:
-                    cast(dict[str, Any], device_info_battery)["via_device_id"] = parent_device.id  # type: ignore[typeddict-item]
+                    cast(dict[str, Any], device_info_battery)["via_device_id"] = parent_device.id
                 else:
                     device_info_battery["via_device"] = parent_identifier  # type: ignore[typeddict-item]
 

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -31,6 +31,7 @@ from .const import (
     matches_modbus_protocol,
 )
 from .debug import get_debug_setting
+from .device_registry_lookup import get_device_by_identifier
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,7 +155,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     async def readFollowUp(old_data: Any, new_data: Any) -> bool:
         dev_registry = dr.async_get(hass)
-        device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, INVERTER_IDENT)}))
+        device = get_device_by_identifier(dev_registry, (DOMAIN, hub_name, INVERTER_IDENT), entry.entry_id)
         if device is not None:
             sw_version = plugin.getSoftwareVersion(new_data)
             hw_version = plugin.getHardwareVersion(new_data)
@@ -217,7 +218,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
                 batt_pack_id = f"battery_{batt_nr + 1}_{batt_pack_nr + 1}"
                 dev_registry = dr.async_get(hass)
-                device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, batt_pack_id)}))
+                device = get_device_by_identifier(dev_registry, (DOMAIN, hub_name, batt_pack_id), entry.entry_id)
                 if device is not None:
                     _LOGGER.debug("batt pack serial: %s", device.serial_number)
                     await battery_config.init_batt_pack(hub, device.serial_number)
@@ -237,8 +238,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     name=f"{hub_name} Battery {batt_nr + 1}/{batt_pack_nr + 1}",
                     manufacturer=hub.plugin.plugin_manufacturer,
                     serial_number=batt_pack_serial,
-                    via_device=cast(tuple[str, str], (DOMAIN, hub_name, INVERTER_IDENT)),
                 )
+                # Link to the parent inverter via via_device_id (scoped to this config
+                # entry) on HA 2026.8+, falling back to the deprecated via_device tuple.
+                parent_identifier = (DOMAIN, hub_name, INVERTER_IDENT)
+                parent_device = get_device_by_identifier(dev_registry, parent_identifier, entry.entry_id)
+                if parent_device is not None:
+                    cast(dict[str, Any], device_info_battery)["via_device_id"] = parent_device.id  # type: ignore[typeddict-item]
+                else:
+                    device_info_battery["via_device"] = parent_identifier  # type: ignore[typeddict-item]
 
                 key_prefix = battery_config.battery_sensor_key_prefix.replace("{batt-nr}", str(batt_nr + 1)).replace(
                     "{pack-nr}", str(batt_pack_nr + 1)
@@ -261,7 +269,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     batt_pack_nr: int = batt_pack_nr,
                 ) -> bool:
                     dev_registry = dr.async_get(hass)
-                    device = dev_registry.async_get_device(identifiers=cast(set[tuple[str, str]], {(DOMAIN, hub_name, batt_pack_id)}))
+                    device = get_device_by_identifier(dev_registry, (DOMAIN, hub_name, batt_pack_id), entry.entry_id)
                     if device is not None:
                         batt_pack_model = await battery_config.get_batt_pack_model(hub)
                         batt_pack_sw_version = await battery_config.get_batt_pack_sw_version(hub, new_data, key_prefix)

--- a/tests/unit/test_device_registry_deprecations.py
+++ b/tests/unit/test_device_registry_deprecations.py
@@ -1,0 +1,130 @@
+"""Regression tests for the ``async_get_device`` / ``via_device`` deprecations.
+
+Home Assistant 2026.8 made device identifiers and connections unique *per
+config entry*. The legacy ``device_registry.async_get_device(identifiers=...)``
+lookup and the ``DeviceInfo(..., via_device=...)`` keyword are both deprecated
+and break in HA 2027.8.0.
+
+These tests guard against reintroducing either deprecation:
+
+- ``test_no_legacy_async_get_device_calls`` ensures the only remaining
+  ``async_get_device`` reference is the intentional fallback inside the shared
+  helper (scoped to a config entry everywhere else).
+- ``test_no_legacy_via_device_keyword`` ensures no ``DeviceInfo(...)`` literal
+  still passes ``via_device=`` (the fallback assignment to a dict is allowed).
+- ``test_helper_prefers_scoped_lookup`` / ``test_helper_falls_back_to_legacy``
+  exercise both runtime branches of the shared helper against a mock registry.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path("custom_components/solax_modbus")
+
+
+def _iter_call_nodes(tree: ast.AST) -> list[ast.Call]:
+    return [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+
+
+def _is_async_get_device_reference(node: ast.AST) -> bool:
+    """True for the single legacy ``async_get_device`` attribute reference.
+
+    The helper captures the legacy lookup once as ``legacy = registry.async_get_device``;
+    we assert that exact attribute access is the only place it is referenced.
+    """
+    return isinstance(node, ast.Attribute) and node.attr == "async_get_device"
+
+
+def _is_via_device_kwarg(call: ast.Call) -> bool:
+    """True for a ``via_device=`` keyword argument on a call."""
+    return any(kw.arg == "via_device" for kw in call.keywords)
+
+
+def test_no_legacy_async_get_device_calls() -> None:
+    """The only ``async_get_device`` reference must be the intentional fallback."""
+    helper = ast.parse((SRC / "device_registry_lookup.py").read_text())
+    helper_refs = [node for node in ast.walk(helper) if _is_async_get_device_reference(node)]
+    assert len(helper_refs) == 1, "expected exactly one legacy fallback reference in the helper"
+
+    # Every other source file must NOT reference the legacy lookup directly.
+    for filename in ("sensor.py", "__init__.py", "energy_dashboard.py"):
+        path = SRC / filename
+        if not path.exists():
+            continue
+        tree = ast.parse(path.read_text())
+        refs = [node for node in ast.walk(tree) if _is_async_get_device_reference(node)]
+        assert not refs, f"{filename} still references the deprecated async_get_device lookup"
+
+
+def test_helper_prefers_scoped_lookup() -> None:
+    """On HA 2026.8+ the helper must use ``async_get_device_by_identifier``."""
+    from custom_components.solax_modbus.device_registry_lookup import get_device_by_identifier
+
+    class _FakeRegistry:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, tuple, str]] = []
+
+        def async_get_device_by_identifier(self, identifier, config_entry_id):  # noqa: ANN001
+            self.calls.append(("scoped", identifier, config_entry_id))
+            return "SCOPED_DEVICE"
+
+    registry = _FakeRegistry()
+    result = get_device_by_identifier(registry, ("solax_modbus", "hub", "inverter"), "entry-1")
+
+    assert result == "SCOPED_DEVICE"
+    assert registry.calls == [("scoped", ("solax_modbus", "hub", "inverter"), "entry-1")]
+
+
+def test_helper_falls_back_to_legacy() -> None:
+    """Without the scoped API the helper must fall back to ``async_get_device``."""
+    from custom_components.solax_modbus.device_registry_lookup import get_device_by_identifier
+
+    class _FakeRegistry:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def async_get_device(self, identifiers=None):  # noqa: ANN001
+            self.calls.append({"identifiers": identifiers})
+            return "LEGACY_DEVICE"
+
+    registry = _FakeRegistry()
+    result = get_device_by_identifier(registry, ("solax_modbus", "hub", "inverter"), "entry-1")
+
+    assert result == "LEGACY_DEVICE"
+    assert registry.calls == [{"identifiers": {("solax_modbus", "hub", "inverter")}}]
+
+
+def test_no_legacy_via_device_keyword() -> None:
+    """No ``DeviceInfo(...)`` literal may pass ``via_device=``."""
+    for filename in ("sensor.py", "__init__.py", "energy_dashboard.py"):
+        path = SRC / filename
+        if not path.exists():
+            continue
+        tree = ast.parse(path.read_text())
+        via_device_calls = [
+            c
+            for c in _iter_call_nodes(tree)
+            if isinstance(c.func, ast.Name) and c.func.id == "DeviceInfo"
+            and _is_via_device_kwarg(c)
+        ]
+        assert not via_device_calls, f"{filename} still passes via_device= to DeviceInfo"
+
+
+def test_via_device_fallback_uses_via_device_id_first() -> None:
+    """The fallback path must set ``via_device_id`` when the parent device resolves."""
+    from custom_components.solax_modbus.device_registry_lookup import get_device_by_identifier
+
+    class _FakeRegistry:
+        def async_get_device_by_identifier(self, identifier, config_entry_id):  # noqa: ANN001
+            return _FakeDevice("parent-id")
+
+    class _FakeDevice:
+        def __init__(self, device_id: str) -> None:
+            self.id = device_id
+
+    registry = _FakeRegistry()
+    device = get_device_by_identifier(registry, ("solax_modbus", "hub", "inverter"), "entry-1")
+    assert device is not None
+    assert device.id == "parent-id"

--- a/tests/unit/test_device_registry_deprecations.py
+++ b/tests/unit/test_device_registry_deprecations.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from typing import Any, cast
+
+from homeassistant.helpers.device_registry import DeviceRegistry
 
 SRC = Path("custom_components/solax_modbus")
 
@@ -64,16 +67,16 @@ def test_helper_prefers_scoped_lookup() -> None:
 
     class _FakeRegistry:
         def __init__(self) -> None:
-            self.calls: list[tuple[str, tuple, str]] = []
+            self.calls: list[tuple[str, tuple[str, str, str], str]] = []
 
-        def async_get_device_by_identifier(self, identifier, config_entry_id):  # noqa: ANN001
+        def async_get_device_by_identifier(self, identifier: tuple[str, str, str], config_entry_id: str) -> Any:
             self.calls.append(("scoped", identifier, config_entry_id))
             return "SCOPED_DEVICE"
 
     registry = _FakeRegistry()
-    result = get_device_by_identifier(registry, ("solax_modbus", "hub", "inverter"), "entry-1")
+    result = get_device_by_identifier(cast(DeviceRegistry, registry), ("solax_modbus", "hub", "inverter"), "entry-1")
 
-    assert result == "SCOPED_DEVICE"
+    assert cast(Any, result) == "SCOPED_DEVICE"
     assert registry.calls == [("scoped", ("solax_modbus", "hub", "inverter"), "entry-1")]
 
 
@@ -83,16 +86,16 @@ def test_helper_falls_back_to_legacy() -> None:
 
     class _FakeRegistry:
         def __init__(self) -> None:
-            self.calls: list[dict] = []
+            self.calls: list[dict[str, Any]] = []
 
-        def async_get_device(self, identifiers=None):  # noqa: ANN001
+        def async_get_device(self, identifiers: Any = None) -> Any:
             self.calls.append({"identifiers": identifiers})
             return "LEGACY_DEVICE"
 
     registry = _FakeRegistry()
-    result = get_device_by_identifier(registry, ("solax_modbus", "hub", "inverter"), "entry-1")
+    result = get_device_by_identifier(cast(DeviceRegistry, registry), ("solax_modbus", "hub", "inverter"), "entry-1")
 
-    assert result == "LEGACY_DEVICE"
+    assert cast(Any, result) == "LEGACY_DEVICE"
     assert registry.calls == [{"identifiers": {("solax_modbus", "hub", "inverter")}}]
 
 
@@ -104,10 +107,7 @@ def test_no_legacy_via_device_keyword() -> None:
             continue
         tree = ast.parse(path.read_text())
         via_device_calls = [
-            c
-            for c in _iter_call_nodes(tree)
-            if isinstance(c.func, ast.Name) and c.func.id == "DeviceInfo"
-            and _is_via_device_kwarg(c)
+            c for c in _iter_call_nodes(tree) if isinstance(c.func, ast.Name) and c.func.id == "DeviceInfo" and _is_via_device_kwarg(c)
         ]
         assert not via_device_calls, f"{filename} still passes via_device= to DeviceInfo"
 
@@ -116,15 +116,15 @@ def test_via_device_fallback_uses_via_device_id_first() -> None:
     """The fallback path must set ``via_device_id`` when the parent device resolves."""
     from custom_components.solax_modbus.device_registry_lookup import get_device_by_identifier
 
-    class _FakeRegistry:
-        def async_get_device_by_identifier(self, identifier, config_entry_id):  # noqa: ANN001
-            return _FakeDevice("parent-id")
-
     class _FakeDevice:
         def __init__(self, device_id: str) -> None:
             self.id = device_id
 
+    class _FakeRegistry:
+        def async_get_device_by_identifier(self, identifier: tuple[str, str, str], config_entry_id: str) -> Any:
+            return _FakeDevice("parent-id")
+
     registry = _FakeRegistry()
-    device = get_device_by_identifier(registry, ("solax_modbus", "hub", "inverter"), "entry-1")
+    device = get_device_by_identifier(cast(DeviceRegistry, registry), ("solax_modbus", "hub", "inverter"), "entry-1")
     assert device is not None
     assert device.id == "parent-id"


### PR DESCRIPTION
I asked ZooCode using ornith-1.5:35b locally to compare #2304 and #2306
I'm not a programmer by trade and I'm fairly new to all of this ZooCode / LLM stuff...

## Comparison of PR 2304 vs PR 2306

There are actually **two** related deprecations, both breaking in HA `2027.8.0`:
1. `device_registry.async_get_device(identifiers=...)` → replaced by `async_get_device_by_identifier(identifier, config_entry_id)` (confirmed at [`core-dev/homeassistant/helpers/device_registry.py:1999`](core-dev/homeassistant/helpers/device_registry.py:1999)).
2. `DeviceInfo(..., via_device=(...))` → replaced by `via_device_id` (confirmed at [`core-dev/homeassistant/helpers/device_registry.py:270`](core-dev/homeassistant/helpers/device_registry.py:270)).

PR 2304 only fixes #1; PR 2306 fixes both.

---

### PR 2304 (`2304_diff.txt`) — scoped lookup in `sensor.py`
Adds a **typed, single** helper and swaps the 3 lookup sites in `sensor.py` to use it, passing `entry.entry_id` as the scope.

| Strength | Detail |
|---|---|
| ✅ Typed | Proper `dr.DeviceRegistry` / `dr.DeviceEntry \| None` signatures, `Callable` cast for the dynamic lookup |
| ✅ DRY | Helper defined once |
| ✅ Correct identifier type | Uses `tuple[str, ...]` (accurate for 3-element tuples) |
| ✅ Regression test | AST-based test enforcing only one `async_get_device` remains (inside the helper), the scoped lookup is checked via `getattr`, and every call site passes `entry.entry_id` |

| Weakness | Detail |
|---|---|
| ❌ Incomplete | Does **not** fix the `via_device` deprecation |

---

### PR 2306 (`2306_diff.txt`) — scoped lookup **and** `via_device` → `via_device_id`
Adds a simpler helper (duplicated across `__init__.py`, `energy_dashboard.py`, `sensor.py`) and resolves `via_device_id` from the parent inverter device in all three files.

| Strength | Detail |
|---|---|
| ✅ Fixes both deprecations | Most complete fix |
| ✅ Correct `via_device_id` pattern | Resolves `via_device_id` when scoped API exists, else falls back to `via_device` |
| ✅ `hass is None` guard | Handles the non-HA code path in `create_energy_dashboard_device_info` |

| Weakness | Detail |
|---|---|
| ❌ Duplicated 3× | Violates DRY |
| ❌ Untyped | Everything is `Any`, losing type safety |
| ❌ Wrong annotation | Signature says `tuple[str, str]` but callers pass 3-element tuples |
| ❌ No regression test | |

---

### Head-to-head

| Criterion | PR 2304 | PR 2306 |
|---|---|---|
| Fixes `async_get_device` deprecation | ✅ | ✅ |
| Fixes `via_device` deprecation | ❌ | ✅ |
| Typing quality | ✅ Typed | ❌ All `Any` |
| Identifier type annotation | ✅ `tuple[str, ...]` | ❌ `tuple[str, str]` (wrong) |
| DRY | ✅ One helper | ❌ Duplicated 3× |
| Regression test | ✅ AST-based | ❌ None |
| Completeness | Partial | Full |

---

### Recommendation

The two PRs are **complementary, not alternatives**. The best fix combines them:

1. Adopt PR 2304's **typed, single** `_get_device_by_identifier` helper (place it in one shared module rather than duplicating it three times).
2. Adopt PR 2306's `via_device` → `via_device_id` resolution logic for `sensor.py` (battery device), `__init__.py` (`group_device_info`), and `energy_dashboard.py` (`create_energy_dashboard_device_info`), keeping the `hass is None` guard.
3. Keep PR 2304's AST-based regression test and extend it to also assert no `via_device=` keyword remains in the affected files.

Let me know if you'd like me to implement this combined fix into `homeassistant-solax-modbus/`.

---

**_I (@wills106) then asked ZooCode to implement the combined PR..._**

---

I implemented the combined fix that merges the strengths of both PRs (PR 2304's typed, DRY, tested helper + PR 2306's `via_device` → `via_device_id` resolution).

## What was done

**1. New shared, typed helper** — [`device_registry_lookup.py`](homeassistant-solax-modbus/custom_components/solax_modbus/device_registry_lookup.py)
- Single source of truth (fixes PR 2306's duplication problem).
- Fully typed (`DeviceRegistry`, `DeviceEntry | None`, `DeviceIdentifier = tuple[str, str, str]`).
- Prefers the scoped `async_get_device_by_identifier(identifier, config_entry_id)` on HA 2026.8+, transparently falling back to the legacy `async_get_device(identifiers=...)` on older versions.
- I caught and fixed a bug during testing: the fallback was wrapping a set inside a set (`{...}`), which is unhashable — corrected to build the set once.

**2. Wired into all 6 deprecated call sites:**
- [`sensor.py`](homeassistant-solax-modbus/custom_components/solax_modbus/sensor.py): 3 `async_get_device` lookups now use the scoped helper (scoped to `entry.entry_id`), plus the battery `via_device` → `via_device_id` resolution.
- [`__init__.py`](homeassistant-solax-modbus/custom_components/solax_modbus/__init__.py): `group_device_info` now resolves `via_device_id`.
- [`energy_dashboard.py`](homeassistant-solax-modbus/custom_components/solax_modbus/energy_dashboard.py): `create_energy_dashboard_device_info` resolves `via_device_id`, keeping the `hass is None` guard for the no-HA path.

**3. Regression test** — [`test_device_registry_deprecations.py`](homeassistant-solax-modbus/tests/unit/test_device_registry_deprecations.py)
- AST-based: asserts the only `async_get_device` reference is the intentional fallback, and no `DeviceInfo(...)` literal passes `via_device=`.
- Runtime: exercises both the scoped and legacy fallback branches of the helper.

## Verification
- All 5 new tests pass.
- Full suite: **517 passed**. The single `test_init.py::test_domain_constant` error is pre-existing (fails identically on the original code) — it requires the `hass` fixture from `pytest-homeassistant-custom-component`, which couldn't be installed because it depends on the C++-building `pyspeex-noise` and this environment has no C++ compiler/root.
- `ruff check` passes on all changed files.

## Note on the two PRs
The two PRs were complementary, not alternatives: PR 2304 fixed only the `async_get_device` deprecation (higher quality — typed, DRY, tested), while PR 2306 fixed both deprecations (more complete but lower quality — untyped, duplicated, wrong annotations, untested). The combined approach takes the best of each.


---

@rosenrot00 as you wrote #2304 and @SimoneB79 you wrote #2306 what are your  thoughts on this PR?
I wasn't expecting it to produce device_registry_lookup.py as neither of your PR's did so.
Has ZooCode just delivered a load of nonsense or does it make sense?