### PR TITLE
Fix SolaX direct VPP register block writes

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -926,6 +926,10 @@ class SolaXModbusHub:
                     val = loaded.get(desc)
                     if val is not None:
                         self.data[desc] = val
+                    elif getattr(self.writeLocals[desc], "async_write_function", None) is not None:
+                        # Transactional controls must distinguish an unknown device
+                        # parameter from a default used for an explicit new command.
+                        self.data.setdefault(desc, None)
                     else:
                         self.data[desc] = self.writeLocals[desc].initvalue  # first time initialisation
             else:

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -328,6 +328,8 @@ class BaseModbusSelectEntityDescription(SelectEntityDescription):
     depends_on: list[str] | None = None  # list of modbus register keys that must be read
     value_function: Callable[[Any, Any, dict[str, Any]], Any] | None = None  # value function for autorepeat (same pattern as buttons)
     autorepeat: bool = False  # if True: select will use value_function for autorepeat
+    # Optional transactional writer: (hub, unit, description, raw value). Must raise on failure.
+    async_write_function: Callable[[Any, int, Any, int | float], Awaitable[None]] | None = None
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -411,6 +413,8 @@ class BaseModbusNumberEntityDescription(NumberEntityDescription):
     depends_on: list[str] | None = None  # list of modbus register keys that must be read
     display_as_box: bool = True  # display numbers as an input box (default); set False for a slider.
     suggested_display_precision: int | None = None
+    # Optional transactional writer: (hub, unit, description, raw value). Must raise on failure.
+    async_write_function: Callable[[Any, int, Any, int | float], Awaitable[None]] | None = None
 
 
 def modbus_protocol_version(hub: Any) -> int:

--- a/custom_components/solax_modbus/number.py
+++ b/custom_components/solax_modbus/number.py
@@ -286,7 +286,9 @@ class SolaXModbusNumber(NumberEntity):
         payload: int | float = value
         if self._fmt in ("i", "f"):
             payload = _scale_native_value_to_register(value, self._attr_scale, self.entity_description.read_scale)
