### PR TITLE
Correct PV charger current sensor names for Growatt SPF models

### DIFF
--- a/custom_components/solax_modbus/plugin_growatt.py
+++ b/custom_components/solax_modbus/plugin_growatt.py
@@ -8653,7 +8653,8 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         icon="mdi:solar-power-variant",
     ),
     GrowattModbusSensorEntityDescription(
-        name="PV Current 1",
+        # SPF protocol: input 7 is Buck1Curr, not the PV input current.
+        name="PV Charger Current 1",
         key="pv_current_1",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
@@ -8665,7 +8666,8 @@ SENSOR_TYPES: list[GrowattModbusSensorEntityDescription] = [
         icon="mdi:current-dc",
     ),
     GrowattModbusSensorEntityDescription(
-        name="PV Current 2",
+        # SPF protocol: input 8 is Buck2Curr; retain the key for existing entities.
+        name="PV Charger Current 2",
         key="pv_current_2",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,

--- a/tests/unit/test_growatt_spf_pv_charger_current.py
+++ b/tests/unit/test_growatt_spf_pv_charger_current.py
@@ -1,0 +1,41 @@
+import pytest
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfElectricCurrent
+
+from custom_components.solax_modbus.const import REG_INPUT, REGISTER_U16
+from custom_components.solax_modbus.plugin_growatt import (
+    FIRMWARE_PREFIX_TYPES,
+    SENSOR_TYPES,
+    SERIAL_PREFIX_TYPES,
+    SPF,
+    SPF_SINGLE_MPPT_SERIAL_PREFIXES,
+    plugin_instance,
+)
+
+
+@pytest.mark.parametrize("prefix,inverter_type", list(SERIAL_PREFIX_TYPES.items()) + list(FIRMWARE_PREFIX_TYPES.items()))
+@pytest.mark.parametrize("channel", [1, 2])
+def test_pv_charger_current_names_are_scoped_to_spf(prefix: str, inverter_type: int, channel: int) -> None:
+    descriptions = [
+        description
+        for description in SENSOR_TYPES
+        if description.key == f"pv_current_{channel}"
+        and plugin_instance.matchInverterWithMask(inverter_type, description.allowedtypes, prefix, description.blacklist)
+    ]
+    if inverter_type & SPF:
+        if channel == 2 and prefix in SPF_SINGLE_MPPT_SERIAL_PREFIXES:
+            assert descriptions == []
+            return
+        assert len(descriptions) == 1
+        description = descriptions[0]
+        assert description.name == f"PV Charger Current {channel}"
+        assert description.register == 6 + channel
+        assert description.register_type == REG_INPUT
+        assert description.register_data_type == REGISTER_U16
+        assert description.scale == 0.1
+        assert description.rounding == 1
+        assert description.native_unit_of_measurement == UnitOfElectricCurrent.AMPERE
+        assert description.device_class == SensorDeviceClass.CURRENT
+    else:
+        for description in descriptions:
+            assert description.name == f"PV Current {channel}"


### PR DESCRIPTION
Rename “PV Current 1/2” to “PV Charger Current 1/2” for models using the SPF register map.

Input registers 7 and 8 represent Buck1/Buck2 converter currents, not PV input currents. The previous names misleadingly suggested these values could be combined directly with the PV input voltage.

Fixes #2301.