### PR TITLE
Fix Growatt TSS APX battery module and BMS1 register mappings

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -94,11 +94,11 @@ MPPT8 = 0x200000
 MPPT10 = 0x400000
 ALL_MPPT_GROUP = MPPT3 | MPPT4 | MPPT6 | MPPT8 | MPPT10
 
-# DLP MID 30KTL3-XH units expose BMS1 module 1 through the APX input-register block.
+# Select the APX input-register block for BMS1 module 1 on DLP and TSS units.
 APX_BMS_INPUT = 0x800000
 ALL_APX_BMS_REGISTER_GROUP = APX_BMS_INPUT
 
-APX_BMS_INPUT_SERIAL_PREFIXES = ["DLP"]
+APX_BMS_INPUT_SERIAL_PREFIXES = ["DLP", "TSS"]
 
 ALLDEFAULT = 0  # should be equivalent to HYBRID | AC | GEN | GEN2 | GEN3 | GEN4 | X1 | X3
 
@@ -9219,7 +9219,7 @@ APX_BMS1_MODULE1_INPUT_REGISTERS = {
 }
 
 # Keep the established 588x holding-register descriptions for other Growatt models,
-# and create a DLP-only 508x input-register variant from the same metadata.
+# and create a 508x input-register variant for APX_BMS_INPUT models from the same metadata.
 SENSOR_TYPES.extend(
     replace(
         description,
@@ -9730,7 +9730,7 @@ SERIAL_PREFIX_TYPES = {
     "DKS": HYBRID | GEN4 | X3 | MPPT3,  # MOD 10000 TL3-HU Hybrid, 3 MPPT
     "DO1": HYBRID | GEN4 | X3 | MPPT3,  # MOD 12000 TL3-HU Hybrid, 3 MPPT
     "TTS": HYBRID | GEN4 | X3 | MPPT3,  # Hybrid KTL3-HU 12kW
-    "TSS": HYBRID | GEN4 | X3 | MPPT3,  # Hybrid KTL3-HU 12kW
+    "TSS": HYBRID | GEN4 | X3 | MPPT3 | APX_BMS_INPUT,  # Hybrid KTL3-HU 12kW
     "PYL": HYBRID | GEN4 | X3,  # MOD 5000 TL3-XH Hybrid, 2 MPPT
     "JCM": HYBRID | GEN4 | X3,  # MOD 6000 TL3-XH Hybrid, 2 MPPT
     "MEK": HYBRID | GEN4 | X3,  # MOD 7000 TL3-XH Hybrid, 2 MPPT

--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -96,7 +96,9 @@ ALL_MPPT_GROUP = MPPT3 | MPPT4 | MPPT6 | MPPT8 | MPPT10
 
 # Select the APX input-register block for BMS1 module 1 on DLP and TSS units.
 APX_BMS_INPUT = 0x800000
-ALL_APX_BMS_REGISTER_GROUP = APX_BMS_INPUT
+# TSS units use the BDC1 input block for the aggregate battery sensors.
+TSS_BMS_INPUT = 0x1000000
+ALL_APX_BMS_REGISTER_GROUP = APX_BMS_INPUT | TSS_BMS_INPUT
 
 APX_BMS_INPUT_SERIAL_PREFIXES = ["DLP", "TSS"]
 
@@ -6673,6 +6675,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         register=5769,  # maybe 5768 and U32
+        blacklist=["TSS"],
         register_type=REG_INPUT,
         register_data_type=REGISTER_U16,  ## maybe U32 if reg is 5768
         scale=0.1,
@@ -6687,6 +6690,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         register=5777,
+        blacklist=["TSS"],
         register_type=REG_INPUT,
         register_data_type=REGISTER_U16,
         allowedtypes=GEN4 | HYBRID,
@@ -6700,6 +6704,7 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         register=5778,
+        blacklist=["TSS"],
         register_type=REG_INPUT,
         register_data_type=REGISTER_U16,
         allowedtypes=GEN4 | HYBRID,
@@ -9205,6 +9210,28 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
     ),
 ]
 
+# Protocol II V1.39: BDC1 input 4008-4076 mirrors input 3165-3233.
+# BMS_SOC (3215) -> 4058; BMS_SOH (3222) -> 4065;
+# Edischr_total H/L (3182/3183) -> 4025/4026, unsigned 32-bit, 0.1 kWh.
+# Keep this mapping scoped to TSS while it is being verified on MOD KTL3-HU.
+TSS_BMS1_INPUT_REGISTERS = {
+    "bms_1_soc": (4058, REGISTER_U16),
+    "bms_1_soh": (4065, REGISTER_U16),
+    "bms_1_toe": (4025, REGISTER_U32),
+}
+
+SENSOR_TYPES.extend(
+    replace(
+        description,
+        register=TSS_BMS1_INPUT_REGISTERS[description.key][0],
+        register_data_type=TSS_BMS1_INPUT_REGISTERS[description.key][1],
+        allowedtypes=description.allowedtypes | TSS_BMS_INPUT,
+        blacklist=None,
+    )
+    for description in tuple(SENSOR_TYPES)
+    if description.key in TSS_BMS1_INPUT_REGISTERS
+)
+
 APX_BMS1_MODULE1_INPUT_REGISTERS = {
     "bms_1_module_1_status": 5080,
     "bms_1_module_1_soh": 5082,
@@ -9730,7 +9757,7 @@ SERIAL_PREFIX_TYPES = {
     "DKS": HYBRID | GEN4 | X3 | MPPT3,  # MOD 10000 TL3-HU Hybrid, 3 MPPT
     "DO1": HYBRID | GEN4 | X3 | MPPT3,  # MOD 12000 TL3-HU Hybrid, 3 MPPT
     "TTS": HYBRID | GEN4 | X3 | MPPT3,  # Hybrid KTL3-HU 12kW
-    "TSS": HYBRID | GEN4 | X3 | MPPT3 | APX_BMS_INPUT,  # Hybrid KTL3-HU 12kW
+    "TSS": HYBRID | GEN4 | X3 | MPPT3 | APX_BMS_INPUT | TSS_BMS_INPUT,  # Hybrid KTL3-HU 12kW
     "PYL": HYBRID | GEN4 | X3,  # MOD 5000 TL3-XH Hybrid, 2 MPPT
     "JCM": HYBRID | GEN4 | X3,  # MOD 6000 TL3-XH Hybrid, 2 MPPT
     "MEK": HYBRID | GEN4 | X3,  # MOD 7000 TL3-XH Hybrid, 2 MPPT

--- a/tests/unit/test_growatt_apx_module_registers.py
+++ b/tests/unit/test_growatt_apx_module_registers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from custom_components.solax_modbus.const import REG_HOLDING, REG_INPUT
+from custom_components.solax_modbus.const import REG_HOLDING, REG_INPUT, REGISTER_U16, REGISTER_U32
 from custom_components.solax_modbus.plugin_growatt import (
     SENSOR_TYPES,
     SERIAL_PREFIX_TYPES,
@@ -64,3 +64,33 @@ def test_other_models_bms1_module1_keep_holding_registers(serial_number: str) ->
         description = descriptions[key]
         assert description.register == register
         assert description.register_type == REG_HOLDING
+
+
+@pytest.mark.parametrize("prefix", list(SERIAL_PREFIX_TYPES))
+def test_bms1_aggregate_registers_are_scoped_to_tss(prefix: str) -> None:
+    expected = {
+        "bms_1_soc": (4058 if prefix == "TSS" else 5777, REGISTER_U16, 1),
+        "bms_1_soh": (4065 if prefix == "TSS" else 5778, REGISTER_U16, 1),
+        "bms_1_toe": (4025 if prefix == "TSS" else 5769, REGISTER_U32 if prefix == "TSS" else REGISTER_U16, 0.1),
+    }
+    inverter_type = SERIAL_PREFIX_TYPES[prefix]
+    for key, (register, data_type, scale) in expected.items():
+        candidates = [description for description in SENSOR_TYPES if description.key == key]
+        original = next(description for description in candidates if description.register in (5769, 5777, 5778))
+        was_supported = plugin_instance.matchInverterWithMask(inverter_type, original.allowedtypes)
+        matching = [
+            description
+            for description in candidates
+            if plugin_instance.matchInverterWithMask(inverter_type, description.allowedtypes, prefix + "0F4L1234", description.blacklist)
+        ]
+        assert len(matching) == int(was_supported)
+        if not was_supported:
+            continue
+        description = matching[0]
+        assert description.register == register
+        assert description.register_type == REG_INPUT
+        assert description.register_data_type == data_type
+        assert description.scale == scale
+        assert description.name == original.name
+        assert description.state_class == original.state_class
+        assert description.entity_registry_enabled_default == original.entity_registry_enabled_default

--- a/tests/unit/test_growatt_apx_module_registers.py
+++ b/tests/unit/test_growatt_apx_module_registers.py
@@ -1,3 +1,5 @@
+import pytest
+
 from custom_components.solax_modbus.const import REG_HOLDING, REG_INPUT
 from custom_components.solax_modbus.plugin_growatt import (
     SENSOR_TYPES,
@@ -20,7 +22,8 @@ def _matching_module1_descriptions(serial_number: str) -> dict[str, GrowattModbu
     return descriptions
 
 
-def test_dlp_bms1_module1_uses_apx_input_registers() -> None:
+@pytest.mark.parametrize("serial_number", ["DLP1234567", "TSS0F4L1234"])
+def test_apx_bms1_module1_uses_input_registers(serial_number: str) -> None:
     expected_input_registers = {
         "bms_1_module_1_status": 5080,
         "bms_1_module_1_soh": 5082,
@@ -33,7 +36,7 @@ def test_dlp_bms1_module1_uses_apx_input_registers() -> None:
         "bms_1_module_1_warning_text": 5098,
         "bms_1_module_1_charge_cycles": 5108,
     }
-    descriptions = _matching_module1_descriptions("DLP1234567")
+    descriptions = _matching_module1_descriptions(serial_number)
 
     for key, register in expected_input_registers.items():
         description = descriptions[key]
@@ -41,7 +44,8 @@ def test_dlp_bms1_module1_uses_apx_input_registers() -> None:
         assert description.register_type == REG_INPUT
 
 
-def test_jcm_bms1_module1_keeps_holding_registers() -> None:
+@pytest.mark.parametrize("serial_number", ["JCM0D12345", "TTS1234567", "DKS1234567"])
+def test_other_models_bms1_module1_keep_holding_registers(serial_number: str) -> None:
     expected_holding_registers = {
         "bms_1_module_1_status": 5880,
         "bms_1_module_1_soh": 5882,
@@ -54,7 +58,7 @@ def test_jcm_bms1_module1_keeps_holding_registers() -> None:
         "bms_1_module_1_warning_text": 5898,
         "bms_1_module_1_charge_cycles": 5908,
     }
-    descriptions = _matching_module1_descriptions("JCM0D12345")
+    descriptions = _matching_module1_descriptions(serial_number)
 
     for key, register in expected_holding_registers.items():
         description = descriptions[key]


### PR DESCRIPTION
Growatt MOD KTL3-HU inverters with the TSS serial prefix report incorrect APX battery module values and zero BMS1 totals because the integration reads the wrong registers.

- Extend the existing APX module input-register mapping to TSS models. The reporter confirmed plausible module values with this change.
- Map BMS1 SoC to input 4058, SoH to 4065, and total discharge energy to 4025–4026 as an unsigned 32-bit value scaled by 0.1 kWh.
- Preserve existing entity IDs and mappings for other models.

The BMS1 aggregate mapping follows Protocol II V1.39 and still needs confirmation on the reporter’s hardware.

Includes regression tests for model-specific register selection.

Related to #2310.