-        if self._write_method == WRITE_MULTISINGLE_MODBUS:
+        if self.entity_description.async_write_function is not None:
+            await self.entity_description.async_write_function(self._hub, self._modbus_addr, self.entity_description, payload)
+        elif self._write_method == WRITE_MULTISINGLE_MODBUS:
             _LOGGER.info(
                 "writing %s %s number register %s value %s after div by readscale %s scale %s with mode %s",
                 self._platform_name,

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfTime,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory  # type: ignore[attr-defined]  # HA stubs incomplete
 
 from custom_components.solax_modbus.const import (  # type: ignore[attr-defined]  # UnitOfReactivePower conditionally exported
@@ -48,7 +49,6 @@ from custom_components.solax_modbus.const import (  # type: ignore[attr-defined]
     TIME_OPTIONS_SEPARATE_REGISTERS,
     WRITE_DATA_LOCAL,
     WRITE_MULTI_MODBUS,
-    WRITE_MULTISINGLE_MODBUS,
     WRITE_SINGLE_MODBUS,
     BaseModbusButtonEntityDescription,
     BaseModbusNumberEntityDescription,
@@ -346,6 +346,147 @@ class SolaXModbusTimeEntityDescription(BaseModbusTimeEntityDescription):
 
 
 # ====================================== Computed value functions  =================================================
+
+
+DIRECT_VPP_PARAMETER_MODES: dict[str, tuple[int, ...]] = {
+    "remote_control_target_set_type_direct": (1, 2, 3, 4, 5, 6, 7),
+    "remotecontrol_active_power_direct": (1,),
+    "remotecontrol_reactive_power_direct": (1,),
+    "remotecontrol_duration_direct": (1,),
+    "remotecontrol_target_soc_direct": (3,),
+    "remotecontrol_target_energy_direct": (2,),
+    "remotecontrol_charge_discharge_power_direct": (2, 3),
+    "remotecontrol_timeout_direct": (1, 2, 3, 4, 5, 6, 7),
+    "remotecontrol_push_mode_power_direct": (4,),
+    "power_control_mode_target_set_type_direct": (8, 9),
+    "remotecontrol_pv_power_limit_direct": (8, 9),
+    "remotecontrol_push_mode_power_8_9_direct": (8, 9),
+    "remotecontrol_duration_8_direct": (8,),
+    "remotecontrol_target_soc_9_direct": (9,),
+    "remotecontrol_timeout_8_9_direct": (8, 9),
+}
+
+
+def _direct_vpp_descriptions() -> dict[str, BaseModbusNumberEntityDescription | BaseModbusSelectEntityDescription]:
+    descriptions: dict[str, BaseModbusNumberEntityDescription | BaseModbusSelectEntityDescription] = {
+        description.key: description for description in NUMBER_TYPES if description.key in DIRECT_VPP_PARAMETER_MODES
+    }
+    descriptions.update((description.key, description) for description in SELECT_TYPES if description.key in DIRECT_VPP_PARAMETER_MODES)
+    return descriptions
+
+
+def build_direct_vpp_command(mode: int, data: dict[str, Any], *, allow_defaults: bool = True) -> tuple[int, list[tuple[str, int]]]:
+    """Build one complete direct VPP command, without starting an autorepeat loop.
+
+    SolaX requires FC16 over 0x7C..0x88 for modes 1..3 and 0x7C..0x8A
+    for modes 4..7, with unused fields zeroed. Modes 8/9 use 0xA0..0xA7.
+    https://kb.solaxpower.com/fr/solution/detail/828080819a0a88fa019a0a941afc01e7
+    """
+    if mode not in range(10):
+        raise HomeAssistantError(f"Unsupported direct VPP mode: {mode}")
+    if mode == 0:
+        # Disable through ModbusPowerControl, including when exiting mode 8/9.
+        # Do not require configured targets just to stop remote control.
+        return 0x7C, [(REGISTER_U16, 0)] * 13
+
+    descriptions = _direct_vpp_descriptions()
+
+    def value(key: str) -> int:
+        if mode not in DIRECT_VPP_PARAMETER_MODES[key]:
+            return 0
+        description = descriptions[key]
+        parameter = data.get(key)
+        if parameter is None and allow_defaults:
+            parameter = description.initvalue
+        if parameter is None:
+            if not allow_defaults:
+                raise HomeAssistantError(
+                    f"Direct VPP parameter '{description.name}' is unknown. "
+                    "Configure the direct VPP targets and select the mode before updating an already active command."
+                )
+            raise HomeAssistantError(f"Set '{description.name}' before enabling direct VPP mode {mode}")
+        if isinstance(description, BaseModbusSelectEntityDescription) and description.option_dict and isinstance(parameter, str):
+            raw_option = {label: raw for raw, label in description.option_dict.items()}.get(parameter)
+            if raw_option is not None:
+                parameter = raw_option
+        try:
+            return int(parameter)
+        except (TypeError, ValueError, OverflowError) as ex:
+            raise HomeAssistantError(f"Invalid direct VPP parameter '{description.name}': {parameter!r}") from ex
+
+    if mode in (8, 9):
+        return 0xA0, [
+            (REGISTER_U16, mode),
+            (REGISTER_U16, value("power_control_mode_target_set_type_direct")),
+            (REGISTER_U32, value("remotecontrol_pv_power_limit_direct")),
+            (REGISTER_S32, value("remotecontrol_push_mode_power_8_9_direct")),
+            (REGISTER_U16, value("remotecontrol_duration_8_direct" if mode == 8 else "remotecontrol_target_soc_9_direct")),
+            (REGISTER_U16, value("remotecontrol_timeout_8_9_direct")),
+        ]
+
+    payload = [
+        (REGISTER_U16, mode),
+        (REGISTER_U16, value("remote_control_target_set_type_direct")),
+        (REGISTER_S32, value("remotecontrol_active_power_direct")),
+        (REGISTER_S32, value("remotecontrol_reactive_power_direct")),
+        (REGISTER_U16, value("remotecontrol_duration_direct")),
+        (REGISTER_U16, value("remotecontrol_target_soc_direct")),
+        (REGISTER_U32, value("remotecontrol_target_energy_direct")),
+        (REGISTER_S32, value("remotecontrol_charge_discharge_power_direct")),
+        (REGISTER_U16, value("remotecontrol_timeout_direct")),
+    ]
+    if mode >= 4:
+        payload.append((REGISTER_S32, value("remotecontrol_push_mode_power_direct")))
+    return 0x7C, payload
+
+
+async def async_write_direct_vpp(
+    hub: Any,
+    unit: int,
+    description: BaseModbusNumberEntityDescription | BaseModbusSelectEntityDescription,
+    parameter: int | float,
+) -> None:
+    """Apply parameter edits immediately, but never activate a mode implicitly."""
+    is_parameter = description.key in DIRECT_VPP_PARAMETER_MODES
+    # Serialize the complete read/build/write transaction with other direct VPP
+    # changes and polling (including the existing autorepeat controllers).
+    async with hub._poll_data_lock:
+        if not hub.localsLoaded and (is_parameter or parameter != 0):
+            await hub._hass.async_add_executor_job(hub.loadLocalData)
+
+        if is_parameter:
+            hub._encode_write_value(parameter, description.register_data_type or REGISTER_U16, single_register=False)
+            # A select's optimistic state can outlive VPP's timeout. Ask the
+            # inverter instead, using the existing Modbus Power Control readback.
+            response = await hub.async_read_input_registers(unit=unit, address=0x100, count=1)
+            try:
+                valid_mode = response is not None and not response.isError() and len(response.registers) == 1 and response.registers[0] in range(10)
+            except (AttributeError, TypeError):
+                valid_mode = False
+            if not valid_mode:
+                raise HomeAssistantError("Cannot read the active SolaX VPP mode (input register 0x100); no VPP command was sent")
+            mode = int(response.registers[0])
+        else:
+            mode = int(parameter)
+
+        data = hub.data | {description.key: parameter}
+        if not is_parameter or mode in DIRECT_VPP_PARAMETER_MODES[description.key]:
+            address, payload = build_direct_vpp_command(mode, data, allow_defaults=not is_parameter)
+            await hub.async_write_registers_multi(unit=unit, address=address, payload=payload)
+            # Remember the complete successful command, including defaults from
+            # explicit activation, for later edits and Home Assistant restarts.
+            for key, field in _direct_vpp_descriptions().items():
+                if mode in DIRECT_VPP_PARAMETER_MODES[key]:
+                    hub.data[key] = data[key] if data.get(key) is not None else field.initvalue
+                    entity = hub.numberEntities.get(key) or hub.selectEntities.get(key)
+                    if entity is not None and entity.hass is not None and entity.enabled:
+                        entity.modbus_data_updated()
+            if mode != 0:
+                hub.localsUpdated = True
+
+        # Inactive-mode parameters are only prepared for the next explicit mode
+        # selection. A rejected write/read must not replace the accepted values.
+        hub.data[description.key] = parameter
 
 
 def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
@@ -2878,7 +3019,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         device_class=NumberDeviceClass.POWER,
         initvalue=0,
         # min_exceptions_minus=MAX_EXPORT,  # negative
-        write_method=WRITE_MULTI_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
         suggested_display_precision=0,
     ),
@@ -2894,7 +3036,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_unit_of_measurement=UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
         device_class=NumberDeviceClass.REACTIVE_POWER,
         initvalue=0,
-        write_method=WRITE_MULTI_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
         suggested_display_precision=0,
     ),
@@ -2910,7 +3053,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=28800,
         native_step=60,
         native_unit_of_measurement=UnitOfTime.SECONDS,
-        write_method=WRITE_SINGLE_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
         suggested_display_precision=0,
     ),
