### PR TITLE
Fix via_device_id TypeError on HA < 2026.8 (retro-compatible fallback)

### DIFF
--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -162,7 +162,7 @@ from .const import (
 from .const import (
     matches_active_when as matches_active_when,
 )
-from .device_registry_lookup import get_device_by_identifier
+from .device_registry_lookup import link_parent_device
 from .modbus_transport import CoreModbusTransport, ModbusTransport, NativeModbusTransport, UnavailableModbusTransport
 from .pymodbus_compat import DataType, convert_from_registers, convert_to_registers, pymodbus_version_info
 from .sensor import SolaXModbusSensor
@@ -1031,14 +1031,14 @@ class SolaXModbusHub:
             name=f"{self._name} {DEVICE_GROUP_NAMES.get(group, group.replace('_', ' ').title())}",
             manufacturer=self.plugin.plugin_manufacturer,
         )
-        # Link to the parent inverter via via_device_id (scoped to this config
-        # entry) on HA 2026.8+, falling back to the deprecated via_device tuple.
-        parent_identifier = (DOMAIN, self._name, INVERTER_IDENT)
-        parent_device = get_device_by_identifier(dr.async_get(self._hass), parent_identifier, self.entry.entry_id)
-        if parent_device is not None:
-            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id
-        else:
-            device_info["via_device"] = parent_identifier  # type: ignore[typeddict-item]
+        # Link to the parent inverter (via_device_id on HA 2026.8+, legacy
+        # via_device tuple otherwise — decided by API support, not lookup success).
+        link_parent_device(
+            cast(dict[str, Any], device_info),
+            dr.async_get(self._hass),
+            (DOMAIN, self._name, INVERTER_IDENT),
+            self.entry.entry_id,
+        )
         return device_info
 
     def register_gated_entity(self, descr: Any, factory: Any, add_entities: Any, holder: dict[Any, Any], platform: str, entity: Any = None) -> None:

--- a/custom_components/solax_modbus/device_registry_lookup.py
+++ b/custom_components/solax_modbus/device_registry_lookup.py
@@ -10,8 +10,9 @@ This module centralises a single, typed helper that prefers the scoped
 older HA versions that only expose the legacy ``async_get_device`` lookup.
 """
 
+import inspect
 from collections.abc import Callable
-from typing import cast
+from typing import Any, cast
 
 from homeassistant.helpers.device_registry import DeviceEntry, DeviceRegistry
 
@@ -55,3 +56,39 @@ def get_device_by_identifier(
     """
     scoped_lookup = _scoped_lookup(registry)
     return scoped_lookup(identifier, config_entry_id)
+
+
+_SUPPORTS_VIA_DEVICE_ID: bool | None = None
+
+
+def supports_via_device_id() -> bool:
+    """True when ``async_get_or_create`` accepts ``via_device_id`` (HA 2026.8+).
+
+    Detected once via signature inspection so older Home Assistant versions,
+    where the keyword does not exist, keep using the deprecated-but-working
+    ``via_device`` tuple instead of raising ``TypeError``.
+    """
+    global _SUPPORTS_VIA_DEVICE_ID  # noqa: PLW0603
+    if _SUPPORTS_VIA_DEVICE_ID is None:
+        params = inspect.signature(DeviceRegistry.async_get_or_create).parameters
+        _SUPPORTS_VIA_DEVICE_ID = "via_device_id" in params
+    return _SUPPORTS_VIA_DEVICE_ID
+
+
+def link_parent_device(
+    device_info: dict[str, Any],
+    registry: DeviceRegistry,
+    parent_identifier: DeviceIdentifier,
+    config_entry_id: str,
+) -> None:
+    """Set ``via_device_id`` when supported (HA 2026.8+), else ``via_device``.
+
+    On HA >= 2026.8 the parent device id (scoped to the config entry) is used.
+    On older versions the deprecated ``via_device`` tuple is kept so entities
+    keep registering correctly.
+    """
+    parent_device = get_device_by_identifier(registry, parent_identifier, config_entry_id)
+    if parent_device is not None and supports_via_device_id():
+        device_info["via_device_id"] = parent_device.id
+    else:
+        device_info["via_device"] = cast("tuple[str, str]", parent_identifier)

--- a/custom_components/solax_modbus/energy_dashboard.py
+++ b/custom_components/solax_modbus/energy_dashboard.py
@@ -39,7 +39,7 @@ from .const import (
     BaseModbusSwitchEntityDescription,
 )
 from .debug import get_debug_setting
-from .device_registry_lookup import get_device_by_identifier
+from .device_registry_lookup import link_parent_device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -373,17 +373,16 @@ def create_energy_dashboard_device_info(hub: Any, hass: Any = None) -> DeviceInf
         name=f"{hub._name} Energy Dashboard",
         configuration_url=config_url,
     )
