### PR TITLE
Fix Sofar BMS validation error handling and improve diagnostics

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -2184,7 +2184,7 @@ class SolaXModbusHub:
 
             if group.readFollowUp is not None:
                 if not await group.readFollowUp(previous_data, data):
-                    _LOGGER.warning("%s: device group validation failed; discarding polling snapshot", self._name)
+                    _LOGGER.warning("%s: device group validation failed; discarding this device group's snapshot", self._name)
                     return PollOutcome.DISCARDED
 
             self._commit_poll_snapshot(previous_data, data)

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -4224,11 +4224,6 @@ class battery_config(base_battery_config):
         return f"BMS: V{new_data[sw_version_key]}"
 
     async def check_battery_on_start(self, hub: Any, old_data: dict[str, Any], key_prefix: str, batt_nr: int, batt_pack_nr: int) -> bool:
-        if not self.batt_pack_serials.__contains__(batt_nr):
-            return False
-        if not self.batt_pack_serials[batt_nr].__contains__(batt_pack_nr):
-            return False
-
         faulty_nr = 0
         payload = faulty_nr << 12 | batt_pack_nr << 8 | batt_nr
         for _retry in range(0, 10):
@@ -4272,13 +4267,9 @@ class battery_config(base_battery_config):
                 "BMS validation after reading failed for battery %s pack %s: missing serial number (%s)", batt_nr, batt_pack_nr, serial_key
             )
             return False
-        expected_serial = self.batt_pack_serials.get(batt_nr, {}).get(batt_pack_nr)
-        if not expected_serial:
-            _LOGGER.warning("BMS validation after reading failed for battery %s pack %s: no registered serial number", batt_nr, batt_pack_nr)
-            return False
-        if serial != expected_serial:
-            _LOGGER.warning("BMS validation after reading failed for battery %s pack %s: serial number mismatch", batt_nr, batt_pack_nr)
-            return False
+        # Selection identifies the requested pack. A stored serial is device metadata,
+        # not a permanent validation constraint (packs can be replaced or reordered).
+        self.batt_pack_serials.setdefault(batt_nr, {})[batt_pack_nr] = serial
         return True
 
     async def _determine_bat_quantitys(self, hub: Any) -> None:

--- a/custom_components/solax_modbus/plugin_sofar.py
+++ b/custom_components/solax_modbus/plugin_sofar.py
@@ -4151,8 +4151,11 @@ class battery_config(base_battery_config):
                 address=self.bms_check_address,
                 count=1,
             )
-            if inverter_data is None or inverter_data.isError():
-                _LOGGER.warning("Cannot read BMS selection register 0x%x", self.bms_check_address)
+            if inverter_data is None:
+                _LOGGER.warning("No response from BMS selection register 0x%x", self.bms_check_address)
+                return None
+            if inverter_data.isError():
+                _LOGGER.warning("Modbus error reading BMS selection register 0x%x: %s", self.bms_check_address, inverter_data)
                 return None
 
             return int(convert_from_registers(inverter_data.registers[:1], DataType.UINT16, "big"))  # type: ignore[attr-defined]  # DataType enum dynamic
@@ -4229,47 +4232,54 @@ class battery_config(base_battery_config):
         faulty_nr = 0
         payload = faulty_nr << 12 | batt_pack_nr << 8 | batt_nr
         for _retry in range(0, 10):
-            inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=self.bms_check_address, count=1)
-            if inverter_data is not None and not inverter_data.isError():
-                read = convert_from_registers(inverter_data.registers[:1], DataType.UINT16, "big")  # type: ignore[attr-defined]  # DataType enum dynamic
-                ok = read == payload
-                if not ok:
-                    await asyncio.sleep(0.3)
-                else:
-                    return True
-
-            else:
-                _LOGGER.error("can't read batt check register")
+            selected_battery = await self._read_selected_battery(hub)
+            if selected_battery == payload:
+                return True
+            if selected_battery is not None:
+                await asyncio.sleep(0.3)
+        _LOGGER.warning(
+            "BMS validation before reading failed for battery %s pack %s: register 0x%x expected 0x%04x, last selection %s",
+            batt_nr,
+            batt_pack_nr,
+            self.bms_check_address,
+            payload,
+            f"0x{selected_battery:04x}" if selected_battery is not None else "unavailable",
+        )
         return False
 
     async def check_battery_on_end(
         self, hub: Any, old_data: dict[str, Any], new_data: dict[str, Any], key_prefix: str, batt_nr: int, batt_pack_nr: int
     ) -> bool:
-        # inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=0x9045, count=2)
-        # if not inverter_data.isError():
-        #     decoder = BinaryPayloadDecoder.fromRegisters(inverter_data.registers, byteorder=Endian.BIG)
-        #     batt_time = value_function_2byte_timestamp(decoder.decode_32bit_uint(), None, None)
-        #     _LOGGER.info(f"batt time: {batt_time}")
-
+        """Reject unverified pack data without turning a validation failure into a poll exception."""
         faulty_nr = 0
         compare_value = faulty_nr << 12 | batt_pack_nr << 8 | batt_nr
-        inverter_data = await hub.async_read_holding_registers(unit=hub._modbus_addr, address=self.bms_check_address, count=1)
-        if not inverter_data.isError():
-            if inverter_data is not None and not inverter_data.isError():
-                new_value = convert_from_registers(inverter_data.registers[:1], DataType.UINT16, "big")  # type: ignore[attr-defined]  # DataType enum dynamic
-                _LOGGER.debug("check_battery_on_end: 0x%x 0x%x", new_value, compare_value)
-            if new_value == compare_value:
-                serial_key = key_prefix + "pack_serial_number"
-                if not new_data.__contains__(serial_key):
-                    _LOGGER.info("batt pack serial not received %s", serial_key)
-                    return False
-                serial = new_data[serial_key]
-                _LOGGER.debug("batt pack serial: %s", serial)
-                return bool(serial == self.batt_pack_serials[batt_nr][batt_pack_nr])
-            else:
-                return False
+        selected_battery = await self._read_selected_battery(hub)
+        if selected_battery != compare_value:
+            _LOGGER.warning(
+                "BMS validation after reading failed for battery %s pack %s: register 0x%x expected 0x%04x, actual selection %s",
+                batt_nr,
+                batt_pack_nr,
+                self.bms_check_address,
+                compare_value,
+                f"0x{selected_battery:04x}" if selected_battery is not None else "unavailable",
+            )
+            return False
 
-        return False
+        serial_key = key_prefix + "pack_serial_number"
+        serial = new_data.get(serial_key)
+        if not serial:
+            _LOGGER.warning(
+                "BMS validation after reading failed for battery %s pack %s: missing serial number (%s)", batt_nr, batt_pack_nr, serial_key
+            )
+            return False
+        expected_serial = self.batt_pack_serials.get(batt_nr, {}).get(batt_pack_nr)
+        if not expected_serial:
+            _LOGGER.warning("BMS validation after reading failed for battery %s pack %s: no registered serial number", batt_nr, batt_pack_nr)
+            return False
+        if serial != expected_serial:
+            _LOGGER.warning("BMS validation after reading failed for battery %s pack %s: serial number mismatch", batt_nr, batt_pack_nr)
+            return False
+        return True
 
     async def _determine_bat_quantitys(self, hub: Any) -> None:
         try:

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -273,9 +273,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     if device is not None:
                         batt_pack_model = await battery_config.get_batt_pack_model(hub)
                         batt_pack_sw_version = await battery_config.get_batt_pack_sw_version(hub, new_data, key_prefix)
-                        dev_registry.async_update_device(device.id, sw_version=batt_pack_sw_version, model=batt_pack_model)
                     result = await battery_config.check_battery_on_end(hub, old_data, new_data, key_prefix, batt_nr, batt_pack_nr)