@@ -2924,14 +3068,15 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
-        write_method=WRITE_SINGLE_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
         suggested_display_precision=0,
     ),
     SolaxModbusNumberEntityDescription(
         name="Remotecontrol Target Energy (mode 2; direct)",
         key="remotecontrol_target_energy_direct",
-        register_data_type=REGISTER_S32,
+        register_data_type=REGISTER_U32,
         fmt="i",
         register=0x84,
         native_min_value=0,
@@ -2940,7 +3085,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=NumberDeviceClass.ENERGY,
         initvalue=0,
-        write_method=WRITE_MULTI_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
         suggested_display_precision=0,
     ),
@@ -2956,7 +3102,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=NumberDeviceClass.POWER,
         initvalue=0,
-        write_method=WRITE_MULTI_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
         suggested_display_precision=0,
     ),
@@ -2972,7 +3119,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=28800,
         native_step=60,
         native_unit_of_measurement=UnitOfTime.SECONDS,
-        write_method=WRITE_MULTISINGLE_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
         suggested_display_precision=0,
     ),
@@ -2988,7 +3136,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=NumberDeviceClass.POWER,
         initvalue=0,
-        write_method=WRITE_MULTI_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=AC | HYBRID | GEN4 | GEN5,
         suggested_display_precision=0,
     ),
@@ -3004,7 +3153,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=NumberDeviceClass.POWER,
         initvalue=15000,
-        write_method=WRITE_MULTI_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=HYBRID | GEN4,
         suggested_display_precision=0,
     ),
@@ -3020,7 +3170,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=NumberDeviceClass.POWER,
         initvalue=0,
-        write_method=WRITE_MULTI_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=HYBRID | GEN4,
         suggested_display_precision=0,
     ),
@@ -3036,7 +3187,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=28800,
         native_step=60,
         native_unit_of_measurement=UnitOfTime.SECONDS,
-        write_method=WRITE_MULTISINGLE_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=HYBRID | GEN4,
         suggested_display_precision=0,
     ),
@@ -3051,7 +3203,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
-        write_method=WRITE_MULTISINGLE_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=HYBRID | GEN4,
         suggested_display_precision=0,
     ),
@@ -3067,7 +3220,8 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         native_max_value=28800,
         native_step=60,
         native_unit_of_measurement=UnitOfTime.SECONDS,
-        write_method=WRITE_MULTISINGLE_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         allowedtypes=HYBRID | GEN4,
         suggested_display_precision=0,
     ),