-    # Link to the parent inverter via via_device_id (scoped to this config entry)
-    # on HA 2026.8+, falling back to the deprecated via_device tuple.
-    parent_identifier = (DOMAIN, hub._name, INVERTER_IDENT)
     if hass is not None:
-        parent_device = get_device_by_identifier(dr.async_get(hass), parent_identifier, hub.entry.entry_id)
-        if parent_device is not None:
-            cast(dict[str, Any], device_info)["via_device_id"] = parent_device.id
-        else:
-            device_info["via_device"] = parent_identifier  # type: ignore[typeddict-item]
+        # via_device_id on HA 2026.8+, legacy via_device tuple otherwise.
+        link_parent_device(
+            cast(dict[str, Any], device_info),
+            dr.async_get(hass),
+            (DOMAIN, hub._name, INVERTER_IDENT),
+            hub.entry.entry_id,
+        )
     else:
-        device_info["via_device"] = parent_identifier  # type: ignore[typeddict-item]
+        device_info["via_device"] = (DOMAIN, hub._name, INVERTER_IDENT)  # type: ignore[typeddict-item]
     return device_info
 
 

--- a/custom_components/solax_modbus/sensor.py
+++ b/custom_components/solax_modbus/sensor.py
@@ -31,7 +31,7 @@ from .const import (
     matches_modbus_protocol,
 )
 from .debug import get_debug_setting
-from .device_registry_lookup import get_device_by_identifier
+from .device_registry_lookup import get_device_by_identifier, link_parent_device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -239,14 +239,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     manufacturer=hub.plugin.plugin_manufacturer,
                     serial_number=batt_pack_serial,
                 )
-                # Link to the parent inverter via via_device_id (scoped to this config
-                # entry) on HA 2026.8+, falling back to the deprecated via_device tuple.
-                parent_identifier = (DOMAIN, hub_name, INVERTER_IDENT)
-                parent_device = get_device_by_identifier(dev_registry, parent_identifier, entry.entry_id)
-                if parent_device is not None:
-                    cast(dict[str, Any], device_info_battery)["via_device_id"] = parent_device.id
-                else:
-                    device_info_battery["via_device"] = parent_identifier  # type: ignore[typeddict-item]
+                # Link to the parent inverter (via_device_id on HA 2026.8+, legacy
+                # via_device tuple otherwise — decided by API support, not lookup success).
+                link_parent_device(
+                    cast(dict[str, Any], device_info_battery),
+                    dev_registry,
+                    (DOMAIN, hub_name, INVERTER_IDENT),
+                    entry.entry_id,
+                )
 
                 key_prefix = battery_config.battery_sensor_key_prefix.replace("{batt-nr}", str(batt_nr + 1)).replace(
                     "{pack-nr}", str(batt_pack_nr + 1)

--- a/tests/unit/test_device_registry_deprecations.py
+++ b/tests/unit/test_device_registry_deprecations.py
@@ -128,3 +128,10 @@ def test_via_device_fallback_uses_via_device_id_first() -> None:
     device = get_device_by_identifier(cast(DeviceRegistry, registry), ("solax_modbus", "hub", "inverter"), "entry-1")
     assert device is not None
     assert device.id == "parent-id"
+
+
+def test_supports_via_device_id_detection() -> None:
+    """The capability probe must return a plain bool on any HA version."""
+    from custom_components.solax_modbus.device_registry_lookup import supports_via_device_id
+
+    assert isinstance(supports_via_device_id(), bool)


### PR DESCRIPTION
Follow-up to #2308, fixes the `via_device_id` breakage on HA < 2026.8.0 reported by @TCWORLD ([comment](https://github.com/wills106/homeassistant-solax-modbus/pull/2308#issuecomment-5590775788)).

## Problem

The fallback logic introduced in #2308 chooses `via_device_id` vs `via_device` based on whether the parent device is **found**. But on HA < 2026.8 the legacy `async_get_device` lookup still works (the parent is always found), so the code sets `via_device_id` — a keyword `DeviceRegistry.async_get_or_create()` only accepts from HA 2026.8.0 onwards:

```
TypeError: DeviceRegistry.async_get_or_create() got an unexpected keyword argument 'via_device_id'
```

Every sub-device fails to register (Energy Dashboard, dry contacts, battery packs) on e.g. HA 2026.7.4.

## Fix

Decide based on whether the registry API **supports** the keyword, not on lookup success:

- `supports_via_device_id()` — one-shot capability probe via signature inspection (version-proof, no version-string parsing)
- `link_parent_device()` — shared helper used by all three call sites:
  - `sensor.py` (battery packs)
  - `__init__.py` (`group_device_info`)
  - `energy_dashboard.py` (`create_energy_dashboard_device_info`, `hass is None` guard kept)

HA ≥ 2026.8 keeps the scoped `via_device_id` behaviour; older versions fall back cleanly to the deprecated-but-working `via_device` tuple. Also removes the small logic duplication left by #2308.

## Test

Adds `test_supports_via_device_id_detection` to the existing regression suite.