### PR TITLE
SolaX: fix and tidy the EPS, Parallel and External Generator sub-devices

### DIFF
--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -2321,7 +2321,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         icon="mdi:home-export-outline",
     ),
     SolaxModbusNumberEntityDescription(
-        name="Min SOC",
+        name="Min SoC",
         key="eps_min_soc",
         device_group="eps",
         register=0x44,
@@ -2335,7 +2335,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         icon="mdi:battery-charging-low",
     ),
     SolaxModbusNumberEntityDescription(
-        name="Restart SOC",
+        name="Restart SoC",
         key="eps_restart_soc",
         device_group="eps",
         register=0x8E,
@@ -3302,7 +3302,7 @@ SWITCH_TYPES: Sequence["SolaXModbusSwitchEntityDescription"] = [
         icon="mdi:dip-switch",
     ),
     SolaXModbusSwitchEntityDescription(
-        name="Schedule 2",
+        name="Schedule P2",
         key="generator_time_2",
         register=0x104,
         device_group="external_generator",
@@ -3324,7 +3324,7 @@ SWITCH_TYPES: Sequence["SolaXModbusSwitchEntityDescription"] = [
         icon="mdi:dip-switch",
     ),
     SolaXModbusSwitchEntityDescription(
-        name="Schedule 2",
+        name="Schedule P2",
         key="generator_time_2",
         register=0x107,
         device_group="external_generator",
@@ -4463,7 +4463,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         internal=True,
     ),
     SolaXModbusSensorEntityDescription(
-        name="Restart SOC",
+        name="Restart SoC",
         key="eps_restart_soc",
         native_unit_of_measurement=PERCENTAGE,
         device_group="eps",
@@ -4630,13 +4630,13 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         device_group="eps",
         register=0xB8,
         scale={
-            0: "50Hz",
-            1: "60Hz",
+            0: "50 Hz",
+            1: "60 Hz",
         },
         allowedtypes=AC | HYBRID | GEN2 | GEN3 | EPS,
     ),
     SolaXModbusSensorEntityDescription(
-        name="Min SOC",
+        name="Min SoC",
         key="eps_min_soc",
         native_unit_of_measurement=PERCENTAGE,
         device_group="eps",
@@ -4650,8 +4650,8 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         device_group="eps",
         register=0xB9,
         scale={
-            0: "50Hz",
-            1: "60Hz",
+            0: "50 Hz",
+            1: "60 Hz",
         },
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -7450,6 +7450,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         device_group="eps",
         register=0x78,
         register_type=REG_INPUT,
+        register_data_type=REGISTER_S16,
         allowedtypes=AC | HYBRID | X3 | EPS,
     ),
     SolaXModbusSensorEntityDescription(
@@ -7494,6 +7495,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         device_group="eps",
         register=0x7C,
         register_type=REG_INPUT,
+        register_data_type=REGISTER_S16,
         allowedtypes=AC | HYBRID | X3 | EPS,
     ),
     SolaXModbusSensorEntityDescription(
@@ -7540,6 +7542,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         device_group="eps",
         register=0x80,
         register_type=REG_INPUT,
+        register_data_type=REGISTER_S16,
         allowedtypes=AC | HYBRID | X3 | EPS,
     ),
     SolaXModbusSensorEntityDescription(
@@ -7675,7 +7678,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         register_type=REG_INPUT,
         register_data_type=REGISTER_U32,
         scale=0.01,
-        rounding=1,
+        rounding=2,
         modbus_max=99,
         allowedtypes=HYBRID | GEN6 | EPS,
     ),
@@ -8507,7 +8510,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=HYBRID | GEN3 | EPS,
     ),
     SolaXModbusSensorEntityDescription(
-        name="Min Esc SOC",
+        name="Min Esc SoC",
         key="eps_min_esc_soc",
         device_group="eps",
         register=0x10E,
@@ -8797,7 +8800,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         icon="mdi:information",
     ),
     SolaXModbusSensorEntityDescription(
-        name="ActivePower L1",
+        name="Active Power L1",
         key="pm_activepower_l1",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -8808,7 +8811,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="ActivePower L2",
+        name="Active Power L2",
         key="pm_activepower_l2",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -8819,7 +8822,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="ActivePower L3",
+        name="Active Power L3",
         key="pm_activepower_l3",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -8896,7 +8899,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         icon="mdi:current-dc",
     ),
     SolaXModbusSensorEntityDescription(
-        name="Reactive or ApparentPower L1",
+        name="Reactive or Apparent Power L1",
         key="pm_reactive_or_apparentpower_l1",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -8907,7 +8910,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="Reactive or ApparentPower L2",
+        name="Reactive or Apparent Power L2",
         key="pm_reactive_or_apparentpower_l2",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -8918,7 +8921,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="Reactive or ApparentPower L3",
+        name="Reactive or Apparent Power L3",
         key="pm_reactive_or_apparentpower_l3",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -9044,15 +9047,52 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         device_group="pm",
         register=0x1FC,
-        scale=0.01,
+        scale=0.1,
         register_type=REG_INPUT,
         register_data_type=REGISTER_S32,
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
         icon="mdi:current-dc",
     ),
+    SolaXModbusSensorEntityDescription(
+        name="Charge Power Limit",
+        key="pm_charge_power_limit",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        device_group="pm",
+        register=0x1FE,
+        register_type=REG_INPUT,
+        register_data_type=REGISTER_S32,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
+        icon="mdi:battery-arrow-up",
+    ),
+    SolaXModbusSensorEntityDescription(
+        name="Discharge Power Limit",
+        key="pm_discharge_power_limit",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        device_group="pm",
+        register=0x200,
+        register_type=REG_INPUT,
+        register_data_type=REGISTER_S32,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
+        icon="mdi:battery-arrow-down",
+    ),
+    SolaXModbusSensorEntityDescription(
+        name="PV Power Total",
+        key="pm_pv_power_total",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_group="pm",
+        register=0x202,
+        register_type=REG_INPUT,
+        register_data_type=REGISTER_U32,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
+        icon="mdi:solar-power",
+    ),
     # PM I2 Inverter
     SolaXModbusSensorEntityDescription(
-        name="I2 ActivePower L1",
+        name="I2 Active Power L1",
         key="pm_i2_activepower_l1",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -9063,7 +9103,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I2 ActivePower L2",
+        name="I2 Active Power L2",
         key="pm_i2_activepower_l2",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -9074,7 +9114,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I2 ActivePower L3",
+        name="I2 Active Power L3",
         key="pm_i2_activepower_l3",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -9085,7 +9125,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I2 Reactive or ApparentPower L1",
+        name="I2 Reactive or Apparent Power L1",
         key="pm_i2_reactive_or_apparentpower_l1",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -9096,7 +9136,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I2 Reactive or ApparentPower L2",
+        name="I2 Reactive or Apparent Power L2",
         key="pm_i2_reactive_or_apparentpower_l2",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -9107,7 +9147,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I2 Reactive or ApparentPower L3",
+        name="I2 Reactive or Apparent Power L3",
         key="pm_i2_reactive_or_apparentpower_l3",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -9282,7 +9322,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
     ),
     # PM I3 Inverter
     SolaXModbusSensorEntityDescription(
-        name="I3 ActivePower L1",
+        name="I3 Active Power L1",
         key="pm_i3_activepower_l1",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -9293,7 +9333,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I3 ActivePower L2",
+        name="I3 Active Power L2",
         key="pm_i3_activepower_l2",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -9304,7 +9344,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I3 ActivePower L3",
+        name="I3 Active Power L3",
         key="pm_i3_activepower_l3",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -9315,7 +9355,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I3 Reactive or ApparentPower L1",
+        name="I3 Reactive or Apparent Power L1",
         key="pm_i3_reactive_or_apparentpower_l1",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -9326,7 +9366,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I3 Reactive or ApparentPower L2",
+        name="I3 Reactive or Apparent Power L2",
         key="pm_i3_reactive_or_apparentpower_l2",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -9337,7 +9377,7 @@ SENSOR_TYPES_MAIN: list[SolaXModbusSensorEntityDescription] = [
         allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6 | PM,
     ),
     SolaXModbusSensorEntityDescription(
-        name="I3 Reactive or ApparentPower L3",
+        name="I3 Reactive or Apparent Power L3",
         key="pm_i3_reactive_or_apparentpower_l3",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
@@ -11330,7 +11370,7 @@ TIME_TYPES = [
         icon="mdi:clock-end",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allow Work Start Time",
+        name="Allow Work Start",
         key="generator_start_time_1",
         register=0xE8,
         device_group="external_generator",
@@ -11341,7 +11381,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allow Work Stop Time",
+        name="Allow Work Stop",
         key="generator_stop_time_1",
         register=0xE9,
         device_group="external_generator",
@@ -11388,7 +11428,7 @@ TIME_TYPES = [
         icon="mdi:clock-end",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Charge Period Start Time",
+        name="Charge P1 Start",
         key="generator_charge_start_time_1",
         register=0x100,
         device_group="external_generator",
@@ -11399,7 +11439,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Charge Period End Time",
+        name="Charge P1 Stop",
         key="generator_charge_stop_time_1",
         register=0x101,
         device_group="external_generator",
@@ -11410,7 +11450,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allowed Disc Period Start Time",
+        name="Discharge P1 Start",
         key="generator_discharge_start_time_1",
         register=0x102,
         device_group="external_generator",
@@ -11421,7 +11461,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allowed Disc Period End Time",
+        name="Discharge P1 Stop",
         key="generator_discharge_stop_time_1",
         register=0x103,
         device_group="external_generator",
@@ -11432,7 +11472,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Charge Period 2 Start Time",
+        name="Charge P2 Start",
         key="generator_charge_start_time_2",
         register=0x105,
         device_group="external_generator",
@@ -11443,7 +11483,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Charge Period 2 End Time",
+        name="Charge P2 Stop",
         key="generator_charge_stop_time_2",
         register=0x106,
         device_group="external_generator",
@@ -11454,7 +11494,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allowed Disc Period 2 Start Time",
+        name="Discharge P2 Start",
         key="generator_discharge_start_time_2",
         register=0x107,
         device_group="external_generator",
@@ -11465,7 +11505,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allowed Disc Period 2 End Time",
+        name="Discharge P2 Stop",
         key="generator_discharge_stop_time_2",
         register=0x108,
         device_group="external_generator",
@@ -11476,7 +11516,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Charge Period Start Time",
+        name="Charge P1 Start",
         key="generator_charge_start_time_1",
         register=0x103,
         device_group="external_generator",
@@ -11487,7 +11527,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Charge Period End Time",
+        name="Charge P1 Stop",
         key="generator_charge_stop_time_1",
         register=0x104,
         device_group="external_generator",
@@ -11498,7 +11538,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allowed Disc Period Start Time",
+        name="Discharge P1 Start",
         key="generator_discharge_start_time_1",
         register=0x105,
         device_group="external_generator",
@@ -11509,7 +11549,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allowed Disc Period End Time",
+        name="Discharge P1 Stop",
         key="generator_discharge_stop_time_1",
         register=0x106,
         device_group="external_generator",
@@ -11520,7 +11560,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Charge Period 2 Start Time",
+        name="Charge P2 Start",
         key="generator_charge_start_time_2",
         register=0x108,
         device_group="external_generator",
@@ -11531,7 +11571,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Charge Period 2 End Time",
+        name="Charge P2 Stop",
         key="generator_charge_stop_time_2",
         register=0x109,
         device_group="external_generator",
@@ -11542,7 +11582,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allowed Disc Period 2 Start Time",
+        name="Discharge P2 Start",
         key="generator_discharge_start_time_2",
         register=0x10A,
         device_group="external_generator",
@@ -11553,7 +11593,7 @@ TIME_TYPES = [
         icon="mdi:generator-stationary",
     ),
     SolaXModbusTimeEntityDescription(
-        name="Allowed Disc Period 2 End Time",
+        name="Discharge P2 Stop",
         key="generator_discharge_stop_time_2",
         register=0x10B,
         device_group="external_generator",


### PR DESCRIPTION
Follow-up to the merged sub-device PRs (#2283 EPS, #2284 Parallel, #2285 External Generator), covering the same three sub-devices in one change: decoding defects found against the protocol document, the registers that document defines but the plugin never exposed, and a display-name tidy-up.

Based directly on `main` — no dependency on other open PRs, so it can merge at any time.

# Decoding fixes

## EPS off-grid active power is signed — `0x0078` / `0x007C` / `0x0080`

The document lists the three-phase off-grid **active** powers as `S16`, while their **apparent** power siblings (`0x0079`, `0x007D`, `0x0081`) are `U16`:

| Register | Variable | Unit | Gain | Format |
| --- | --- | --- | --- | --- |
| 0x0078 | OffGridPower_R (X3) | W | 1 | **S16** |
| 0x0079 | OffGridPowerApparent_R (X3) | VA | 1 | U16 |

All six were decoded unsigned. A negative off-grid active power — the inverter drawing rather than supplying on that phase — wrapped to roughly **65000 W** instead of reading as a small negative number. Now `REGISTER_S16` on the three active-power entities only; the apparent-power ones are correctly left unsigned.

## Parallel battery current scale — `0x01FC`

The document gives `BatCurrentAll` as **A, gain 10** (scale 0.1). The entity used **0.01**, so parallel battery current read **ten times too low**.

The wrong value appears to be copied from the single-inverter register `0x0015`, where 0.01 is correct **only for GEN2**:

```
0x0015  Battery Current Charge    scale 0.01   HYBRID | GEN2            <- the only 0.01 case
0x0015  Battery Current Charge    scale 0.1    AC | HYBRID | GEN3 | GEN4
0x0015  Battery 1 Current Charge  scale 0.1    AC | HYBRID | GEN5 | GEN6
0x01FC  Battery Current Charge    scale 0.01   … GEN3 | GEN4 | GEN5 | GEN6 | PM   <- affected
```

The parallel entity covers GEN3–GEN6, none of which use 0.01.

**Corroborated on hardware.** On an X3 Hybrid 15kW the single-inverter registers follow the document exactly, which is what makes its gains trustworthy where they cannot be measured:

```
0x0014 BatVoltageCharge1 = 4804 → 480.4 V   (gain 10)
0x0015 BatCurrentCharge1 =   93 →   9.3 A   (gain 10, S16)
0x0016 BatPowerCharge1   = 4516 →  4516 W
                          480.4 × 9.3 ≈ 4468 W ✓
```

## EPS Yield Total rounding — `0x008E`

The entity scales by 0.01 but rounded to one decimal, discarding the hundredths the register provides. Since #2275 the sensor platform derives Home Assistant's display precision from the same `rounding`, so the lost digit showed in the UI too. Now `rounding=2`, matching the scale.

## Missing documented parallel registers

The block stopped at `0x01FC`, though the document defines three more:

| Register | Variable | Format | New entity |
| --- | --- | --- | --- |
| 0x01FE~0x01FF | ChargePowerLimitAll | S32 | Charge Power Limit |
| 0x0200~0x0201 | DischargePowerLimitAll | S32 | Discharge Power Limit |
| 0x0202~0x0203 | PvPowerAll | U32 | PV Power Total |


# Display-name tidy-up

Cosmetic only — keys, entity ids of sensors/numbers/selects/switches, option values and register mappings are untouched.

### EPS (3)

`Min SOC` → `Min SoC`, `Restart SOC` → `Restart SoC`, `Min Esc SOC` → `Min Esc SoC` — the state of charge is spelled `SoC` everywhere else in the integration.

### Parallel (18)

Glued words gain their space, for the shared entities and their per-inverter I2/I3 variants:

| Before | After |
| --- | --- |
| `ActivePower L1/L2/L3` | `Active Power L1/L2/L3` |
| `I2 / I3 ActivePower L1/L2/L3` | `I2 / I3 Active Power L1/L2/L3` |
| `Reactive or ApparentPower L1/L2/L3` | `Reactive or Apparent Power L1/L2/L3` |
| `I2 / I3 Reactive or ApparentPower L1/L2/L3` | `I2 / I3 Reactive or Apparent Power L1/L2/L3` |

### External Generator (11)

The schedules adopt the `<Function> [P<n>] Start|Stop` convention:

| Before | After |
| --- | --- |
| `Allow Work Start Time` / `Stop Time` | `Allow Work Start` / `Allow Work Stop` |
| `Charge Period Start Time` / `End Time` | `Charge P1 Start` / `Charge P1 Stop` |
| `Charge Period 2 Start Time` / `End Time` | `Charge P2 Start` / `Charge P2 Stop` |
| `Allowed Disc Period Start Time` / `End Time` | `Discharge P1 Start` / `Discharge P1 Stop` |
| `Allowed Disc Period 2 Start Time` / `End Time` | `Discharge P2 Start` / `Discharge P2 Stop` |
| `Schedule 2` | `Schedule P2` |

`Stop` rather than `End` so each pair sorts Start-then-Stop (`Sta` < `Sto`, and it matches the register name `generator_stop_time`); no `Time` suffix, since the entity is already a time; `P<n>` so a period's entities group together. The wordy prefixes are dropped because the **External Generator** sub-device already supplies that context, and the shortened names do not collide with the battery schedules on the main device (`Force Charge P1 Start`, `Allowed Discharge P1 Start`).

**Entity ids:** those External Generator time entities are not registry-backed in this integration, so their ids follow the display name (`time.<hub>_charge_period_start_time` → `time.<hub>_charge_p1_start`). Every other entity keeps its id, since those come from the keys, which do not change.

# Deliberately not changed

The 36 `I2 …` / `I3 …` per-inverter entities (`0x0204` onwards). The document declares the parallel range as `0x01DD~0x02ED` but only specifies registers up to `0x0203`, so those entities cannot be verified against it. They are left exactly as they are rather than changed on a guess.

## Testing limits — please read

These cannot be exercised on my system: it is a **single inverter** (`SystemInvNum = 0`) with **EPS idle**, so the entire parallel block and every off-grid register read zero. The changes rest on the protocol document, plus the GEN2/GEN3 pattern above for the scale.

Feedback from anyone running a **parallel system** or with an **active EPS/off-grid load** would be very welcome — particularly whether parallel battery current now reads plausibly (it should be 10× higher than before) and whether off-grid active power shows sensible small negatives instead of ~65000 W.