@@ -3760,7 +3914,8 @@ SELECT_TYPES: Sequence["SolaxModbusSelectEntityDescription"] = [
         name="Modbus Power Control (direct)",
         key="modbus_power_control_direct",
         register=0x7C,
-        write_method=WRITE_MULTISINGLE_MODBUS,
+        write_method=WRITE_MULTI_MODBUS,
+        async_write_function=async_write_direct_vpp,
         option_dict={
             0: "Disabled",
             1: "Enable Power Control Mode",
@@ -3778,10 +3933,11 @@ SELECT_TYPES: Sequence["SolaxModbusSelectEntityDescription"] = [
         icon="mdi:transmission-tower",
     ),
     SolaxModbusSelectEntityDescription(
-        name="RemoteControl Target Set Type (mode 8/9; direct)",
+        name="RemoteControl Target Set Type (mode 1-7; direct)",
         key="remote_control_target_set_type_direct",
         register=0x7D,
-        write_method=WRITE_MULTISINGLE_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         option_dict={
             1: "Set",
             2: "Update",
@@ -3794,7 +3950,8 @@ SELECT_TYPES: Sequence["SolaxModbusSelectEntityDescription"] = [
         name="RemoteControl Power Control Mode (mode 8/9; direct)",
         key="remote_control_power_control_mode_direct",
         register=0xA0,
-        write_method=WRITE_MULTISINGLE_MODBUS,
+        write_method=WRITE_MULTI_MODBUS,
+        async_write_function=async_write_direct_vpp,
         option_dict={
             0: "Disabled",
             8: "Individual Setting - Duration Mode",
@@ -3808,7 +3965,8 @@ SELECT_TYPES: Sequence["SolaxModbusSelectEntityDescription"] = [
         name="Power Control Mode Target Set Type (mode 8/9; direct)",
         key="power_control_mode_target_set_type_direct",
         register=0xA1,
-        write_method=WRITE_MULTISINGLE_MODBUS,
+        write_method=WRITE_DATA_LOCAL,
+        async_write_function=async_write_direct_vpp,
         option_dict={
             1: "Set",
             2: "Update",

--- a/custom_components/solax_modbus/select.py
+++ b/custom_components/solax_modbus/select.py
@@ -196,7 +196,9 @@ class SolaXModbusSelect(SelectEntity):
         """Change the select option."""
         reverse_dict = self.entity_description.reverse_option_dict
         payload: Any = reverse_dict.get(option, None) if reverse_dict else None
-        if self._write_method == WRITE_MULTISINGLE_MODBUS:
+        if self.entity_description.async_write_function is not None:
+            await self.entity_description.async_write_function(self._hub, self._modbus_addr, self.entity_description, payload)
+        elif self._write_method == WRITE_MULTISINGLE_MODBUS:
             _LOGGER.info("writing %s select register %s value %s with method %s", self._platform_name, self._register, payload, self._write_method)
             await self._hub.async_write_registers_single(
                 unit=self._modbus_addr,
@@ -214,6 +216,7 @@ class SolaXModbusSelect(SelectEntity):
             )
         elif self._write_method == WRITE_DATA_LOCAL:
             _LOGGER.info("*** local data written %s: %s", self._key, payload)
+        if self._write_method == WRITE_DATA_LOCAL:
             self._hub.localsUpdated = True  # mark to save permanently
         self._hub.data[self._key] = option
         await self._hub.async_refresh_gated_entities()

--- a/docs/solax-direct-vpp.md
+++ b/docs/solax-direct-vpp.md
@@ -1,0 +1,53 @@
+# SolaX direct VPP controls
+
+The existing `(direct)` entities send one-shot VPP commands. They do not start
+the integration's autorepeat controller.
+
+## Operation
+
+1. Unlock the inverter as required by its firmware.
+2. Set the direct parameters for the desired mode.
+3. Select the direct VPP mode to send the complete command.
+
+While that mode is active, changing a relevant parameter immediately sends the
+complete command with the new value. There is no additional Apply button and
+no need to reselect the mode for each change. The selected **Set/Update** value
+is preserved; the inverter interprets target and duration updates according to
+that setting. In particular, **Set** may restart a target or duration.
+
+Before applying a parameter change, the integration reads the active mode from
+input register `0x0100`. It does not use the last selected mode as proof that VPP
+is still running. If VPP has ended, or the parameter belongs to another mode,
+the value is saved for the next explicit activation without sending a command.
+The mode 8 duration and mode 9 target SOC are stored separately even though
+they share register `0x00A6`.
+
+Parameters are persisted using the integration's existing local-data storage.
+Restarting Home Assistant does not start or repeat a VPP command.
+
+## First use after upgrading / externally activated VPP
+
+Earlier versions did not persist the direct parameters. If VPP is already
+running but the integration does not know all its parameters, an individual
+edit is rejected with an explanatory error. This prevents unknown companion
+values from being replaced with defaults. Configure the intended parameters
+with VPP disabled, then select the mode once to establish the complete command.
+Subsequent edits are applied immediately, including after a normal restart.
+
+An explicit mode selection uses the existing entity defaults for unspecified
+parameters. Mode 3 has no default target SOC: set it before enabling that mode.
+Disabling VPP does not require target parameters or a successful mode read.
+Read or write failures remain errors; rejected values are not saved as accepted.
+
+## Register blocks
+
+[SolaX's VPP documentation](https://kb.solaxpower.com/fr/solution/detail/828080819a0a88fa019a0a941afc01e7)
+requires complete FC16 commands for modes 1–7, including zeroes for unused fields:
+
+- Modes 1–3: `0x007C–0x0088` (13 registers).
+- Modes 4–7: `0x007C–0x008A` (15 registers).
+- Modes 8/9 use `0x00A0–0x00A7` (8 registers).
+
+The integration retains SolaX's low-word-first 32-bit encoding and the signed
+power values. Target energy and PV power limit are unsigned 32-bit values.
+These changes do not add support for new inverter models or firmware versions.

--- a/tests/unit/test_solax_direct_vpp.py
+++ b/tests/unit/test_solax_direct_vpp.py
@@ -1,0 +1,472 @@
+"""Regression tests for complete, one-shot SolaX direct VPP commands."""
+
+import asyncio
+import json
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.solax_modbus import SolaXModbusHub
+from custom_components.solax_modbus.const import (
+    WRITE_DATA_LOCAL,
+    WRITE_MULTI_MODBUS,
+    BaseModbusNumberEntityDescription,
+    BaseModbusSelectEntityDescription,
+)
+from custom_components.solax_modbus.number import SolaXModbusNumber
+from custom_components.solax_modbus.plugin_solax import (
+    DIRECT_VPP_PARAMETER_MODES,
+    NUMBER_TYPES,
+    SELECT_TYPES,
+    async_write_direct_vpp,
+    build_direct_vpp_command,
+)
+from custom_components.solax_modbus.select import SolaXModbusSelect
+from tests.unit.test_write_pipeline import make_hub
+
+
+def encode_command(mode: int, data: dict[str, Any]) -> tuple[int, list[int]]:
+    """Exercise the production encoder, including SolaX's low-word-first order."""
+    address, payload = build_direct_vpp_command(mode, data)
+    hub = make_hub()
+    hub.plugin.order32 = "little"
+    return address, hub._encode_multi_write_payload(payload)
+
+
+@pytest.fixture
+def parameters() -> dict[str, Any]:
+    """Populate even irrelevant fields so zero-padding cannot pass accidentally."""
+    return {
+        "remote_control_target_set_type_direct": "Update",
+        "remotecontrol_active_power_direct": -5000,
+        "remotecontrol_reactive_power_direct": -200,
+        "remotecontrol_duration_direct": 300,
+        "remotecontrol_target_soc_direct": 30,
+        "remotecontrol_target_energy_direct": 9000,
+        "remotecontrol_charge_discharge_power_direct": -4000,
+        "remotecontrol_timeout_direct": 600,
+        "remotecontrol_push_mode_power_direct": -1000,
+        "power_control_mode_target_set_type_direct": "Set",
+        "remotecontrol_pv_power_limit_direct": 15000,
+        "remotecontrol_push_mode_power_8_9_direct": -2000,
+        "remotecontrol_duration_8_direct": 3600,
+        "remotecontrol_target_soc_9_direct": 80,
+        "remotecontrol_timeout_8_9_direct": 120,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (1, [1, 2, 0xEC78, 0xFFFF, 0xFF38, 0xFFFF, 300, 0, 0, 0, 0, 0, 600]),
+        (2, [2, 2, 0, 0, 0, 0, 0, 0, 9000, 0, 0xF060, 0xFFFF, 600]),
+        (3, [3, 2, 0, 0, 0, 0, 0, 30, 0, 0, 0xF060, 0xFFFF, 600]),
+        (4, [4, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 600, 0xFC18, 0xFFFF]),
+        (5, [5, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 600, 0, 0]),
+        (6, [6, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 600, 0, 0]),
+        (7, [7, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 600, 0, 0]),
+    ],
+)
+def test_legacy_modes_write_complete_zero_padded_block(mode: int, expected: list[int], parameters: dict[str, Any]) -> None:
+    assert encode_command(mode, parameters) == (0x7C, expected)
+
+
+@pytest.mark.parametrize(("mode", "duration_or_soc"), [(8, 3600), (9, 80)])
+def test_individual_modes_write_separate_complete_block(mode: int, duration_or_soc: int, parameters: dict[str, Any]) -> None:
+    assert encode_command(mode, parameters) == (0xA0, [mode, 1, 15000, 0, 0xF830, 0xFFFF, duration_or_soc, 120])
+
+
+def test_disable_needs_no_target_values() -> None:
+    assert encode_command(0, {}) == (0x7C, [0] * 13)
+
+
+def test_soc_mode_requires_explicit_target() -> None:
+    with pytest.raises(HomeAssistantError, match="Target SOC.*before enabling"):
+        build_direct_vpp_command(3, {})
+
+
+def test_zero_soc_target_is_not_treated_as_missing() -> None:
+    _, words = encode_command(3, {"remotecontrol_target_soc_direct": 0})
+    assert words[7] == 0
+
+
+def test_defaults_come_from_existing_entity_descriptions() -> None:
+    assert encode_command(1, {}) == (0x7C, [1, 1, 0, 0, 0, 0, 60, 0, 0, 0, 0, 0, 0])
+
+
+def test_target_energy_is_unsigned_32_bit(parameters: dict[str, Any]) -> None:
+    parameters["remotecontrol_target_energy_direct"] = 0xFEDCBA98
+    _, words = encode_command(2, parameters)
+    assert words[8:10] == [0xBA98, 0xFEDC]
+
+
+@pytest.mark.parametrize("mode", [-1, 10, 65535])
+def test_unknown_modes_are_rejected(mode: int) -> None:
+    with pytest.raises(HomeAssistantError, match="Unsupported direct VPP mode"):
+        build_direct_vpp_command(mode, {})
+
+
+def test_irrelevant_invalid_parameter_does_not_block_other_modes() -> None:
+    assert len(encode_command(5, {"remotecontrol_target_soc_direct": "unavailable"})[1]) == 15
+
+
+def test_relevant_invalid_parameter_is_rejected() -> None:
+    with pytest.raises(HomeAssistantError, match="Invalid direct VPP parameter.*Target SOC"):
+        build_direct_vpp_command(3, {"remotecontrol_target_soc_direct": "unavailable"})
+
+
+def test_building_a_command_does_not_mutate_parameters(parameters: dict[str, Any]) -> None:
+    original = parameters.copy()
+    build_direct_vpp_command(1, parameters)
+    assert parameters == original
+
+
+def make_mode_select(key: str, data: dict[str, Any]) -> tuple[SolaXModbusSelect, Any]:
+    description = next(description for description in SELECT_TYPES if description.key == key)
+    assert description.option_dict is not None
+    description = replace(description, reverse_option_dict={label: raw for raw, label in description.option_dict.items()})
+    hub = make_direct_hub(data)
+    entity = SolaXModbusSelect("solax", hub, 1, {}, description)
+    entity.async_write_ha_state = Mock()  # type: ignore[method-assign]
+    return entity, hub
+
+
+def make_direct_hub(data: dict[str, Any], mode: int = 0) -> Any:
+    hub = make_hub()
+    hub.plugin.order32 = "little"
+    hub.data = data.copy()
+    hub._poll_data_lock = asyncio.Lock()
+    hub.localsLoaded = True
+    hub.localsUpdated = False
+    hub.numberEntities = {}
+    hub.selectEntities = {}
+    hub.async_write_registers_multi = AsyncMock()
+    hub.async_write_registers_single = AsyncMock()
+    hub.async_write_register = AsyncMock()
+    hub.async_read_input_registers = AsyncMock(return_value=SimpleNamespace(isError=lambda: False, registers=[mode]))
+    hub.async_refresh_gated_entities = AsyncMock()
+    return hub
+
+
+def make_number(key: str, hub: Any) -> SolaXModbusNumber:
+    description = next(description for description in NUMBER_TYPES if description.key == key)
+    entity = SolaXModbusNumber("solax", hub, 1, {}, description)
+    entity.async_write_ha_state = Mock()  # type: ignore[method-assign]
+    return entity
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("key", "mode"),
+    [("modbus_power_control_direct", mode) for mode in range(10)] + [("remote_control_power_control_mode_direct", mode) for mode in (0, 8, 9)],
+)
+async def test_mode_selection_sends_one_full_command(key: str, mode: int, parameters: dict[str, Any]) -> None:
+    entity, hub = make_mode_select(key, parameters)
+    assert entity.entity_description.option_dict is not None
+    option = entity.entity_description.option_dict[mode]
+    assert entity.entity_description.write_method == WRITE_MULTI_MODBUS
+
+    await entity.async_select_option(option)
+
+    address, payload = build_direct_vpp_command(mode, parameters)
+    hub.async_write_registers_multi.assert_awaited_once_with(unit=1, address=address, payload=payload)
+    hub.async_write_registers_single.assert_not_awaited()
+    assert hub.data[key] == option
+    assert entity.entity_description.value_function is None
+    assert entity.entity_description.autorepeat is False
+    assert hub.data == parameters | {key: option}
+
+
+@pytest.mark.asyncio
+async def test_failed_command_does_not_publish_selected_mode(parameters: dict[str, Any]) -> None:
+    key = "modbus_power_control_direct"
+    entity, hub = make_mode_select(key, parameters | {key: "Disabled"})
+    hub.async_write_registers_multi.side_effect = HomeAssistantError("write rejected")
+
+    with pytest.raises(HomeAssistantError, match="write rejected"):
+        await entity.async_select_option("Enable SOC Target Control Mode")
+
+    assert hub.data[key] == "Disabled"
+    hub.async_refresh_gated_entities.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_required_parameter_prevents_any_write() -> None:
+    entity, hub = make_mode_select("modbus_power_control_direct", {})
+
+    with pytest.raises(HomeAssistantError, match="Target SOC.*before enabling"):
+        await entity.async_select_option("Enable SOC Target Control Mode")
+
+    hub.async_write_registers_multi.assert_not_awaited()
+    assert hub.data == {}
+
+
+@pytest.mark.parametrize("key", list(DIRECT_VPP_PARAMETER_MODES))
+def test_all_direct_parameters_use_transactional_writer_and_persistence(key: str) -> None:
+    descriptions: list[BaseModbusNumberEntityDescription | BaseModbusSelectEntityDescription] = list(NUMBER_TYPES)
+    descriptions.extend(SELECT_TYPES)
+    description = next(description for description in descriptions if description.key == key)
+    assert description.async_write_function is async_write_direct_vpp
+    assert description.write_method == WRITE_DATA_LOCAL
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("key", "mode", "new_value"),
+    [
+        ("remotecontrol_active_power_direct", 1, -2000),
+        ("remotecontrol_reactive_power_direct", 1, -300),
+        ("remotecontrol_duration_direct", 1, 120),
+        ("remotecontrol_target_soc_direct", 3, 0),
+        ("remotecontrol_target_energy_direct", 2, 2000),
+        ("remotecontrol_charge_discharge_power_direct", 2, 3000),
+        ("remotecontrol_charge_discharge_power_direct", 3, -3000),
+        ("remotecontrol_timeout_direct", 5, 300),
+        ("remotecontrol_push_mode_power_direct", 4, -5000),
+        ("remotecontrol_pv_power_limit_direct", 8, 0),
+        ("remotecontrol_push_mode_power_8_9_direct", 9, -5000),
+        ("remotecontrol_duration_8_direct", 8, 7200),
+        ("remotecontrol_target_soc_9_direct", 9, 90),
+        ("remotecontrol_timeout_8_9_direct", 8, 240),
+    ],
+)
+async def test_active_parameter_change_immediately_sends_complete_command(key: str, mode: int, new_value: int, parameters: dict[str, Any]) -> None:
+    hub = make_direct_hub(parameters, mode)
+    entity = make_number(key, hub)
+
+    await entity.async_set_native_value(new_value)
+
+    address, payload = build_direct_vpp_command(mode, parameters | {key: new_value})
+    hub.async_read_input_registers.assert_awaited_once_with(unit=1, address=0x100, count=1)
+    hub.async_write_registers_multi.assert_awaited_once_with(unit=1, address=address, payload=payload)
+    hub.async_write_registers_single.assert_not_awaited()
+    hub.async_write_register.assert_not_awaited()
+    assert hub.data == parameters | {key: new_value}
+    assert hub.localsUpdated is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("key", "mode"),
+    [("remote_control_target_set_type_direct", 2), ("power_control_mode_target_set_type_direct", 8)],
+)
+async def test_target_set_type_changes_immediately_and_is_not_overridden(key: str, mode: int, parameters: dict[str, Any]) -> None:
+    entity, hub = make_mode_select(key, parameters)
+    hub.async_read_input_registers.return_value.registers = [mode]
+
+    await entity.async_select_option("Update")
+
+    address, payload = build_direct_vpp_command(mode, parameters | {key: "Update"})
+    hub.async_write_registers_multi.assert_awaited_once_with(unit=1, address=address, payload=payload)
+    assert hub.data[key] == "Update"
+    assert hub.localsUpdated is True
+
+
+@pytest.mark.asyncio
+async def test_stale_mode_select_cannot_reactivate_expired_vpp(parameters: dict[str, Any]) -> None:
+    parameters["modbus_power_control_direct"] = "Enable Power Control Mode"
+    hub = make_direct_hub(parameters, mode=0)
+    entity = make_number("remotecontrol_active_power_direct", hub)
+
+    await entity.async_set_native_value(2000)
+
+    hub.async_write_registers_multi.assert_not_awaited()
+    assert hub.data[entity.entity_description.key] == 2000
+    assert hub.localsUpdated is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("key", "mode"),
+    [("remotecontrol_duration_8_direct", 9), ("remotecontrol_target_soc_9_direct", 8), ("remotecontrol_active_power_direct", 4)],
+)
+async def test_irrelevant_parameter_does_not_resend_or_switch_active_mode(key: str, mode: int, parameters: dict[str, Any]) -> None:
+    hub = make_direct_hub(parameters, mode)
+    entity = make_number(key, hub)
+
+    await entity.async_set_native_value(50)
+
+    hub.async_write_registers_multi.assert_not_awaited()
+    assert hub.data == parameters | {key: 50}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        SimpleNamespace(isError=lambda: True, registers=[1]),
+        SimpleNamespace(isError=lambda: False, registers=[]),
+        SimpleNamespace(isError=lambda: False, registers=[1, 2]),
+        SimpleNamespace(isError=lambda: False, registers=[10]),
+        SimpleNamespace(isError=lambda: False, registers=[65535]),
+        object(),
+    ],
+)
+async def test_unknown_active_mode_fails_without_write_or_cache_change(response: Any, parameters: dict[str, Any]) -> None:
+    hub = make_direct_hub(parameters)
+    hub.async_read_input_registers.return_value = response
+    entity = make_number("remotecontrol_active_power_direct", hub)
+
+    with pytest.raises(HomeAssistantError, match="Cannot read the active.*0x100"):
+        await entity.async_set_native_value(1000)
+
+    hub.async_write_registers_multi.assert_not_awaited()
+    assert hub.data == parameters
+    assert hub.localsUpdated is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_active_command_is_not_overwritten_with_defaults() -> None:
+    hub = make_direct_hub({}, mode=1)
+    entity = make_number("remotecontrol_active_power_direct", hub)
+
+    with pytest.raises(HomeAssistantError, match="parameter.*unknown"):
+        await entity.async_set_native_value(1000)
+
+    hub.async_write_registers_multi.assert_not_awaited()
+    assert hub.data == {}
+
+
+@pytest.mark.asyncio
+async def test_failed_parameter_write_preserves_all_previous_values(parameters: dict[str, Any]) -> None:
+    hub = make_direct_hub(parameters, mode=3)
+    hub.async_write_registers_multi.side_effect = HomeAssistantError("write rejected")
+    entity = make_number("remotecontrol_target_soc_direct", hub)
+
+    with pytest.raises(HomeAssistantError, match="write rejected"):
+        await entity.async_set_native_value(75)
+
+    assert hub.data == parameters
+    assert hub.localsUpdated is False
+
+
+@pytest.mark.asyncio
+async def test_successful_activation_remembers_defaults_for_immediate_updates() -> None:
+    select, hub = make_mode_select("modbus_power_control_direct", {})
+    await select.async_select_option("Enable Power Control Mode")
+    assert hub.data["remotecontrol_duration_direct"] == 60
+    assert hub.data["remotecontrol_reactive_power_direct"] == 0
+    hub.async_read_input_registers.return_value.registers = [1]
+    hub.async_write_registers_multi.reset_mock()
+    number = make_number("remotecontrol_active_power_direct", hub)
+
+    await number.async_set_native_value(-1000)
+
+    hub.async_write_registers_multi.assert_awaited_once()
+    assert hub.data["remotecontrol_active_power_direct"] == -1000
+
+
+@pytest.mark.asyncio
+async def test_concurrent_changes_keep_both_new_values(parameters: dict[str, Any]) -> None:
+    hub = make_direct_hub(parameters, mode=1)
+    first_write_started = asyncio.Event()
+    finish_first_write = asyncio.Event()
+    writes: list[list[tuple[str, int]]] = []
+
+    async def write(*, unit: int, address: int, payload: list[tuple[str, int]]) -> None:
+        writes.append(payload)
+        if len(writes) == 1:
+            first_write_started.set()
+            await finish_first_write.wait()
+
+    hub.async_write_registers_multi.side_effect = write
+    active = make_number("remotecontrol_active_power_direct", hub)
+    reactive = make_number("remotecontrol_reactive_power_direct", hub)
+    first = asyncio.create_task(active.async_set_native_value(1000))
+    await first_write_started.wait()
+    second = asyncio.create_task(reactive.async_set_native_value(500))
+    finish_first_write.set()
+    await asyncio.gather(first, second)
+
+    expected_data = parameters | {"remotecontrol_active_power_direct": 1000, "remotecontrol_reactive_power_direct": 500}
+    assert writes[-1] == build_direct_vpp_command(1, expected_data)[1]
+    assert hub.data == expected_data
+
+
+def configure_local_storage(hub: Any, tmp_path: Path) -> None:
+    hub.writeLocals = {
+        description.key: description for description in (*NUMBER_TYPES, *SELECT_TYPES) if description.key in DIRECT_VPP_PARAMETER_MODES
+    }
+    hub._hass = SimpleNamespace(config=SimpleNamespace(path=lambda name: str(tmp_path / name)))
+    hub.plugin.localDataCallback = Mock()
+    hub.cyclecount = 10
+
+
+def test_parameters_are_restored_but_no_mode_is_restored_or_reactivated(parameters: dict[str, Any], tmp_path: Path) -> None:
+    hub = make_direct_hub(parameters | {"modbus_power_control_direct": "Enable Power Control Mode"})
+    configure_local_storage(hub, tmp_path)
+    hub.saveLocalData()
+    restored = make_direct_hub({})
+    configure_local_storage(restored, tmp_path)
+
+    restored.loadLocalData()
+
+    assert restored.data == parameters
+    assert restored.localsLoaded is True
+    restored.async_write_registers_multi.assert_not_awaited()
+
+
+def test_existing_local_file_does_not_invent_unknown_direct_parameters(tmp_path: Path) -> None:
+    hub = make_direct_hub({})
+    configure_local_storage(hub, tmp_path)
+    (tmp_path / "test_data.json").write_text(json.dumps({"_version": hub.DATAFORMAT_VERSION}))
+
+    hub.loadLocalData()
+
+    assert hub.data["remotecontrol_active_power_direct"] is None
+    assert hub.data["remotecontrol_duration_direct"] is None
+
+
+@pytest.mark.asyncio
+async def test_disable_does_not_need_local_storage_or_mode_read() -> None:
+    entity, hub = make_mode_select("modbus_power_control_direct", {})
+    hub.localsLoaded = False
+    hub._hass = SimpleNamespace(async_add_executor_job=AsyncMock(side_effect=AssertionError("must not load parameters")))
+
+    await entity.async_select_option("Disabled")
+
+    hub.async_read_input_registers.assert_not_awaited()
+    hub.async_write_registers_multi.assert_awaited_once_with(unit=1, address=0x7C, payload=build_direct_vpp_command(0, {})[1])
+    assert hub.localsUpdated is False
+
+
+@pytest.mark.asyncio
+async def test_invalid_parameter_is_not_even_staged_while_disabled() -> None:
+    hub = make_direct_hub({})
+    entity = make_number("remotecontrol_pv_power_limit_direct", hub)
+
+    with pytest.raises(HomeAssistantError, match="outside"):
+        await entity.async_set_native_value(-1)
+
+    assert hub.data == {}
+    hub.async_write_registers_multi.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_activation_updates_companion_entity_states() -> None:
+    entity, hub = make_mode_select("modbus_power_control_direct", {})
+    duration = Mock()
+    hub.numberEntities["remotecontrol_duration_direct"] = duration
+
+    await entity.async_select_option("Enable Power Control Mode")
+
+    duration.modbus_data_updated.assert_called_once()
+    assert hub.data["remotecontrol_duration_direct"] == 60
+
+
+@pytest.mark.asyncio
+async def test_parameter_update_reaches_transport_as_one_complete_fc16_write(parameters: dict[str, Any]) -> None:
+    hub = make_direct_hub(parameters, mode=3)
+    hub.async_write_registers_multi = SolaXModbusHub.async_write_registers_multi.__get__(hub)
+    hub._transport.write = AsyncMock(return_value=SimpleNamespace(isError=lambda: False))
+    entity = make_number("remotecontrol_charge_discharge_power_direct", hub)
+
+    await entity.async_set_native_value(-4000)
+
+    hub._transport.write.assert_awaited_once_with(1, 0x7C, [3, 2, 0, 0, 0, 0, 0, 30, 0, 0, 0xF060, 0xFFFF, 600], multiple=True)


### PR DESCRIPTION
Send complete, mode-specific FC16 register blocks for SolaX direct VPP controls instead of individual register writes.

Parameter changes continue to apply immediately while the relevant mode is active. Read the current inverter mode before updates to avoid reactivating expired commands. Preserve the selected Set/Update behavior and leave autorepeat controls unchanged.

Addresses #2302