-                    return bool(result)
+                    if not result:
+                        return False
+                    if device is not None:
+                        batt_pack_serial = await battery_config.get_batt_pack_serial(hub, batt_nr, batt_pack_nr)
+                        old_serial = device.serial_number
+                        dev_registry.async_update_device(
+                            device.id, sw_version=batt_pack_sw_version, model=batt_pack_model, serial_number=batt_pack_serial
+                        )
+                        if old_serial != batt_pack_serial:
+                            _LOGGER.warning(
+                                "%s: Battery %s / Pack %s: serial number changed from %r to %r; device information updated",
+                                hub_name,
+                                batt_nr + 1,
+                                batt_pack_nr + 1,
+                                old_serial,
+                                batt_pack_serial,
+                            )
+                    return True
 
                 entityToList(
                     hub,

--- a/tests/unit/test_poll_snapshot.py
+++ b/tests/unit/test_poll_snapshot.py
@@ -9,6 +9,7 @@ import pytest
 
 from custom_components.solax_modbus import BlockReadResult, PendingWrite, SolaXModbusHub
 from custom_components.solax_modbus.const import REGISTER_U16, PollOutcome
+from custom_components.solax_modbus.plugin_sofar import battery_config
 
 
 def make_hub() -> Any:
@@ -382,6 +383,52 @@ async def test_cancelled_read_preparation_returns_skipped() -> None:
     assert result is PollOutcome.SKIPPED
     assert group.publish_updates is False
     hub.async_read_modbus_block.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", [None, TimeoutError("BMS read timed out")], ids=["no-response", "exception"])
+async def test_sofar_validation_failure_only_discards_pack_group(response: Any) -> None:
+    """A failed BMS check must not trigger global sleep/slowdown or suppress inverter updates."""
+    hub = make_hub()
+    hub._modbus_addr = 1
+    hub.async_read_holding_registers = AsyncMock(side_effect=[response])
+    config = battery_config(batt_pack_serials={0: {0: "PACK-0"}})
+
+    async def validate_pack(old_data: dict[str, Any], new_data: dict[str, Any]) -> bool:
+        return await config.check_battery_on_end(hub, old_data, new_data, "", 0, 0)
+
+    pack_group = make_group(follow_up=validate_pack)
+    inverter_group = make_group()
+    pack_sensor, inverter_sensor = Mock(), Mock()
+    pack_group.sensors = [pack_sensor]
+    inverter_group.sensors = [inverter_sensor]
+    pack_group.holdingBlocks = [SimpleNamespace(start=1)]
+    inverter_group.holdingBlocks = [SimpleNamespace(start=2)]
+    hub.data.update({"pack_power": 10, "inverter_power": 20, "sleep_none": 30, "sleep_zero": 40})
+    hub.sleepnone = ["sleep_none"]
+    hub.sleepzero = ["sleep_zero"]
+    hub.blocks_changed = False
+    hub.cyclecount = 1
+
+    async def read_block(data: dict[str, Any], block: Any, typ: str) -> BlockReadResult:
+        key = "pack_power" if block.start == 1 else "inverter_power"
+        data[key] = 100
+        return successful_block(key)
+
+    hub.async_read_modbus_block = read_block
+    interval_group = SimpleNamespace(device_groups={"pack": pack_group, "inverter": inverter_group})
+
+    outcome, updated_sensors = await hub._refresh_interval_group_once(interval_group)
+
+    assert outcome is PollOutcome.SUCCESS
+    assert updated_sensors == 1
+    assert hub.data["pack_power"] == 10
+    assert hub.data["inverter_power"] == 100
+    assert hub.data["sleep_none"] == 30
+    assert hub.data["sleep_zero"] == 40
+    assert hub.slowdown == 1
+    pack_sensor.modbus_data_updated.assert_not_called()
+    inverter_sensor.modbus_data_updated.assert_called_once_with()
 
 
 def test_snapshot_commit_preserves_concurrent_local_change() -> None:

--- a/tests/unit/test_sofar_battery_device_metadata.py
+++ b/tests/unit/test_sofar_battery_device_metadata.py
@@ -1,9 +1,13 @@
 """Exercise battery follow-up callbacks, including persistent device metadata."""
 
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from custom_components.solax_modbus import sensor
 from custom_components.solax_modbus.const import CONF_READ_BATTERY, DOMAIN
@@ -12,7 +16,9 @@ from custom_components.solax_modbus.plugin_sofar import battery_config
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("selection", [0, 0x0100, None], ids=["valid-pack", "wrong-pack", "unreadable-selection"])
-async def test_pack_metadata_updated_only_after_validation(monkeypatch, caplog, selection):
+async def test_pack_metadata_updated_only_after_validation(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, selection: int | None
+) -> None:
     """Keep device IDs, repair stale serials once, and preserve failed snapshots' metadata."""
     config = battery_config(
         number_strings=1,
@@ -21,19 +27,19 @@ async def test_pack_metadata_updated_only_after_validation(monkeypatch, caplog, 
     )
     devices = {f"battery_1_{i}": SimpleNamespace(id=f"pack-device-{i}", serial_number=f"OLD-{i}") for i in (1, 2)}
 
-    def update_device(device_id, **changes):
+    def update_device(device_id: str, **changes: Any) -> None:
         device = next(device for device in devices.values() if device.id == device_id)
         for key, value in changes.items():
             setattr(device, key, value)
 
     registry = SimpleNamespace(async_update_device=Mock(side_effect=update_device))
-    monkeypatch.setattr(sensor.dr, "async_get", lambda hass: registry)
+    monkeypatch.setattr(dr, "async_get", lambda hass: registry)
     monkeypatch.setattr(sensor, "get_device_by_identifier", lambda registry, identifier, entry_id: devices.get(identifier[2]))
-    callbacks = []
+    callbacks: list[Any] = []
     monkeypatch.setattr(sensor, "entityToList", lambda *args: callbacks.append(args[-1]))
     monkeypatch.setattr(sensor, "entityToListSingle", Mock())
 
-    async def select(hub, batt_nr, pack_nr):
+    async def select(hub: Any, batt_nr: int, pack_nr: int) -> bool:
         config.selected_batt_nr = batt_nr
         config.selected_batt_pack_nr = pack_nr
         return True
@@ -50,8 +56,8 @@ async def test_pack_metadata_updated_only_after_validation(monkeypatch, caplog, 
         plugin=SimpleNamespace(BATTERY_CONFIG=config, SENSOR_TYPES=[], ENERGY_DASHBOARD_MAPPING=None, plugin_manufacturer="Sofar"),
         async_read_holding_registers=AsyncMock(return_value=response),
     )
-    hass = SimpleNamespace(data={DOMAIN: {"Sofar": {"hub": hub}}})
-    entry = SimpleNamespace(data={}, options={"name": "Sofar", CONF_READ_BATTERY: True}, entry_id="entry")
+    hass = cast(HomeAssistant, SimpleNamespace(data={DOMAIN: {"Sofar": {"hub": hub}}}))
+    entry = cast(ConfigEntry, SimpleNamespace(data={}, options={"name": "Sofar", CONF_READ_BATTERY: True}, entry_id="entry"))
     assert await sensor.async_setup_entry(hass, entry, Mock())
     assert config.batt_pack_serials == {0: {0: "OLD-1", 1: "OLD-2"}}
 

--- a/tests/unit/test_sofar_battery_device_metadata.py
+++ b/tests/unit/test_sofar_battery_device_metadata.py
@@ -1,0 +1,76 @@
+"""Exercise battery follow-up callbacks, including persistent device metadata."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.solax_modbus import sensor
+from custom_components.solax_modbus.const import CONF_READ_BATTERY, DOMAIN
+from custom_components.solax_modbus.plugin_sofar import battery_config
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selection", [0, 0x0100, None], ids=["valid-pack", "wrong-pack", "unreadable-selection"])
+async def test_pack_metadata_updated_only_after_validation(monkeypatch, caplog, selection):
+    """Keep device IDs, repair stale serials once, and preserve failed snapshots' metadata."""
+    config = battery_config(
+        number_strings=1,
+        number_cels_in_parallel=2,
+        battery_sensor_key_prefix="battery_{batt-nr}_{pack-nr}_",
+    )
+    devices = {f"battery_1_{i}": SimpleNamespace(id=f"pack-device-{i}", serial_number=f"OLD-{i}") for i in (1, 2)}
+
+    def update_device(device_id, **changes):
+        device = next(device for device in devices.values() if device.id == device_id)
+        for key, value in changes.items():
+            setattr(device, key, value)
+
+    registry = SimpleNamespace(async_update_device=Mock(side_effect=update_device))
+    monkeypatch.setattr(sensor.dr, "async_get", lambda hass: registry)
+    monkeypatch.setattr(sensor, "get_device_by_identifier", lambda registry, identifier, entry_id: devices.get(identifier[2]))
+    callbacks = []
+    monkeypatch.setattr(sensor, "entityToList", lambda *args: callbacks.append(args[-1]))
+    monkeypatch.setattr(sensor, "entityToListSingle", Mock())
+
+    async def select(hub, batt_nr, pack_nr):
+        config.selected_batt_nr = batt_nr
+        config.selected_batt_pack_nr = pack_nr
+        return True
+
+    monkeypatch.setattr(config, "select_battery", select)
+    monkeypatch.setattr(config, "get_batt_pack_model", AsyncMock(return_value="BTS"))
+    monkeypatch.setattr(config, "get_batt_pack_sw_version", AsyncMock(return_value="V1"))
+    response = None if selection is None else SimpleNamespace(registers=[selection], isError=lambda: False)
+    hub = SimpleNamespace(
+        name="Sofar",
+        _modbus_addr=1,
+        device_info={},
+        rebuild_blocks=Mock(),
+        plugin=SimpleNamespace(BATTERY_CONFIG=config, SENSOR_TYPES=[], ENERGY_DASHBOARD_MAPPING=None, plugin_manufacturer="Sofar"),
+        async_read_holding_registers=AsyncMock(return_value=response),
+    )
+    hass = SimpleNamespace(data={DOMAIN: {"Sofar": {"hub": hub}}})
+    entry = SimpleNamespace(data={}, options={"name": "Sofar", CONF_READ_BATTERY: True}, entry_id="entry")
+    assert await sensor.async_setup_entry(hass, entry, Mock())
+    assert config.batt_pack_serials == {0: {0: "OLD-1", 1: "OLD-2"}}
+
+    follow_up = callbacks[1]
+    for _ in range(2):
+        assert await follow_up({}, {"battery_1_1_pack_serial_number": "NEW-1"}) is (selection == 0)
+
+    if selection == 0:
+        assert devices["battery_1_1"].serial_number == "NEW-1"
+        assert config.batt_pack_serials[0][0] == "NEW-1"
+        assert caplog.text.count("serial number changed from 'OLD-1' to 'NEW-1'") == 1
+        registry.async_update_device.assert_called_with("pack-device-1", sw_version="V1", model="BTS", serial_number="NEW-1")
+        # On the next integration setup, the registry supplies the corrected reference.
+        config.batt_pack_serials.clear()
+        assert await sensor.async_setup_entry(hass, entry, Mock())
+        assert config.batt_pack_serials[0][0] == "NEW-1"
+    else:
+        registry.async_update_device.assert_not_called()
+        assert devices["battery_1_1"].serial_number == "OLD-1"
+        assert config.batt_pack_serials[0][0] == "OLD-1"
+        assert "serial number changed" not in caplog.text
+    assert devices["battery_1_2"].serial_number == "OLD-2"

--- a/tests/unit/test_sofar_battery_selection.py
+++ b/tests/unit/test_sofar_battery_selection.py
@@ -1,6 +1,8 @@
 """Tests for SOFAR battery-pack selection."""
 
+import asyncio
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -62,3 +64,107 @@ async def test_select_battery_contains_rejected_write() -> None:
 
     assert config.selected_batt_nr is None
     assert config.selected_batt_pack_nr is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        (None, "No response from BMS selection register 0x9044"),
+        (SimpleNamespace(isError=lambda: True), "Modbus error reading BMS selection register 0x9044"),
+        (TimeoutError("read timed out"), "Cannot read BMS selection register 0x9044"),
+        (SimpleNamespace(registers=[], isError=lambda: False), "Cannot read BMS selection register 0x9044"),
+    ],
+    ids=["no-response", "modbus-error", "exception", "empty-response"],
+)
+async def test_end_validation_contains_read_failures(response: Any, message: str, caplog: pytest.LogCaptureFixture) -> None:
+    """An unreadable selection rejects the snapshot instead of raising a poll exception."""
+    config = battery_config(batt_pack_serials={0: {1: "PACK-1"}})
+    hub = make_hub()
+    hub.async_read_holding_registers.side_effect = [response]
+
+    assert await config.check_battery_on_end(hub, {}, {"pack_serial_number": "PACK-1"}, "", 0, 1) is False
+
+    assert message in caplog.text
+    assert "battery 0 pack 1: register 0x9044 expected 0x0100, actual selection unavailable" in caplog.text
+    hub.async_write_registers_single.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("selection", "new_data", "registered_serials", "message"),
+    [
+        (0, {"b1_pack_serial_number": "PACK-1"}, {0: {1: "PACK-1"}}, "expected 0x0100, actual selection 0x0000"),
+        (0x0100, {}, {0: {1: "PACK-1"}}, "missing serial number (b1_pack_serial_number)"),
+        (0x0100, {"b1_pack_serial_number": None}, {0: {1: "PACK-1"}}, "missing serial number"),
+        (0x0100, {"b1_pack_serial_number": "PACK-2"}, {0: {1: "PACK-1"}}, "serial number mismatch"),
+        (0x0100, {"b1_pack_serial_number": "PACK-1"}, {}, "no registered serial number"),
+    ],
+    ids=["wrong-pack", "missing-serial", "null-serial", "wrong-serial", "unregistered-pack"],
+)
+async def test_end_validation_reports_rejection_reason(
+    selection: int,
+    new_data: dict[str, Any],
+    registered_serials: dict[int, dict[int, str]],
+    message: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Keep pack identity checks and explain which one failed."""
+    config = battery_config(batt_pack_serials=registered_serials)
+    hub = make_hub(selection)
+
+    assert await config.check_battery_on_end(hub, {}, new_data, "b1_", 0, 1) is False
+
+    assert "BMS validation after reading failed for battery 0 pack 1" in caplog.text
+    assert message in caplog.text
+    hub.async_write_registers_single.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_end_validation_accepts_matching_pack_and_serial(caplog: pytest.LogCaptureFixture) -> None:
+    """Successful validation is unchanged and does not emit warnings."""
+    config = battery_config(batt_pack_serials={0: {1: "PACK-1"}})
+    hub = make_hub(0x0100)
+
+    assert await config.check_battery_on_end(hub, {}, {"b1_pack_serial_number": "PACK-1"}, "b1_", 0, 1) is True
+
+    hub.async_read_holding_registers.assert_awaited_once_with(unit=1, address=0x9044, count=1)
+    assert not caplog.records
+
+
+@pytest.mark.asyncio
+async def test_start_validation_retries_mismatched_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Preserve the existing selection retry delay."""
+    config = battery_config(batt_pack_serials={0: {1: "PACK-1"}})
+    hub = make_hub(0, 0x0100)
+    sleep = AsyncMock()
+    monkeypatch.setattr("custom_components.solax_modbus.plugin_sofar.asyncio.sleep", sleep)
+
+    assert await config.check_battery_on_start(hub, {}, "", 0, 1) is True
+
+    sleep.assert_awaited_once_with(0.3)
+    assert hub.async_read_holding_registers.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_start_validation_contains_read_exception(caplog: pytest.LogCaptureFixture) -> None:
+    """Exhausted selection reads skip the pack instead of raising."""
+    config = battery_config(batt_pack_serials={0: {1: "PACK-1"}})
+    hub = make_hub()
+    hub.async_read_holding_registers.side_effect = TimeoutError("read timed out")
+
+    assert await config.check_battery_on_start(hub, {}, "", 0, 1) is False
+
+    assert hub.async_read_holding_registers.await_count == 10
+    assert "BMS validation before reading failed for battery 0 pack 1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_validation_does_not_swallow_task_cancellation() -> None:
+    """Allow integration shutdown to cancel a pending BMS validation."""
+    config = battery_config(batt_pack_serials={0: {1: "PACK-1"}})
+    hub = make_hub()
+    hub.async_read_holding_registers.side_effect = asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await config.check_battery_on_end(hub, {}, {}, "", 0, 1)

--- a/tests/unit/test_sofar_battery_selection.py
+++ b/tests/unit/test_sofar_battery_selection.py
@@ -1,6 +1,7 @@
 """Tests for SOFAR battery-pack selection."""
 
 import asyncio
+from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -94,13 +95,11 @@ async def test_end_validation_contains_read_failures(response: Any, message: str
 @pytest.mark.parametrize(
     ("selection", "new_data", "registered_serials", "message"),
     [
-        (0, {"b1_pack_serial_number": "PACK-1"}, {0: {1: "PACK-1"}}, "expected 0x0100, actual selection 0x0000"),
+        (0, {"b1_pack_serial_number": "PACK-2"}, {0: {1: "PACK-1"}}, "expected 0x0100, actual selection 0x0000"),
         (0x0100, {}, {0: {1: "PACK-1"}}, "missing serial number (b1_pack_serial_number)"),
         (0x0100, {"b1_pack_serial_number": None}, {0: {1: "PACK-1"}}, "missing serial number"),
-        (0x0100, {"b1_pack_serial_number": "PACK-2"}, {0: {1: "PACK-1"}}, "serial number mismatch"),
-        (0x0100, {"b1_pack_serial_number": "PACK-1"}, {}, "no registered serial number"),
     ],
-    ids=["wrong-pack", "missing-serial", "null-serial", "wrong-serial", "unregistered-pack"],
+    ids=["wrong-pack", "missing-serial", "null-serial"],
 )
 async def test_end_validation_reports_rejection_reason(
     selection: int,
@@ -110,13 +109,28 @@ async def test_end_validation_reports_rejection_reason(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Keep pack identity checks and explain which one failed."""
-    config = battery_config(batt_pack_serials=registered_serials)
+    config = battery_config(batt_pack_serials=deepcopy(registered_serials))
     hub = make_hub(selection)
 
     assert await config.check_battery_on_end(hub, {}, new_data, "b1_", 0, 1) is False
 
     assert "BMS validation after reading failed for battery 0 pack 1" in caplog.text
     assert message in caplog.text
+    assert config.batt_pack_serials == registered_serials
+    hub.async_write_registers_single.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("registered_serials", [{0: {1: "OLD-PACK"}}, {}], ids=["replaced-pack", "unregistered-pack"])
+async def test_valid_selection_refreshes_serial_metadata(registered_serials: dict[int, dict[int, str]]) -> None:
+    """Old or absent device metadata must not block a correctly selected pack."""
+    config = battery_config(batt_pack_serials=registered_serials)
+    hub = make_hub(0x0100, 0x0100)
+
+    assert await config.check_battery_on_start(hub, {}, "b1_", 0, 1) is True
+    assert await config.check_battery_on_end(hub, {}, {"b1_pack_serial_number": "NEW-PACK"}, "b1_", 0, 1) is True
+    assert await config.get_batt_pack_serial(hub, 0, 1) == "NEW-PACK"
+    assert hub.async_read_holding_registers.await_count == 2
     hub.async_write_registers_single.assert_not_awaited()
 
 


### PR DESCRIPTION
Handle missing or failed BMS selection reads safely instead of raising exceptions during battery-pack validation.

Reuse the existing safe read helper for the checks before and after polling. Keep pack-selection and serial-number validation intact to prevent assigning data to the wrong pack.

Related to #2312. This addresses the error-handling defect and improves diagnosis; the reporter's underlying validation failure still needs confirmation.